### PR TITLE
fix: rename PyPI distribution to interlock-cb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the last recorded failure.
 - Async-first `timeout` primitive that turns a hang into `CallTimeoutError`.
 - Observability: `EventListener` protocol, a zero-dependency
-  `LoggingEventListener`, and an `OTelEventListener` (extra `interlock[otel]`).
-- httpx2 transport integration (extra `interlock[httpx2]`):
+  `LoggingEventListener`, and an `OTelEventListener` (extra `interlock-cb[otel]`).
+- httpx2 transport integration (extra `interlock-cb[httpx2]`):
   `CircuitBreakerTransport` and `AsyncCircuitBreakerTransport` apply a breaker
   per host, with an `HttpStatusClassifier` treating `429, 500, 502, 503, 504`
   and transport exceptions as failures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ uv run prek install           # one-time, installs the git hook
 - **Types are part of the API.** Public surface stays fully typed; mypy and
   pyright must pass in strict mode.
 - **Keep the core dependency-free.** Anything external belongs in an extra
-  (`interlock[otel]`, `interlock[httpx2]`), imported lazily.
+  (`interlock-cb[otel]`, `interlock-cb[httpx2]`), imported lazily.
 - **Conventional commits.** Use `feat:`, `fix:`, `docs:`, `refactor:`, `test:`,
   `chore:`, `perf:`, `ci:` prefixes.
 - **Update the docs and CHANGELOG.** User-facing changes update the relevant

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # interlock
 
 [![CI](https://github.com/bagowix/interlock/actions/workflows/ci.yml/badge.svg)](https://github.com/bagowix/interlock/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/interlock.svg)](https://pypi.org/project/interlock/)
-[![Python versions](https://img.shields.io/pypi/pyversions/interlock.svg)](https://pypi.org/project/interlock/)
+[![PyPI](https://img.shields.io/pypi/v/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
+[![Python versions](https://img.shields.io/pypi/pyversions/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A modern circuit breaker for Python — sync and async in a single class,
@@ -21,19 +21,19 @@ integrations at the transport level.
   signature *and* its sync/async nature; ships `py.typed`, passes mypy and
   pyright in strict mode.
 - **Zero-dependency core.** Standard library only; everything external lives in
-  optional extras (`interlock[otel]`, `interlock[httpx2]`).
+  optional extras (`interlock-cb[otel]`, `interlock-cb[httpx2]`).
 
 ## Installation
 
 ```bash
-uv add interlock          # or: pip install interlock
+uv add interlock-cb          # or: pip install interlock-cb
 ```
 
 Optional extras:
 
 ```bash
-uv add 'interlock[otel]'    # OpenTelemetry metrics listener
-uv add 'interlock[httpx2]'  # per-host httpx2 transport
+uv add 'interlock-cb[otel]'    # OpenTelemetry metrics listener
+uv add 'interlock-cb[httpx2]'  # per-host httpx2 transport
 ```
 
 ## Quickstart

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,14 +3,14 @@
 ## Install
 
 ```bash
-uv add interlock          # or: pip install interlock
+uv add interlock-cb          # or: pip install interlock-cb
 ```
 
 The core is pure standard library. External integrations are optional extras:
 
 ```bash
-uv add 'interlock[otel]'    # OpenTelemetry metrics listener
-uv add 'interlock[httpx2]'  # per-host httpx2 transport
+uv add 'interlock-cb[otel]'    # OpenTelemetry metrics listener
+uv add 'interlock-cb[httpx2]'  # per-host httpx2 transport
 ```
 
 ## Create a breaker

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -45,11 +45,11 @@ LoggingEventListener(logging.getLogger('myapp.breakers'))
 
 ## OpenTelemetry metrics
 
-The OTel listener lives in the `interlock[otel]` extra and is imported
+The OTel listener lives in the `interlock-cb[otel]` extra and is imported
 explicitly, so the core stays dependency-free:
 
 ```bash
-uv add 'interlock[otel]'
+uv add 'interlock-cb[otel]'
 ```
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ integrations at the transport level.
 ## Installation
 
 ```bash
-uv add interlock
+uv add interlock-cb
 ```
 
 ## Status

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -1,11 +1,11 @@
 # httpx2 integration
 
-The `interlock[httpx2]` extra wraps an [httpx2](https://pypi.org/project/httpx2/)
+The `interlock-cb[httpx2]` extra wraps an [httpx2](https://pypi.org/project/httpx2/)
 transport so a circuit breaker is applied **per host** transparently — no
 decorators or `call` wrappers in your request code.
 
 ```bash
-uv add 'interlock[httpx2]'
+uv add 'interlock-cb[httpx2]'
 ```
 
 ## Synchronous client

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -19,14 +19,14 @@ from the Markdown sources by ``scripts/build_llms_full.py`` — edit the pages i
 ## Install
 
 ```bash
-uv add interlock          # or: pip install interlock
+uv add interlock-cb          # or: pip install interlock-cb
 ```
 
 The core is pure standard library. External integrations are optional extras:
 
 ```bash
-uv add 'interlock[otel]'    # OpenTelemetry metrics listener
-uv add 'interlock[httpx2]'  # per-host httpx2 transport
+uv add 'interlock-cb[otel]'    # OpenTelemetry metrics listener
+uv add 'interlock-cb[httpx2]'  # per-host httpx2 transport
 ```
 
 ## Create a breaker
@@ -385,11 +385,11 @@ LoggingEventListener(logging.getLogger('myapp.breakers'))
 
 ## OpenTelemetry metrics
 
-The OTel listener lives in the `interlock[otel]` extra and is imported
+The OTel listener lives in the `interlock-cb[otel]` extra and is imported
 explicitly, so the core stays dependency-free:
 
 ```bash
-uv add 'interlock[otel]'
+uv add 'interlock-cb[otel]'
 ```
 
 ```python
@@ -480,12 +480,12 @@ metrics as any other.
 
 # httpx2 integration
 
-The `interlock[httpx2]` extra wraps an [httpx2](https://pypi.org/project/httpx2/)
+The `interlock-cb[httpx2]` extra wraps an [httpx2](https://pypi.org/project/httpx2/)
 transport so a circuit breaker is applied **per host** transparently — no
 decorators or `call` wrappers in your request code.
 
 ```bash
-uv add 'interlock[httpx2]'
+uv add 'interlock-cb[httpx2]'
 ```
 
 ## Synchronous client
@@ -639,11 +639,11 @@ Implement any of these to swap a core behaviour:
 ## Listeners
 
 - **`LoggingEventListener(logger=None)`** — top-level; zero dependencies.
-- **`interlock.otel.OTelEventListener(meter=None)`** — extra `interlock[otel]`.
+- **`interlock.otel.OTelEventListener(meter=None)`** — extra `interlock-cb[otel]`.
 
 ## httpx2 adapters
 
-Extra `interlock[httpx2]`, module `interlock.httpx2`:
+Extra `interlock-cb[httpx2]`, module `interlock.httpx2`:
 
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -35,5 +35,5 @@ Key facts for answering questions about interlock:
 ## Optional
 
 - [Full documentation](llms-full.txt): every page above inlined into one file.
-- Extras: `interlock[otel]` (OpenTelemetry metrics), `interlock[httpx2]` (transport).
+- Extras: `interlock-cb[otel]` (OpenTelemetry metrics), `interlock-cb[httpx2]` (transport).
 - Source and changelog: see the repository `CHANGELOG.md`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -80,11 +80,11 @@ Implement any of these to swap a core behaviour:
 ## Listeners
 
 - **`LoggingEventListener(logger=None)`** — top-level; zero dependencies.
-- **`interlock.otel.OTelEventListener(meter=None)`** — extra `interlock[otel]`.
+- **`interlock.otel.OTelEventListener(meter=None)`** — extra `interlock-cb[otel]`.
 
 ## httpx2 adapters
 
-Extra `interlock[httpx2]`, module `interlock.httpx2`:
+Extra `interlock-cb[httpx2]`, module `interlock.httpx2`:
 
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "interlock"
+name = "interlock-cb"
 dynamic = ["version"]
 description = "A modern circuit breaker for Python: sync + async, sliding-window rate, slow-call detection, type-safe API."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 ]
 
 [[package]]
-name = "interlock"
+name = "interlock-cb"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The name "interlock" is reserved on PyPI, so the package is published as "interlock-cb" (pip install interlock-cb). The import name is unchanged — code still uses `import interlock`. Updates install commands, PyPI badges and extras specs across README and docs. Also adds a Dependabot config for GitHub Actions and uv dependency updates.