### PR TITLE
feat: add optional auto-transition timer for OPEN -> HALF_OPEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and raises `CallTimeoutError` on overrun. Documents the worker-thread
   limitation: Python cannot kill a thread, so the worker keeps running in the
   background after a timeout.
+- `Config.auto_transition` (default `False`): opt into a timer that proactively
+  moves a breaker `OPEN → HALF_OPEN` once `wait_duration_in_open` elapses,
+  emitting the state change without waiting for the next call. The lazy
+  transition stays authoritative; the timer admits no probe and is cancelled on
+  `reset()`, `force_open()`, or when a call makes the move first.
 
 ## [1.0.0] - 2026-06-27
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -32,6 +32,7 @@ config = Config(
 | `permitted_calls_in_half_open` | `10` | Probe calls allowed while `HALF_OPEN`. |
 | `max_concurrent_probes` | `1` | Cap on **simultaneous** probes in `HALF_OPEN`. Must be in `[1, permitted_calls_in_half_open]`. |
 | `wait_duration_in_open` | `60.0` | Seconds to stay `OPEN` before the first probe is allowed. |
+| `auto_transition` | `False` | When `True`, a timer moves the breaker `OPEN → HALF_OPEN` once the wait elapses, instead of waiting for the next call. See [States](states.md#proactive-transition-auto_transition). |
 | `window_type` | `COUNT_BASED` | `COUNT_BASED` or `TIME_BASED`. |
 | `window_size` | `100` | Last N calls (count-based) or last N seconds (time-based). |
 

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -7,7 +7,7 @@ A breaker has three core states plus three operator overrides.
 ```mermaid
 stateDiagram-v2
     CLOSED --> OPEN: failure/slow rate crosses threshold
-    OPEN --> HALF_OPEN: first call after wait_duration_in_open
+    OPEN --> HALF_OPEN: first call after wait_duration_in_open (or timer, if auto_transition)
     HALF_OPEN --> CLOSED: probes succeed
     HALF_OPEN --> OPEN: a probe fails
 ```
@@ -17,11 +17,43 @@ stateDiagram-v2
   the breaker trips to `OPEN`.
 - **`OPEN`** — calls are rejected immediately with `CircuitOpenError`. After
   `wait_duration_in_open` seconds, the **next** call lazily moves the breaker to
-  `HALF_OPEN` (there is no background timer in v1.0).
+  `HALF_OPEN`. Enable [`auto_transition`](#proactive-transition-auto_transition)
+  to have a timer make that move on its own.
 - **`HALF_OPEN`** — a limited number of probe calls are admitted, with a cap on
   how many run concurrently, so a barely-recovered dependency is not hit by the
   full parallel load at once. Probes succeeding closes the breaker; a probe
   failing re-opens it.
+
+## Proactive transition (`auto_transition`)
+
+By default the `OPEN → HALF_OPEN` move is **lazy**: it happens on the first call
+after `wait_duration_in_open` elapses. A low-traffic service can therefore sit in
+`OPEN` longer than necessary, and — since nothing changes until that call — the
+state-change event is not emitted, leaving a blind spot on dashboards.
+
+Set `auto_transition=True` to arm a timer that performs the move on its own when
+the wait elapses, emitting `on_state_change` without waiting for a call:
+
+```python
+from interlock import CircuitBreaker, Config
+
+breaker = CircuitBreaker(
+    name='payments',
+    config=Config(wait_duration_in_open=30.0, auto_transition=True),
+)
+# 30s after opening, the breaker moves to HALF_OPEN and emits the event,
+# even if no call arrives.
+```
+
+The lazy path stays authoritative: the timer only flips the state (it admits no
+probe), so the first real call still becomes the first probe. If a call arrives
+exactly as the timer fires, a lock ensures the transition and its event happen
+exactly once. The timer is cancelled automatically on `reset()`, `force_open()`,
+or when a call makes the move first.
+
+The timer is a daemon thread, used uniformly for sync and async breakers (the
+breaker's critical sections are guarded by a `threading.Lock`, never an event
+loop), so a pending timer never blocks interpreter shutdown.
 
 ## Operator overrides
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -165,6 +165,7 @@ config = Config(
 | `permitted_calls_in_half_open` | `10` | Probe calls allowed while `HALF_OPEN`. |
 | `max_concurrent_probes` | `1` | Cap on **simultaneous** probes in `HALF_OPEN`. Must be in `[1, permitted_calls_in_half_open]`. |
 | `wait_duration_in_open` | `60.0` | Seconds to stay `OPEN` before the first probe is allowed. |
+| `auto_transition` | `False` | When `True`, a timer moves the breaker `OPEN → HALF_OPEN` once the wait elapses, instead of waiting for the next call. See [States](states.md#proactive-transition-auto_transition). |
 | `window_type` | `COUNT_BASED` | `COUNT_BASED` or `TIME_BASED`. |
 | `window_size` | `100` | Last N calls (count-based) or last N seconds (time-based). |
 
@@ -221,7 +222,7 @@ A breaker has three core states plus three operator overrides.
 ```mermaid
 stateDiagram-v2
     CLOSED --> OPEN: failure/slow rate crosses threshold
-    OPEN --> HALF_OPEN: first call after wait_duration_in_open
+    OPEN --> HALF_OPEN: first call after wait_duration_in_open (or timer, if auto_transition)
     HALF_OPEN --> CLOSED: probes succeed
     HALF_OPEN --> OPEN: a probe fails
 ```
@@ -231,11 +232,43 @@ stateDiagram-v2
   the breaker trips to `OPEN`.
 - **`OPEN`** — calls are rejected immediately with `CircuitOpenError`. After
   `wait_duration_in_open` seconds, the **next** call lazily moves the breaker to
-  `HALF_OPEN` (there is no background timer in v1.0).
+  `HALF_OPEN`. Enable [`auto_transition`](#proactive-transition-auto_transition)
+  to have a timer make that move on its own.
 - **`HALF_OPEN`** — a limited number of probe calls are admitted, with a cap on
   how many run concurrently, so a barely-recovered dependency is not hit by the
   full parallel load at once. Probes succeeding closes the breaker; a probe
   failing re-opens it.
+
+## Proactive transition (`auto_transition`)
+
+By default the `OPEN → HALF_OPEN` move is **lazy**: it happens on the first call
+after `wait_duration_in_open` elapses. A low-traffic service can therefore sit in
+`OPEN` longer than necessary, and — since nothing changes until that call — the
+state-change event is not emitted, leaving a blind spot on dashboards.
+
+Set `auto_transition=True` to arm a timer that performs the move on its own when
+the wait elapses, emitting `on_state_change` without waiting for a call:
+
+```python
+from interlock import CircuitBreaker, Config
+
+breaker = CircuitBreaker(
+    name='payments',
+    config=Config(wait_duration_in_open=30.0, auto_transition=True),
+)
+# 30s after opening, the breaker moves to HALF_OPEN and emits the event,
+# even if no call arrives.
+```
+
+The lazy path stays authoritative: the timer only flips the state (it admits no
+probe), so the first real call still becomes the first probe. If a call arrives
+exactly as the timer fires, a lock ensures the transition and its event happen
+exactly once. The timer is cancelled automatically on `reset()`, `force_open()`,
+or when a call makes the move first.
+
+The timer is a daemon thread, used uniformly for sync and async breakers (the
+breaker's critical sections are guarded by a `threading.Lock`, never an event
+loop), so a pending timer never blocks interpreter shutdown.
 
 ## Operator overrides
 

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -82,6 +82,8 @@ class Engine:
         self._machine = StateMachine(config=config, clock=clock)
         self._lock = threading.Lock()
         self._last_failure: BaseException | None = None
+        self._timer: threading.Timer | None = None
+        self._timer_lock = threading.Lock()
 
     @property
     def state(self) -> State:
@@ -171,7 +173,7 @@ class Engine:
             self._machine.reset()
             after = self._machine.state
 
-        self._emit_state_change(before, after)
+        self._on_transition(before, after)
         self._listener.on_reset(name=self._name)
 
     def force_open(self) -> None:
@@ -192,7 +194,7 @@ class Engine:
             mutate()
             after = self._machine.state
 
-        self._emit_state_change(before, after)
+        self._on_transition(before, after)
 
     def _admit(self) -> None:
         with self._lock:
@@ -202,7 +204,7 @@ class Engine:
             retry_after = None if admitted else self._machine.retry_after()
             last_failure = self._last_failure
 
-        self._emit_state_change(before, after)
+        self._on_transition(before, after)
         if not admitted:
             self._listener.on_rejected(name=self._name)
             raise CircuitOpenError(
@@ -225,8 +227,58 @@ class Engine:
                 self._last_failure = exception
 
         self._listener.on_call(name=self._name, outcome=outcome, duration=duration)
-        self._emit_state_change(before, after)
+        self._on_transition(before, after)
 
-    def _emit_state_change(self, before: State, after: State) -> None:
-        if after != before:
-            self._listener.on_state_change(name=self._name, old=before, new=after)
+    def _on_transition(self, before: State, after: State) -> None:
+        if after == before:
+            return
+
+        self._listener.on_state_change(name=self._name, old=before, new=after)
+        if after is State.OPEN:
+            self._schedule_auto_transition()
+        elif before is State.OPEN:
+            self._cancel_auto_transition()
+
+    def _schedule_auto_transition(self) -> None:
+        """Arm a timer to fire the proactive OPEN → HALF_OPEN once the wait ends.
+
+        A no-op unless ``auto_transition`` is enabled. The timer is a daemon so a
+        pending one never blocks interpreter shutdown, and it is cancelled the
+        moment the breaker leaves ``OPEN`` by any path (a real probe, ``reset``,
+        ``force_open`` or the timer itself).
+        """
+        if not self._config.auto_transition:
+            return
+
+        timer = threading.Timer(self._config.wait_duration_in_open, self._fire_auto_transition)
+        timer.daemon = True
+        with self._timer_lock:
+            self._cancel_timer_locked()
+            self._timer = timer
+
+        timer.start()
+
+    def _cancel_auto_transition(self) -> None:
+        with self._timer_lock:
+            self._cancel_timer_locked()
+
+    def _cancel_timer_locked(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    def _fire_auto_transition(self) -> None:
+        """Timer callback: flip OPEN → HALF_OPEN under the lock, then emit.
+
+        Races with a real call are settled by the lock: whichever acquires it
+        first performs the single transition; the loser sees a non-``OPEN`` state,
+        so ``attempt_auto_transition`` is a no-op and ``_on_transition`` (which
+        ignores an unchanged state) emits nothing. The state changes exactly once
+        and the event fires exactly once.
+        """
+        with self._lock:
+            before = self._machine.state
+            self._machine.attempt_auto_transition()
+            after = self._machine.state
+
+        self._on_transition(before, after)

--- a/interlock/_state_machine.py
+++ b/interlock/_state_machine.py
@@ -101,6 +101,20 @@ class StateMachine:
         elif self._state is State.METRICS_ONLY:
             self._window.record(outcome)
 
+    def attempt_auto_transition(self) -> bool:
+        """Proactively move ``OPEN`` → ``HALF_OPEN`` once the wait has elapsed.
+
+        Unlike ``acquire``, this admits no probe — it only flips the state, so an
+        out-of-band timer can surface the transition without consuming a probe
+        slot. Returns whether it transitioned; the lazy path in ``acquire``
+        stays authoritative and a later real call admits the first probe.
+        """
+        if self._state is not State.OPEN or not self._wait_elapsed():
+            return False
+
+        self._to_half_open()
+        return True
+
     def force_open(self) -> None:
         """Override to ``FORCED_OPEN``: reject all traffic until reset."""
         self._state = State.FORCED_OPEN
@@ -121,11 +135,14 @@ class StateMachine:
         self._close()
 
     def _begin_probing_if_elapsed(self) -> bool:
-        if self._clock.monotonic() - self._opened_at < self._config.wait_duration_in_open:
+        if not self._wait_elapsed():
             return False
 
         self._to_half_open()
         return self._admit_probe()
+
+    def _wait_elapsed(self) -> bool:
+        return self._clock.monotonic() - self._opened_at >= self._config.wait_duration_in_open
 
     def _admit_probe(self) -> bool:
         # Cap total probes (don't hammer a barely-recovered dependency) and how

--- a/interlock/config.py
+++ b/interlock/config.py
@@ -19,6 +19,11 @@ class Config:
     treat calls slower than 60s as slow (but never trip on slowness alone until
     tuned), stay open 60s before a single probe is allowed.
 
+    ``auto_transition`` opts into a timer that proactively moves a breaker from
+    ``OPEN`` to ``HALF_OPEN`` once ``wait_duration_in_open`` elapses, emitting the
+    state change without waiting for the next call. It defaults to ``False``,
+    preserving the lazy transition (which stays authoritative either way).
+
     Raises:
         ValueError: If any value is out of range or inconsistent.
     """
@@ -30,6 +35,7 @@ class Config:
     permitted_calls_in_half_open: int = 10
     max_concurrent_probes: int = 1
     wait_duration_in_open: float = 60.0
+    auto_transition: bool = False
     window_type: WindowType = WindowType.COUNT_BASED
     window_size: int = 100
 

--- a/tests/test_auto_transition.py
+++ b/tests/test_auto_transition.py
@@ -1,0 +1,118 @@
+"""End-to-end tests for the auto-transition timer.
+
+Unlike the deterministic FakeClock tests, these exercise the real
+``threading.Timer``: they use a short real ``wait_duration_in_open`` and wait on
+a thread-safe ``Event`` the listener sets when the breaker reaches ``HALF_OPEN``.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from interlock import CircuitBreaker, Config, State
+
+_WAIT = 0.05
+
+
+class _HalfOpenSignal:
+    """Listener that flags when the breaker proactively reaches HALF_OPEN."""
+
+    def __init__(self) -> None:
+        self.reached_half_open = threading.Event()
+        self.state_changes: list[tuple[State, State]] = []
+
+    def on_state_change(self, *, name: str, old: State, new: State) -> None:
+        self.state_changes.append((old, new))
+        if new is State.HALF_OPEN:
+            self.reached_half_open.set()
+
+    def on_call(self, *, name: str, outcome: object, duration: float) -> None: ...
+    def on_rejected(self, *, name: str) -> None: ...
+    def on_reset(self, *, name: str) -> None: ...
+
+
+def _config(*, auto_transition: bool) -> Config:
+    return Config(
+        minimum_number_of_calls=2,
+        window_size=10,
+        permitted_calls_in_half_open=2,
+        max_concurrent_probes=2,
+        wait_duration_in_open=_WAIT,
+        auto_transition=auto_transition,
+    )
+
+
+def _trip_sync(breaker: CircuitBreaker) -> None:
+    def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            breaker.call(boom)
+
+
+def test__auto_transition__sync__timer_moves_to_half_open() -> None:
+    signal = _HalfOpenSignal()
+    breaker = CircuitBreaker(name='auto', config=_config(auto_transition=True), listener=signal)
+    _trip_sync(breaker)
+    assert breaker.state is State.OPEN
+
+    assert signal.reached_half_open.wait(2.0)
+    assert breaker.state is State.HALF_OPEN
+    assert (State.OPEN, State.HALF_OPEN) in signal.state_changes
+
+
+@pytest.mark.asyncio
+async def test__auto_transition__async__timer_moves_to_half_open() -> None:
+    signal = _HalfOpenSignal()
+    breaker = CircuitBreaker(
+        name='auto-async', config=_config(auto_transition=True), listener=signal
+    )
+
+    async def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            await breaker.call(boom)
+    assert breaker.state is State.OPEN
+
+    # The timer fires on its own thread; wait off the event loop.
+    assert await asyncio.to_thread(signal.reached_half_open.wait, 2.0)
+    assert breaker.state is State.HALF_OPEN
+
+
+def test__auto_transition_disabled__stays_open_until_a_call() -> None:
+    signal = _HalfOpenSignal()
+    breaker = CircuitBreaker(name='lazy', config=_config(auto_transition=False), listener=signal)
+    _trip_sync(breaker)
+
+    assert not signal.reached_half_open.wait(_WAIT * 4)
+    assert breaker.state is State.OPEN
+
+
+def test__auto_transition__reset_before_timer__no_transition() -> None:
+    signal = _HalfOpenSignal()
+    breaker = CircuitBreaker(
+        name='auto-reset', config=_config(auto_transition=True), listener=signal
+    )
+    _trip_sync(breaker)
+
+    breaker.reset()
+
+    assert not signal.reached_half_open.wait(_WAIT * 4)
+    assert breaker.state is State.CLOSED
+
+
+def test__auto_transition__force_open_before_timer__no_transition() -> None:
+    signal = _HalfOpenSignal()
+    breaker = CircuitBreaker(
+        name='auto-force', config=_config(auto_transition=True), listener=signal
+    )
+    _trip_sync(breaker)
+
+    breaker.force_open()
+
+    assert not signal.reached_half_open.wait(_WAIT * 4)
+    assert breaker.state is State.FORCED_OPEN

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,3 +55,11 @@ def test__config__invalid_value__raises_value_error(
 def test__config__concurrent_probes_above_permitted__raises_value_error() -> None:
     with pytest.raises(ValueError, match='max_concurrent_probes'):
         Config(permitted_calls_in_half_open=3, max_concurrent_probes=5)
+
+
+def test__config__auto_transition__defaults_to_false() -> None:
+    assert Config().auto_transition is False
+
+
+def test__config__auto_transition__can_be_enabled() -> None:
+    assert Config(auto_transition=True).auto_transition is True

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -281,6 +281,63 @@ def test__half_open__retry_after__is_none(config: Config, fake_clock: FakeClock)
     fake_clock.advance(5.0)
     assert machine.acquire() is True  # crosses the wait into HALF_OPEN as the first probe
 
+
+def test__attempt_auto_transition__open_and_elapsed__moves_to_half_open(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, config.minimum_number_of_calls)
+    fake_clock.advance(config.wait_duration_in_open)
+
+    assert machine.attempt_auto_transition() is True
+    assert machine.state is State.HALF_OPEN
+
+
+def test__attempt_auto_transition__open_not_elapsed__stays_open(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, config.minimum_number_of_calls)
+    fake_clock.advance(config.wait_duration_in_open - 1)
+
+    assert machine.attempt_auto_transition() is False
+    assert machine.state is State.OPEN
+
+
+def test__attempt_auto_transition__not_open__returns_false(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+
+    assert machine.attempt_auto_transition() is False
+    assert machine.state is State.CLOSED
+
+
+def test__attempt_auto_transition__admits_no_probe(config: Config, fake_clock: FakeClock) -> None:
+    machine = StateMachine(
+        config=replace(config, permitted_calls_in_half_open=1, max_concurrent_probes=1),
+        clock=fake_clock,
+    )
+    _trip_to_open(machine, config.minimum_number_of_calls)
+    fake_clock.advance(config.wait_duration_in_open)
+
+    machine.attempt_auto_transition()
+
+    # No probe slot was consumed: the first real probe is still admitted.
+    assert machine.acquire() is True
+
+
+def test__attempt_auto_transition__after_lazy_acquire__no_double_transition(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, config.minimum_number_of_calls)
+    fake_clock.advance(config.wait_duration_in_open)
+    assert machine.acquire() is True  # real call wins the lazy transition first
+
+    assert machine.attempt_auto_transition() is False
+    assert machine.state is State.HALF_OPEN
+
     assert machine.state is State.HALF_OPEN
     assert machine.retry_after() is None
 


### PR DESCRIPTION
## Summary

By default the OPEN -> HALF_OPEN move is lazy (on the first call after wait_duration_in_open). A low-traffic breaker can then sit in OPEN longer than needed, and the state-change event isn't emitted until a call arrives — a blind spot for dashboards.

Config.auto_transition (default False) arms a daemon threading.Timer that performs the move when the wait elapses and emits on_state_change without a call. The lazy path stays authoritative: the timer only flips the state via the new I/O-free StateMachine.attempt_auto_transition() (it admits no probe), so the first real call is still the first probe. A lock makes a timer/call race transition exactly once; the timer is cancelled on reset, force_open or when a call makes the move first.

threading.Timer is used for both sync and async paths, consistent with the library's threading.Lock model (asyncio primitives are not thread-safe and a single sync/async class would race on cross-context cancellation)