### PR TITLE
docs: point Documentation URL and README to the hosted site

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ async def orders(breaker: Annotated[CircuitBreaker, Depends(orders_db)]) -> list
 
 ## Documentation
 
-Full guides, integration recipes and the API reference live in [`docs/`](docs/):
+The full documentation is hosted at **<https://bagowix.github.io/interlock/>**.
+The sources live in [`docs/`](docs/):
 
 - [Getting started](docs/getting-started.md)
 - [Configuration](docs/guides/configuration.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ fastapi = ["fastapi>=0.128.0"]
 
 [project.urls]
 Homepage = "https://github.com/bagowix/interlock"
-Documentation = "https://github.com/bagowix/interlock/tree/main/docs"
+Documentation = "https://bagowix.github.io/interlock/"
 Repository = "https://github.com/bagowix/interlock"
 Changelog = "https://github.com/bagowix/interlock/blob/main/CHANGELOG.md"
 Issues = "https://github.com/bagowix/interlock/issues"


### PR DESCRIPTION
## Summary

The docs are deployed to GitHub Pages at https://bagowix.github.io/interlock/. Point the PyPI "Documentation" URL there instead of the raw repo tree, and add a hosted-site link to the README's Documentation section.