### PR TITLE
feat: add sync_timeout for synchronous calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `sync_timeout(seconds)` decorator: a synchronous counterpart to `timeout`.
+  It runs the wrapped callable in a daemon worker thread joined with a deadline
+  and raises `CallTimeoutError` on overrun. Documents the worker-thread
+  limitation: Python cannot kill a thread, so the worker keeps running in the
+  background after a timeout.
+
 ## [1.0.0] - 2026-06-27
 
 ### Added

--- a/docs/guides/timeout.md
+++ b/docs/guides/timeout.md
@@ -14,10 +14,9 @@ async with timeout(2.0):
 
 ## Composing with a breaker
 
-`timeout` is async-only by design (a sync timeout is planned for v1.1). Compose
-it with a breaker manually — pipeline composition is a v2 feature. Put the
-timeout *inside* the protected callable so the breaker observes the
-`CallTimeoutError`:
+Compose `timeout` with a breaker manually — pipeline composition is a v2
+feature. Put the timeout *inside* the protected callable so the breaker observes
+the `CallTimeoutError`:
 
 ```python
 from interlock import CircuitBreaker, timeout
@@ -33,6 +32,38 @@ async def search(q: str) -> bytes:
 Now a request that exceeds 2 seconds raises `CallTimeoutError`; the breaker
 counts it as a failure and, once the failure rate crosses the threshold, opens
 the circuit — converting slow hangs into fast rejections.
+
+## Synchronous code
+
+`timeout` relies on asyncio cancelling the coroutine in place, which has no
+synchronous equivalent: a blocking call cannot be interrupted from outside its
+own thread, and `signal.SIGALRM` only works in the main thread, so it breaks in
+threaded servers. `sync_timeout` instead runs the callable in a daemon worker
+thread and joins it with a deadline. It is a decorator, so it wraps a *callable*
+rather than a block:
+
+```python
+from interlock import CircuitBreaker, sync_timeout
+
+breaker = CircuitBreaker(name='search')
+
+@breaker
+@sync_timeout(2.0)
+def search(q: str) -> bytes:
+    return client.get('/search', params={'q': q}).content
+```
+
+A call that exceeds 2 seconds raises `CallTimeoutError`, which the breaker
+records exactly as with the async path. The decorator preserves the wrapped
+function's signature, arguments and return value.
+
+!!! warning "The worker keeps running after a timeout"
+    Python cannot forcibly kill a thread. After `sync_timeout` raises, the
+    worker thread keeps running in the background until the call returns on its
+    own — it cannot be cancelled, so it may still hold the resource it was
+    waiting on. The caller is unblocked immediately, but the underlying work is
+    not stopped. Prefer the async `timeout` wherever you control an event loop;
+    reach for `sync_timeout` only in genuinely synchronous code.
 
 ## Why not bake it in?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -447,10 +447,9 @@ async with timeout(2.0):
 
 ## Composing with a breaker
 
-`timeout` is async-only by design (a sync timeout is planned for v1.1). Compose
-it with a breaker manually — pipeline composition is a v2 feature. Put the
-timeout *inside* the protected callable so the breaker observes the
-`CallTimeoutError`:
+Compose `timeout` with a breaker manually — pipeline composition is a v2
+feature. Put the timeout *inside* the protected callable so the breaker observes
+the `CallTimeoutError`:
 
 ```python
 from interlock import CircuitBreaker, timeout
@@ -466,6 +465,38 @@ async def search(q: str) -> bytes:
 Now a request that exceeds 2 seconds raises `CallTimeoutError`; the breaker
 counts it as a failure and, once the failure rate crosses the threshold, opens
 the circuit — converting slow hangs into fast rejections.
+
+## Synchronous code
+
+`timeout` relies on asyncio cancelling the coroutine in place, which has no
+synchronous equivalent: a blocking call cannot be interrupted from outside its
+own thread, and `signal.SIGALRM` only works in the main thread, so it breaks in
+threaded servers. `sync_timeout` instead runs the callable in a daemon worker
+thread and joins it with a deadline. It is a decorator, so it wraps a *callable*
+rather than a block:
+
+```python
+from interlock import CircuitBreaker, sync_timeout
+
+breaker = CircuitBreaker(name='search')
+
+@breaker
+@sync_timeout(2.0)
+def search(q: str) -> bytes:
+    return client.get('/search', params={'q': q}).content
+```
+
+A call that exceeds 2 seconds raises `CallTimeoutError`, which the breaker
+records exactly as with the async path. The decorator preserves the wrapped
+function's signature, arguments and return value.
+
+!!! warning "The worker keeps running after a timeout"
+    Python cannot forcibly kill a thread. After `sync_timeout` raises, the
+    worker thread keeps running in the background until the call returns on its
+    own — it cannot be cancelled, so it may still hold the resource it was
+    waiting on. The caller is unblocked immediately, but the underlying work is
+    not stopped. Prefer the async `timeout` wherever you control an event loop;
+    reach for `sync_timeout` only in genuinely synchronous code.
 
 ## Why not bake it in?
 
