### PR TITLE
chore: release automation, self-hosted coverage badge, comparison table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,28 @@ jobs:
 
       - name: Tests
         run: uv run pytest --cov
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov
+
+      - name: Coverage badge and PR comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,14 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # interlock
 
 [![CI](https://github.com/bagowix/interlock/actions/workflows/ci.yml/badge.svg)](https://github.com/bagowix/interlock/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/bagowix/interlock/python-coverage-comment-action-data/badge.svg)](https://github.com/bagowix/interlock/tree/python-coverage-comment-action-data)
 [![PyPI](https://img.shields.io/pypi/v/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
+[![Downloads](https://img.shields.io/pypi/dm/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![Python versions](https://img.shields.io/pypi/pyversions/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![llms.txt](https://img.shields.io/badge/-llms.txt-brightgreen)](docs/llms.txt)
 
 A modern circuit breaker for Python — sync and async in a single class,
 sliding-window rate and slow-call detection, a type-safe API, and transparent
@@ -22,6 +25,44 @@ integrations at the transport level.
   pyright in strict mode.
 - **Zero-dependency core.** Standard library only; everything external lives in
   optional extras (`interlock-cb[otel]`, `interlock-cb[httpx2]`).
+
+## How it compares
+
+interlock-cb is young (first released in 2026). [pybreaker][pybreaker] and
+[circuitbreaker][circuitbreaker] are mature, well-documented and proven in
+production for years — for many projects they are exactly the right choice. Each
+library is strong in different places:
+
+| Feature | interlock-cb | pybreaker | circuitbreaker |
+|---|:---:|:---:|:---:|
+| Core states (closed / open / half-open) | ✅ | ✅ | ✅ |
+| Choose which exceptions count as failures | ✅ | ✅ | ✅ |
+| Zero-dependency core | ✅ | ✅ | ✅ |
+| `async` / `await` (asyncio) | ✅ | Tornado | ✅ |
+| Event / state-change listeners | ✅ | ✅ | — |
+| Shared state across processes (Redis) | planned | ✅ | — |
+| Fallback function | planned | — | ✅ |
+| Years of production use | new | ✅ | ✅ |
+| Failure-**rate** sliding window | ✅ | — | — |
+| Time-based window | ✅ | — | — |
+| Slow-call detection | ✅ | — | — |
+| Result-based failure classification | ✅ | — | — |
+| Type-safe decorator (preserves signature) | ✅ | — | — |
+| Built-in httpx transport | ✅ | — | — |
+| OpenTelemetry metrics | ✅ | — | — |
+
+<sub>Compared against pybreaker 1.x and circuitbreaker 2.1 as documented in mid-2026.
+pybreaker's async support is Tornado-based, not asyncio. "planned" items are on
+the interlock-cb roadmap (Redis-backed state, fallback). Both established
+libraries trip on a consecutive-failure count rather than a rate window.
+Something out of date? Please open a PR.</sub>
+
+Reach for an established library if you want a small, proven breaker today, state
+shared across hosts, or a built-in fallback. Choose interlock-cb when you want
+rate-based windows, slow-call detection and a fully typed API.
+
+[pybreaker]: https://github.com/danielfm/pybreaker
+[circuitbreaker]: https://github.com/fabfuel/circuitbreaker
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ filterwarnings = [
 [tool.coverage.run]
 branch = true
 source = ["interlock"]
+relative_files = true
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
## Summary

- release.yml: github-release job creates a GitHub Release from each v* tag
- ci.yml: coverage job publishes a self-hosted badge via
    python-coverage-comment-action (no external service); relative_files in config
- README: CI/coverage/downloads/llms.txt badges; fact-checked "How it compares"
    table (sourced from pybreaker and circuitbreaker docs) that credits each
    library's real strengths alongside interlock-cb's differentiators