@@ -611,18 +642,25 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
 - **`InterlockError`** — base of all interlock errors.
 - **`CircuitOpenError(breaker_name, *, retry_after=None, last_failure=None)`** —
   raised on rejection; attributes `breaker_name`, `retry_after`, `last_failure`.
-- **`CallTimeoutError(timeout)`** — raised by `timeout`; attribute `timeout`.
+- **`CallTimeoutError(timeout)`** — raised by `timeout` and `sync_timeout`;
+  attribute `timeout`.
 - **`InterlockDeprecationWarning`** — subclasses `UserWarning`, visible by
   default.
 
-## `timeout`
+## `timeout` / `sync_timeout`
 
 ```python
-async with timeout(seconds): ...
+async with timeout(seconds): ...   # async block
+
+@sync_timeout(seconds)             # synchronous callable
+def work(): ...
 ```
 
-Async context manager that raises `CallTimeoutError` if the block exceeds
-`seconds`. See [Timeout](guides/timeout.md).
+`timeout` is an async context manager that raises `CallTimeoutError` if the
+block exceeds `seconds`. `sync_timeout` is a decorator that runs a synchronous
+callable in a daemon worker thread and raises `CallTimeoutError` if it overruns
+`seconds`; the worker keeps running after a timeout (Python cannot kill a
+thread). See [Timeout](guides/timeout.md).
 
 ## Protocols (extension points)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -52,18 +52,25 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
 - **`InterlockError`** — base of all interlock errors.
 - **`CircuitOpenError(breaker_name, *, retry_after=None, last_failure=None)`** —
   raised on rejection; attributes `breaker_name`, `retry_after`, `last_failure`.
-- **`CallTimeoutError(timeout)`** — raised by `timeout`; attribute `timeout`.
+- **`CallTimeoutError(timeout)`** — raised by `timeout` and `sync_timeout`;
+  attribute `timeout`.
 - **`InterlockDeprecationWarning`** — subclasses `UserWarning`, visible by
   default.
 
-## `timeout`
+## `timeout` / `sync_timeout`
 
 ```python
-async with timeout(seconds): ...
+async with timeout(seconds): ...   # async block
+
+@sync_timeout(seconds)             # synchronous callable
+def work(): ...
 ```
 
-Async context manager that raises `CallTimeoutError` if the block exceeds
-`seconds`. See [Timeout](guides/timeout.md).
+`timeout` is an async context manager that raises `CallTimeoutError` if the
+block exceeds `seconds`. `sync_timeout` is a decorator that runs a synchronous
+callable in a daemon worker thread and raises `CallTimeoutError` if it overruns
+`seconds`; the worker keeps running after a timeout (Python cannot kill a
+thread). See [Timeout](guides/timeout.md).
 
 ## Protocols (extension points)
 

--- a/interlock/__init__.py
+++ b/interlock/__init__.py
@@ -20,7 +20,7 @@ from interlock.protocols import (
 )
 from interlock.registry import Registry
 from interlock.state import State
-from interlock.timeout import timeout
+from interlock.timeout import sync_timeout, timeout
 from interlock.version import VERSION
 from interlock.window import WindowSnapshot, WindowType
 
@@ -49,5 +49,6 @@ __all__ = (
     'WindowSnapshot',
     'WindowType',
     '__version__',
+    'sync_timeout',
     'timeout',
 )

--- a/interlock/timeout.py
+++ b/interlock/timeout.py
@@ -1,22 +1,31 @@
-"""An async-first timeout primitive.
+"""Timeout primitives for sync and async calls.
 
 A circuit breaker without a timeout is unsafe: a call that hangs forever is
-never counted as slow or failed — it just holds a resource. ``timeout`` bounds
-an awaited block, converting a hang into a ``CallTimeoutError`` that a
-surrounding breaker records as a (slow) failure.
+never counted as slow or failed — it just holds a resource. A timeout converts
+a hang into a ``CallTimeoutError`` that a surrounding breaker records as a
+(slow) failure.
 
-It composes with a breaker manually — inside a decorated coroutine or a
-``breaker.call`` target — rather than being baked into the breaker; pipeline
-composition is deferred to v2. Async only by design; a sync timeout is v1.1.
+Both primitives compose with a breaker manually — inside a decorated callable
+or a ``breaker.call`` target — rather than being baked into the breaker;
+pipeline composition is deferred to v2.
+
+``timeout`` bounds an awaited block: asyncio can cancel the coroutine in place.
+``sync_timeout`` cannot — a synchronous block has no portable in-place
+cancellation (``signal.SIGALRM`` only works in the main thread and breaks in
+threaded servers). It therefore wraps a *callable*, running it in a daemon
+worker thread joined with a deadline.
 """
 
 import asyncio
 import contextlib
-from collections.abc import AsyncGenerator
+import functools
+import threading
+from collections.abc import AsyncGenerator, Callable
 
+from interlock._typing import P, R, SyncCallable
 from interlock.errors import CallTimeoutError
 
-__all__ = ('timeout',)
+__all__ = ('sync_timeout', 'timeout')
 
 
 @contextlib.asynccontextmanager
@@ -31,3 +40,48 @@ async def timeout(seconds: float) -> AsyncGenerator[None, None]:
             yield
     except TimeoutError as exc:
         raise CallTimeoutError(seconds) from exc
+
+
+def sync_timeout(seconds: float) -> Callable[[SyncCallable[P, R]], SyncCallable[P, R]]:
+    """Bound a synchronous callable to ``seconds`` via a daemon worker thread.
+
+    The decorated callable runs in a worker thread that the caller joins with a
+    deadline; overrunning the deadline raises ``CallTimeoutError``. The
+    signature, arguments and return value are preserved.
+
+    Limitation: Python cannot forcibly kill a thread. After a timeout the worker
+    keeps running in the background until it returns on its own — it cannot be
+    cancelled, so it may still hold the resource it was waiting on. Prefer the
+    async :func:`timeout` wherever you control an event loop.
+
+    Raises:
+        ValueError: If ``seconds`` is not positive.
+        CallTimeoutError: If the call does not finish within ``seconds``.
+    """
+    if seconds <= 0:
+        raise ValueError(f'sync_timeout seconds must be positive, got {seconds!r}')
+
+    def decorator(fn: SyncCallable[P, R]) -> SyncCallable[P, R]:
+        @functools.wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            result: list[R] = []
+            failure: list[BaseException] = []
+
+            def run() -> None:
+                try:
+                    result.append(fn(*args, **kwargs))
+                except BaseException as exc:  # noqa: BLE001 — re-raised in the caller as-is
+                    failure.append(exc)
+
+            worker = threading.Thread(target=run, name='interlock-sync-timeout', daemon=True)
+            worker.start()
+            worker.join(seconds)
+            if worker.is_alive():
+                raise CallTimeoutError(seconds)
+            if failure:
+                raise failure[0]
+            return result[0]
+
+        return wrapper
+
+    return decorator

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,8 +1,9 @@
 import asyncio
+import threading
 
 import pytest
 
-from interlock import CallTimeoutError, CircuitBreaker, Config, timeout
+from interlock import CallTimeoutError, CircuitBreaker, Config, sync_timeout, timeout
 
 
 @pytest.mark.asyncio
@@ -58,3 +59,91 @@ async def test__composed_with_breaker__records_slow_failure() -> None:
     snapshot = breaker.snapshot()
     assert snapshot.failed_calls == 1
     assert snapshot.slow_calls == 1
+
+
+def test__sync_timeout__within_deadline__returns_result() -> None:
+    @sync_timeout(1.0)
+    def quick() -> int:
+        return 42
+
+    assert quick() == 42
+
+
+def test__sync_timeout__preserves_arguments() -> None:
+    @sync_timeout(1.0)
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(2, b=3) == 5
+
+
+def test__sync_timeout__exceeds_deadline__raises_call_timeout_error() -> None:
+    release = threading.Event()
+
+    @sync_timeout(0.05)
+    def hang() -> None:
+        release.wait()
+
+    try:
+        with pytest.raises(CallTimeoutError):
+            hang()
+    finally:
+        release.set()
+
+
+def test__sync_timeout__call_timeout_error__carries_deadline() -> None:
+    release = threading.Event()
+
+    @sync_timeout(0.05)
+    def hang() -> None:
+        release.wait()
+
+    try:
+        with pytest.raises(CallTimeoutError) as exc_info:
+            hang()
+        assert exc_info.value.timeout == 0.05
+    finally:
+        release.set()
+
+
+def test__sync_timeout__body_raises__propagates_unchanged() -> None:
+    @sync_timeout(1.0)
+    def boom() -> None:
+        raise ValueError('boom')
+
+    with pytest.raises(ValueError, match='boom'):
+        boom()
+
+
+def test__sync_timeout__non_positive_seconds__raises_value_error() -> None:
+    with pytest.raises(ValueError, match='positive'):
+        sync_timeout(0)
+
+
+def test__sync_timeout__composed_with_breaker__records_slow_failure() -> None:
+    breaker = CircuitBreaker(
+        name='io',
+        config=Config(
+            minimum_number_of_calls=1,
+            window_size=10,
+            slow_call_duration_threshold=0.01,
+            permitted_calls_in_half_open=1,
+            max_concurrent_probes=1,
+            wait_duration_in_open=5.0,
+        ),
+    )
+    release = threading.Event()
+
+    @sync_timeout(0.05)
+    def hang() -> None:
+        release.wait()
+
+    try:
+        with pytest.raises(CallTimeoutError):
+            breaker.call(hang)
+
+        snapshot = breaker.snapshot()
+        assert snapshot.failed_calls == 1
+        assert snapshot.slow_calls == 1
+    finally:
+        release.set()


### PR DESCRIPTION
## Summary

Async `timeout` relies on asyncio cancelling the coroutine in place which has no synchronous equivalent. `sync_timeout(seconds)` runs the wrapped callable in a daemon worker thread joined with a deadline and raises CallTimeoutError on overrun, preserving the signature via ParamSpec + functools.wraps

Documents the inherent limitation: Python cannot kill a thread, so the worker keeps running in the background after a timeout. Prefer async `timeout` where an event loop is available.