### PR TITLE
fix: harden Storage contract and probe accounting

### DIFF
--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -118,16 +118,16 @@ class Engine:
         Raises:
             CircuitOpenError: If the breaker rejects the call.
         """
-        self._admit()
+        generation = self._admit()
         start = self._clock.monotonic()
 
         try:
             result = fn(*args, **kwargs)
         except Exception as exc:
-            self._settle(result=None, exception=exc, start=start)
+            self._settle(result=None, exception=exc, start=start, generation=generation)
             raise
         else:
-            self._settle(result=result, exception=None, start=start)
+            self._settle(result=result, exception=None, start=start, generation=generation)
             return result
 
     async def call_async(self, fn: AsyncCallable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
@@ -136,35 +136,37 @@ class Engine:
         Raises:
             CircuitOpenError: If the breaker rejects the call.
         """
-        self._admit()
+        generation = self._admit()
         start = self._clock.monotonic()
 
         try:
             result = await fn(*args, **kwargs)
         except Exception as exc:
-            self._settle(result=None, exception=exc, start=start)
+            self._settle(result=None, exception=exc, start=start, generation=generation)
             raise
         else:
-            self._settle(result=result, exception=None, start=start)
+            self._settle(result=result, exception=None, start=start, generation=generation)
             return result
 
-    def enter_block(self) -> float:
-        """Admit a guarded block and return its start time.
+    def enter_block(self) -> tuple[float, int]:
+        """Admit a guarded block; return its start time and admission generation.
 
         Backs the context-manager surface, where there is no callable to run —
-        only a block whose exception and duration are observed.
+        only a block whose exception and duration are observed. The generation
+        is handed back to ``exit_block`` so a block that outlives a state
+        transition is not recorded into the wrong era.
 
         Raises:
             CircuitOpenError: If the breaker rejects the block.
         """
-        self._admit()
-        return self._clock.monotonic()
+        generation = self._admit()
+        return self._clock.monotonic(), generation
 
-    def exit_block(self, *, start: float, exception: BaseException | None) -> None:
+    def exit_block(self, *, start: float, generation: int, exception: BaseException | None) -> None:
         """Record a guarded block's outcome from its exception and duration."""
         if exception is not None and not isinstance(exception, Exception):
             return  # mirror call(): cancellation/shutdown are not downstream failures
-        self._settle(result=None, exception=exception, start=start)
+        self._settle(result=None, exception=exception, start=start, generation=generation)
 
     def reset(self) -> None:
         """Return to ``CLOSED`` with a fresh window, discarding past metrics."""
@@ -172,6 +174,7 @@ class Engine:
             before = self._machine.state
             self._machine.reset()
             after = self._machine.state
+            self._last_failure = None
 
         self._on_transition(before, after)
         self._listener.on_reset(name=self._name)
@@ -196,11 +199,13 @@ class Engine:
 
         self._on_transition(before, after)
 
-    def _admit(self) -> None:
+    def _admit(self) -> int:
+        """Admit one call and return the generation it was admitted in."""
         with self._lock:
             before = self._machine.state
             admitted = self._machine.acquire()
             after = self._machine.state
+            generation = self._machine.generation
             retry_after = None if admitted else self._machine.retry_after()
             last_failure = self._last_failure
 
@@ -213,7 +218,11 @@ class Engine:
                 last_failure=last_failure,
             )
 
-    def _settle(self, *, result: object, exception: Exception | None, start: float) -> None:
+        return generation
+
+    def _settle(
+        self, *, result: object, exception: Exception | None, start: float, generation: int
+    ) -> None:
         duration = self._clock.monotonic() - start
         failure = self._classifier.is_failure(result=result, exception=exception)
         slow = duration >= self._config.slow_call_duration_threshold
@@ -221,7 +230,7 @@ class Engine:
 
         with self._lock:
             before = self._machine.state
-            self._machine.record(outcome)
+            self._machine.record(outcome, generation=generation)
             after = self._machine.state
             if failure and exception is not None:
                 self._last_failure = exception

--- a/interlock/_state_machine.py
+++ b/interlock/_state_machine.py
@@ -48,12 +48,24 @@ class StateMachine:
         self._window = build_window(config=config, clock=clock)
         self._state = State.CLOSED
         self._opened_at = 0.0
+        self._generation = 0
         self._reset_probes()
 
     @property
     def state(self) -> State:
         """The current lifecycle state."""
         return self._state
+
+    @property
+    def generation(self) -> int:
+        """Era counter, bumped on every transition.
+
+        The call layer captures it at admission and passes it back to
+        ``record``, which drops outcomes admitted in an earlier era — a call
+        admitted in CLOSED must not settle as a HALF_OPEN probe, and a stale
+        probe must not pollute the fresh window after a close or reset.
+        """
+        return self._generation
 
     def snapshot(self) -> WindowSnapshot:
         """An immutable view of the current window aggregates."""
@@ -91,8 +103,15 @@ class StateMachine:
 
         return False  # FORCED_OPEN
 
-    def record(self, outcome: Outcome) -> None:
-        """Record one completed call's outcome and evaluate any transition."""
+    def record(self, outcome: Outcome, *, generation: int | None = None) -> None:
+        """Record one completed call's outcome and evaluate any transition.
+
+        ``generation`` is the era captured at admission; an outcome from an
+        earlier era is dropped (see ``generation``). ``None`` skips the check.
+        """
+        if generation is not None and generation != self._generation:
+            return
+
         if self._state is State.CLOSED:
             self._window.record(outcome)
             self._evaluate_closed()
@@ -118,16 +137,19 @@ class StateMachine:
     def force_open(self) -> None:
         """Override to ``FORCED_OPEN``: reject all traffic until reset."""
         self._state = State.FORCED_OPEN
+        self._generation += 1
         self._reset_probes()
 
     def disable(self) -> None:
         """Override to ``DISABLED``: admit all traffic, record nothing."""
         self._state = State.DISABLED
+        self._generation += 1
         self._reset_probes()
 
     def metrics_only(self) -> None:
         """Override to ``METRICS_ONLY``: admit all traffic, record but never trip."""
         self._state = State.METRICS_ONLY
+        self._generation += 1
         self._reset_probes()
 
     def reset(self) -> None:
@@ -196,14 +218,17 @@ class StateMachine:
     def _open(self) -> None:
         self._state = State.OPEN
         self._opened_at = self._clock.monotonic()
+        self._generation += 1
 
     def _to_half_open(self) -> None:
         self._state = State.HALF_OPEN
+        self._generation += 1
         self._reset_probes()
 
     def _close(self) -> None:
         self._state = State.CLOSED
         self._window = build_window(config=self._config, clock=self._clock)
+        self._generation += 1
         self._reset_probes()
 
     def _reset_probes(self) -> None:

--- a/interlock/breaker.py
+++ b/interlock/breaker.py
@@ -63,7 +63,7 @@ class CircuitBreaker:
             classifier=classifier,
             listener=listener,
         )
-        self._block_starts: list[float] = []
+        self._blocks: list[tuple[float, int]] = []
 
     @property
     def name(self) -> str:
@@ -143,7 +143,7 @@ class CircuitBreaker:
         return sync_wrapper
 
     def __enter__(self) -> Self:
-        self._block_starts.append(self._engine.enter_block())
+        self._blocks.append(self._engine.enter_block())
         return self
 
     def __exit__(
@@ -152,11 +152,12 @@ class CircuitBreaker:
         exc: BaseException | None,
         _traceback: TracebackType | None,
     ) -> Literal[False]:
-        self._engine.exit_block(start=self._block_starts.pop(), exception=exc)
+        start, generation = self._blocks.pop()
+        self._engine.exit_block(start=start, generation=generation, exception=exc)
         return False
 
     async def __aenter__(self) -> Self:
-        self._block_starts.append(self._engine.enter_block())
+        self._blocks.append(self._engine.enter_block())
         return self
 
     async def __aexit__(
@@ -165,5 +166,6 @@ class CircuitBreaker:
         exc: BaseException | None,
         _traceback: TracebackType | None,
     ) -> Literal[False]:
-        self._engine.exit_block(start=self._block_starts.pop(), exception=exc)
+        start, generation = self._blocks.pop()
+        self._engine.exit_block(start=start, generation=generation, exception=exc)
         return False

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -64,12 +64,17 @@ class Storage(Protocol):
         """Return the current shared view, or ``None`` if no key exists."""
         ...
 
-    def trip_open(self, *, name: str, ttl: float) -> SharedState:
+    def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
         """Transition to ``OPEN``, stamping the backend's time as ``opened_at``.
 
         Idempotent while already ``OPEN`` (the first opener's time stands);
         from ``HALF_OPEN`` it reopens with a fresh ``opened_at`` and clears
-        probe accounting.
+        probe accounting. With ``expected_version`` set, the transition is
+        fenced: it applies only while the backend still holds that version, so
+        a decision computed from a stale view cannot clobber a newer state.
+        A fenced-out call is a no-op returning the current view.
         """
         ...
 
@@ -84,7 +89,7 @@ class Storage(Protocol):
         """
         ...
 
-    def lease_probe(self, *, name: str) -> ProbeLease:
+    def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
         """Claim one global probe slot, decrementing the shared budget.
 
         ``granted`` is true only in ``HALF_OPEN`` with budget remaining; this
@@ -95,13 +100,20 @@ class Storage(Protocol):
     def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
         """Tally one completed probe's outcome into the shared accounting.
 
-        Returns the updated view; the caller treats
+        Tallies only while ``HALF_OPEN`` — a probe outcome that arrives after
+        the state has already moved on (another instance tripped or closed) is
+        dropped, returning the current view untouched. The caller treats
         ``probes_completed >= probes_permitted`` as "round finished, decide now".
         """
         ...
 
-    def close(self, *, name: str, ttl: float) -> SharedState:
-        """Transition to ``CLOSED`` and clear probe accounting."""
+    def close(self, *, name: str, ttl: float, expected_version: int | None = None) -> SharedState:
+        """Transition to ``CLOSED`` and clear probe accounting.
+
+        With ``expected_version`` set, fenced exactly like ``trip_open``: a
+        delayed "probes passed" decision cannot close a breaker that has since
+        re-opened.
+        """
         ...
 
 
@@ -117,7 +129,9 @@ class AsyncStorage(Protocol):
         """Return the current shared view, or ``None`` if no key exists."""
         ...
 
-    async def trip_open(self, *, name: str, ttl: float) -> SharedState:
+    async def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
         """Transition to ``OPEN``, stamping the backend's time as ``opened_at``."""
         ...
 
@@ -127,15 +141,17 @@ class AsyncStorage(Protocol):
         """Move ``OPEN`` → ``HALF_OPEN`` once ``wait_duration`` has elapsed."""
         ...
 
-    async def lease_probe(self, *, name: str) -> ProbeLease:
+    async def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
         """Claim one global probe slot, decrementing the shared budget."""
         ...
 
     async def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
-        """Tally one completed probe's outcome into the shared accounting."""
+        """Tally one completed probe's outcome (only while ``HALF_OPEN``)."""
         ...
 
-    async def close(self, *, name: str, ttl: float) -> SharedState:
+    async def close(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
         """Transition to ``CLOSED`` and clear probe accounting."""
         ...
 

--- a/interlock/redis.py
+++ b/interlock/redis.py
@@ -13,7 +13,10 @@ Threshold *policy* stays in the core state machine, which calls ``trip_open`` /
 ``close`` once it has decided.
 
 Wire-compatible with Redis, Valkey, and any RESP server: this speaks plain
-commands and ``EVAL``, with no server-specific features.
+commands and ``EVAL``, with no server-specific features. The scripts call
+``TIME`` before writing, so the server must replicate scripts by effects —
+Redis >= 5.0 or any Valkey (the ``redis>=5.0.0`` dependency pin is the
+*client* library version, not the server's).
 """
 
 from typing import Any
@@ -44,18 +47,22 @@ _NOW_US = (
     'return tonumber(t[1]) * 1000000 + tonumber(t[2]) end)()'
 )
 
+# expected_version < 0 means unfenced; a fenced-out call performs no write at
+# all (not even a TTL refresh — a stale actor must not extend the key's life).
 _TRIP_OPEN = f"""
 local key = KEYS[1]
 local ttl_ms = tonumber(ARGV[1])
-local state = redis.call('HGET', key, 'state')
-if state ~= 'open' then
-  local version = tonumber(redis.call('HGET', key, 'version') or '0') + 1
-  redis.call('HSET', key,
-    'state', 'open', 'opened_at', {_NOW_US}, 'version', version,
-    'probes_permitted', 0, 'probes_remaining', 0, 'probes_completed', 0,
-    'probe_failures', 0, 'probe_slows', 0, 'v', 1)
+local expected = tonumber(ARGV[2])
+local version = tonumber(redis.call('HGET', key, 'version') or '0')
+if expected < 0 or version == expected then
+  if redis.call('HGET', key, 'state') ~= 'open' then
+    redis.call('HSET', key,
+      'state', 'open', 'opened_at', {_NOW_US}, 'version', version + 1,
+      'probes_permitted', 0, 'probes_remaining', 0, 'probes_completed', 0,
+      'probe_failures', 0, 'probe_slows', 0, 'v', 1)
+  end
+  redis.call('PEXPIRE', key, ttl_ms)
 end
-redis.call('PEXPIRE', key, ttl_ms)
 {_RETURN_STATE}
 """
 
@@ -80,6 +87,7 @@ redis.call('PEXPIRE', key, ttl_ms)
 
 _LEASE_PROBE = f"""
 local key = KEYS[1]
+local ttl_ms = tonumber(ARGV[1])
 local granted = 0
 if redis.call('HGET', key, 'state') == 'half_open' then
   if tonumber(redis.call('HGET', key, 'probes_remaining') or '0') > 0 then
@@ -88,33 +96,41 @@ if redis.call('HGET', key, 'state') == 'half_open' then
     granted = 1
   end
 end
+redis.call('PEXPIRE', key, ttl_ms)
 local r = redis.call('HMGET', KEYS[1], {_FIELDS})
 table.insert(r, 1, granted)
 return r
 """
 
+# Tallies only while HALF_OPEN: a probe outcome arriving after the state moved
+# on (another instance tripped or closed) must not pollute the new accounting.
 _RECORD_PROBE = f"""
 local key = KEYS[1]
 local is_failure = tonumber(ARGV[1])
 local is_slow = tonumber(ARGV[2])
 local ttl_ms = tonumber(ARGV[3])
-redis.call('HINCRBY', key, 'probes_completed', 1)
-redis.call('HINCRBY', key, 'version', 1)
-if is_failure == 1 then redis.call('HINCRBY', key, 'probe_failures', 1) end
-if is_slow == 1 then redis.call('HINCRBY', key, 'probe_slows', 1) end
-redis.call('PEXPIRE', key, ttl_ms)
+if redis.call('HGET', key, 'state') == 'half_open' then
+  redis.call('HINCRBY', key, 'probes_completed', 1)
+  redis.call('HINCRBY', key, 'version', 1)
+  if is_failure == 1 then redis.call('HINCRBY', key, 'probe_failures', 1) end
+  if is_slow == 1 then redis.call('HINCRBY', key, 'probe_slows', 1) end
+  redis.call('PEXPIRE', key, ttl_ms)
+end
 {_RETURN_STATE}
 """
 
 _CLOSE = f"""
 local key = KEYS[1]
 local ttl_ms = tonumber(ARGV[1])
-local version = tonumber(redis.call('HGET', key, 'version') or '0') + 1
-redis.call('HSET', key,
-  'state', 'closed', 'opened_at', 0, 'version', version,
-  'probes_permitted', 0, 'probes_remaining', 0, 'probes_completed', 0,
-  'probe_failures', 0, 'probe_slows', 0, 'v', 1)
-redis.call('PEXPIRE', key, ttl_ms)
+local expected = tonumber(ARGV[2])
+local version = tonumber(redis.call('HGET', key, 'version') or '0')
+if expected < 0 or version == expected then
+  redis.call('HSET', key,
+    'state', 'closed', 'opened_at', 0, 'version', version + 1,
+    'probes_permitted', 0, 'probes_remaining', 0, 'probes_completed', 0,
+    'probe_failures', 0, 'probe_slows', 0, 'v', 1)
+  redis.call('PEXPIRE', key, ttl_ms)
+end
 {_RETURN_STATE}
 """
 
@@ -125,8 +141,21 @@ def _s(value: object) -> str:
 
 
 def _ms(ttl: float) -> int:
-    """Convert a TTL in seconds to whole milliseconds for ``PEXPIRE``."""
-    return int(ttl * 1000)
+    """Convert a TTL in seconds to whole milliseconds for ``PEXPIRE``.
+
+    Rejects TTLs under one millisecond: ``PEXPIRE key 0`` would delete the key
+    outright instead of expiring it.
+    """
+    ms = int(ttl * 1000)
+    if ms <= 0:
+        msg = f'ttl must be at least 0.001 seconds, got {ttl!r}'
+        raise ValueError(msg)
+    return ms
+
+
+def _fence(expected_version: int | None) -> int:
+    """Encode ``expected_version`` for Lua: ``-1`` disables the fence."""
+    return -1 if expected_version is None else expected_version
 
 
 def _shared_from_values(values: list[Any]) -> SharedState:
@@ -184,9 +213,17 @@ class RedisStorage:
         """Return the current shared view, or ``None`` if no key exists."""
         return _shared_from_map(self._client.hgetall(self._key(name)))
 
-    def trip_open(self, *, name: str, ttl: float) -> SharedState:
-        """Atomically transition to ``OPEN`` (idempotent while already open)."""
-        values = self._client.eval(_TRIP_OPEN, 1, self._key(name), _ms(ttl))
+    def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        """Atomically transition to ``OPEN`` (idempotent while already open).
+
+        With ``expected_version``, fenced: a no-op unless the backend still
+        holds that version.
+        """
+        values = self._client.eval(
+            _TRIP_OPEN, 1, self._key(name), _ms(ttl), _fence(expected_version)
+        )
         return _shared_from_values(values)
 
     def begin_half_open_if_elapsed(
@@ -198,13 +235,13 @@ class RedisStorage:
         )
         return _shared_from_values(values)
 
-    def lease_probe(self, *, name: str) -> ProbeLease:
+    def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
         """Atomically claim one global probe slot."""
-        values = self._client.eval(_LEASE_PROBE, 1, self._key(name))
+        values = self._client.eval(_LEASE_PROBE, 1, self._key(name), _ms(ttl))
         return ProbeLease(granted=bool(int(_s(values[0]))), state=_shared_from_values(values[1:]))
 
     def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
-        """Tally one completed probe's outcome into the shared accounting."""
+        """Tally one completed probe's outcome (only while ``HALF_OPEN``)."""
         values = self._client.eval(
             _RECORD_PROBE,
             1,
@@ -215,9 +252,13 @@ class RedisStorage:
         )
         return _shared_from_values(values)
 
-    def close(self, *, name: str, ttl: float) -> SharedState:
-        """Atomically transition to ``CLOSED`` and clear probe accounting."""
-        values = self._client.eval(_CLOSE, 1, self._key(name), _ms(ttl))
+    def close(self, *, name: str, ttl: float, expected_version: int | None = None) -> SharedState:
+        """Atomically transition to ``CLOSED`` and clear probe accounting.
+
+        With ``expected_version``, fenced: a delayed "probes passed" decision
+        cannot close a breaker that has since re-opened.
+        """
+        values = self._client.eval(_CLOSE, 1, self._key(name), _ms(ttl), _fence(expected_version))
         return _shared_from_values(values)
 
 
@@ -240,9 +281,17 @@ class AsyncRedisStorage:
         """Return the current shared view, or ``None`` if no key exists."""
         return _shared_from_map(await self._client.hgetall(self._key(name)))
 
-    async def trip_open(self, *, name: str, ttl: float) -> SharedState:
-        """Atomically transition to ``OPEN`` (idempotent while already open)."""
-        values = await self._client.eval(_TRIP_OPEN, 1, self._key(name), _ms(ttl))
+    async def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        """Atomically transition to ``OPEN`` (idempotent while already open).
+
+        With ``expected_version``, fenced: a no-op unless the backend still
+        holds that version.
+        """
+        values = await self._client.eval(
+            _TRIP_OPEN, 1, self._key(name), _ms(ttl), _fence(expected_version)
+        )
         return _shared_from_values(values)
 
     async def begin_half_open_if_elapsed(
@@ -254,13 +303,13 @@ class AsyncRedisStorage:
         )
         return _shared_from_values(values)
 
-    async def lease_probe(self, *, name: str) -> ProbeLease:
+    async def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
         """Atomically claim one global probe slot."""
-        values = await self._client.eval(_LEASE_PROBE, 1, self._key(name))
+        values = await self._client.eval(_LEASE_PROBE, 1, self._key(name), _ms(ttl))
         return ProbeLease(granted=bool(int(_s(values[0]))), state=_shared_from_values(values[1:]))
 
     async def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
-        """Tally one completed probe's outcome into the shared accounting."""
+        """Tally one completed probe's outcome (only while ``HALF_OPEN``)."""
         values = await self._client.eval(
             _RECORD_PROBE,
             1,
@@ -271,7 +320,15 @@ class AsyncRedisStorage:
         )
         return _shared_from_values(values)
 
-    async def close(self, *, name: str, ttl: float) -> SharedState:
-        """Atomically transition to ``CLOSED`` and clear probe accounting."""
-        values = await self._client.eval(_CLOSE, 1, self._key(name), _ms(ttl))
+    async def close(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        """Atomically transition to ``CLOSED`` and clear probe accounting.
+
+        With ``expected_version``, fenced: a delayed "probes passed" decision
+        cannot close a breaker that has since re-opened.
+        """
+        values = await self._client.eval(
+            _CLOSE, 1, self._key(name), _ms(ttl), _fence(expected_version)
+        )
         return _shared_from_values(values)

--- a/tests/inmemory_storage.py
+++ b/tests/inmemory_storage.py
@@ -27,9 +27,11 @@ class _Core:
         with self._lock:
             return self._store.get(name)
 
-    def trip_open(self, *, name: str) -> SharedState:
+    def trip_open(self, *, name: str, expected_version: int | None) -> SharedState:
         with self._lock:
             current = self._store.get(name) or SharedState.closed()
+            if expected_version is not None and current.version != expected_version:
+                return current
             if current.state is State.OPEN:
                 return current
 
@@ -85,6 +87,9 @@ class _Core:
     def record_probe(self, *, name: str, outcome: Outcome) -> SharedState:
         with self._lock:
             current = self._store.get(name) or SharedState.closed()
+            if current.state is not State.HALF_OPEN:
+                return current  # stale probe outcome: the state has moved on
+
             new = dataclasses.replace(
                 current,
                 version=current.version + 1,
@@ -96,9 +101,12 @@ class _Core:
 
             return new
 
-    def close(self, *, name: str) -> SharedState:
+    def close(self, *, name: str, expected_version: int | None) -> SharedState:
         with self._lock:
             current = self._store.get(name) or SharedState.closed()
+            if expected_version is not None and current.version != expected_version:
+                return current
+
             new = dataclasses.replace(SharedState.closed(), version=current.version + 1)
             self._store[name] = new
             return new
@@ -113,8 +121,10 @@ class InMemoryStorage:
     def read(self, name: str) -> SharedState | None:
         return self._core.read(name)
 
-    def trip_open(self, *, name: str, ttl: float) -> SharedState:
-        return self._core.trip_open(name=name)
+    def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        return self._core.trip_open(name=name, expected_version=expected_version)
 
     def begin_half_open_if_elapsed(
         self, *, name: str, wait_duration: float, permitted: int, ttl: float
@@ -123,14 +133,14 @@ class InMemoryStorage:
             name=name, wait_duration=wait_duration, permitted=permitted
         )
 
-    def lease_probe(self, *, name: str) -> ProbeLease:
+    def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
         return self._core.lease_probe(name=name)
 
     def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
         return self._core.record_probe(name=name, outcome=outcome)
 
-    def close(self, *, name: str, ttl: float) -> SharedState:
-        return self._core.close(name=name)
+    def close(self, *, name: str, ttl: float, expected_version: int | None = None) -> SharedState:
+        return self._core.close(name=name, expected_version=expected_version)
 
 
 class AsyncInMemoryStorage:
@@ -142,8 +152,10 @@ class AsyncInMemoryStorage:
     async def read(self, name: str) -> SharedState | None:
         return self._core.read(name)
 
-    async def trip_open(self, *, name: str, ttl: float) -> SharedState:
-        return self._core.trip_open(name=name)
+    async def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        return self._core.trip_open(name=name, expected_version=expected_version)
 
     async def begin_half_open_if_elapsed(
         self, *, name: str, wait_duration: float, permitted: int, ttl: float
@@ -152,11 +164,13 @@ class AsyncInMemoryStorage:
             name=name, wait_duration=wait_duration, permitted=permitted
         )
 
-    async def lease_probe(self, *, name: str) -> ProbeLease:
+    async def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
         return self._core.lease_probe(name=name)
 
     async def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
         return self._core.record_probe(name=name, outcome=outcome)
 
-    async def close(self, *, name: str, ttl: float) -> SharedState:
-        return self._core.close(name=name)
+    async def close(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        return self._core.close(name=name, expected_version=expected_version)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -215,3 +215,29 @@ async def test__call_async__open_circuit__rejects_without_executing(engine: Engi
         await engine.call_async(probe)
 
     assert executed == []
+
+
+def test__stale_block__settling_in_half_open__not_counted_as_probe(
+    engine: Engine, fake_clock: FakeClock
+) -> None:
+    start, generation = engine.enter_block()  # admitted while CLOSED
+    _trip_to_open(engine)  # breaker trips while the block is still running
+    fake_clock.advance(5.0)
+    assert engine.call_sync(lambda: 'probe') == 'probe'  # -> HALF_OPEN, first probe succeeds
+
+    engine.exit_block(start=start, generation=generation, exception=None)
+
+    # permitted_calls_in_half_open=2: had the stale block counted as the second
+    # probe, the round would have finished and the breaker would have closed.
+    assert engine.state is State.HALF_OPEN
+
+
+def test__reset__clears_last_failure(engine: Engine) -> None:
+    _trip_to_open(engine)  # last_failure is now ValueError('boom')
+
+    engine.reset()
+    engine.force_open()
+    with pytest.raises(CircuitOpenError) as exc_info:
+        engine.call_sync(lambda: 1)
+
+    assert exc_info.value.last_failure is None

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -133,7 +133,7 @@ def test__begin_half_open__after_elapsed__seeds_budget(storage: RedisStorage) ->
 
 
 def test__lease_probe__not_half_open__denied_on_absent_key(storage: RedisStorage) -> None:
-    lease = storage.lease_probe(name='svc')
+    lease = storage.lease_probe(name='svc', ttl=TTL)
 
     assert lease.granted is False
     assert lease.state.state is State.CLOSED
@@ -143,7 +143,7 @@ def test__lease_probe__grants_until_budget_exhausted(storage: RedisStorage) -> N
     storage.trip_open(name='svc', ttl=TTL)
     storage.begin_half_open_if_elapsed(name='svc', wait_duration=0.0, permitted=3, ttl=TTL)
 
-    grants = [storage.lease_probe(name='svc').granted for _ in range(4)]
+    grants = [storage.lease_probe(name='svc', ttl=TTL).granted for _ in range(4)]
 
     assert grants == [True, True, True, False]
 
@@ -181,7 +181,75 @@ def test__trip_open__from_half_open__reopens_fresh(storage: RedisStorage) -> Non
     assert state.probes_remaining == 0
 
 
-# --- T2.3: atomicity under concurrency ---
+def test__record_probe__not_half_open__is_dropped(storage: RedisStorage) -> None:
+    storage.trip_open(name='svc', ttl=TTL)
+
+    state = storage.record_probe(name='svc', outcome=Outcome.FAILURE, ttl=TTL)
+
+    assert state.state is State.OPEN
+    assert state.probes_completed == 0
+    assert state.probe_failures == 0
+
+
+def test__record_probe__absent_key__does_not_create_state(storage: RedisStorage) -> None:
+    state = storage.record_probe(name='svc', outcome=Outcome.FAILURE, ttl=TTL)
+
+    assert state.state is State.CLOSED
+    assert state.probes_completed == 0
+    assert storage.read('svc') is None
+
+
+def test__close__matching_expected_version__applies(storage: RedisStorage) -> None:
+    storage.trip_open(name='svc', ttl=TTL)
+    storage.begin_half_open_if_elapsed(name='svc', wait_duration=0.0, permitted=1, ttl=TTL)
+    current = storage.record_probe(name='svc', outcome=Outcome.SUCCESS, ttl=TTL)
+
+    state = storage.close(name='svc', ttl=TTL, expected_version=current.version)
+
+    assert state.state is State.CLOSED
+    assert state.version == current.version + 1
+
+
+def test__close__stale_expected_version__is_fenced_out(storage: RedisStorage) -> None:
+    storage.trip_open(name='svc', ttl=TTL)
+    storage.begin_half_open_if_elapsed(name='svc', wait_duration=0.0, permitted=1, ttl=TTL)
+    stale = storage.record_probe(name='svc', outcome=Outcome.SUCCESS, ttl=TTL)
+    reopened = storage.trip_open(name='svc', ttl=TTL)  # another instance reopened meanwhile
+
+    state = storage.close(name='svc', ttl=TTL, expected_version=stale.version)
+
+    assert state.state is State.OPEN  # the delayed close must not win
+    assert state.version == reopened.version
+
+
+def test__trip_open__stale_expected_version__is_fenced_out(storage: RedisStorage) -> None:
+    storage.trip_open(name='svc', ttl=TTL)
+    storage.begin_half_open_if_elapsed(name='svc', wait_duration=0.0, permitted=1, ttl=TTL)
+    stale = storage.record_probe(name='svc', outcome=Outcome.FAILURE, ttl=TTL)
+    closed = storage.close(name='svc', ttl=TTL)  # another instance closed meanwhile
+
+    state = storage.trip_open(name='svc', ttl=TTL, expected_version=stale.version)
+
+    assert state.state is State.CLOSED  # the delayed reopen must not win
+    assert state.version == closed.version
+
+
+def test__ttl__non_positive__rejected(storage: RedisStorage) -> None:
+    with pytest.raises(ValueError, match='ttl'):
+        storage.trip_open(name='svc', ttl=0.0)
+
+
+def test__read__ignores_unknown_hash_fields(
+    storage: RedisStorage, redis_client: redis_mod.Redis, prefix: str
+) -> None:
+    # Forward-compat: a newer writer may add fields this version does not know.
+    storage.trip_open(name='svc', ttl=TTL)
+    redis_client.hset(f'{prefix}svc', 'future_field', 'whatever')
+
+    state = storage.read('svc')
+
+    assert state is not None
+    assert state.state is State.OPEN
 
 
 @requires_real_redis
@@ -218,7 +286,7 @@ def test__lease_probe__concurrent__grants_exactly_budget(storage: RedisStorage) 
 
     def worker() -> None:
         barrier.wait()
-        result = storage.lease_probe(name='svc').granted
+        result = storage.lease_probe(name='svc', ttl=TTL).granted
         with lock:
             granted.append(result)
 
@@ -229,9 +297,6 @@ def test__lease_probe__concurrent__grants_exactly_budget(storage: RedisStorage) 
         thread.join()
 
     assert sum(granted) == budget
-
-
-# --- T2.4: TTL ---
 
 
 def test__ttl__set_on_write(
@@ -251,7 +316,15 @@ def test__ttl__key_expires(storage: RedisStorage) -> None:
     assert storage.read('svc') is None
 
 
-# --- async mirror ---
+def test__ttl__lease_probe_refreshes_expiry(
+    storage: RedisStorage, redis_client: redis_mod.Redis, prefix: str
+) -> None:
+    storage.trip_open(name='svc', ttl=TTL)
+    storage.begin_half_open_if_elapsed(name='svc', wait_duration=0.0, permitted=3, ttl=TTL)
+
+    storage.lease_probe(name='svc', ttl=TTL * 2)
+
+    assert redis_client.pttl(f'{prefix}svc') > TTL * 1000
 
 
 @pytest.mark.asyncio
@@ -270,14 +343,20 @@ async def test__async__full_cycle(prefix: str) -> None:
         )
         assert half.state is State.HALF_OPEN
 
-        lease = await storage.lease_probe(name='svc')
+        lease = await storage.lease_probe(name='svc', ttl=TTL)
         assert lease.granted is True
 
         tally = await storage.record_probe(name='svc', outcome=Outcome.FAILURE, ttl=TTL)
         assert tally.probes_completed == 1
         assert tally.probe_failures == 1
 
-        closed = await storage.close(name='svc', ttl=TTL)
+        fenced = await storage.close(name='svc', ttl=TTL, expected_version=tally.version - 1)
+        assert fenced.state is State.HALF_OPEN  # stale version: fenced out
+
+        closed = await storage.close(name='svc', ttl=TTL, expected_version=tally.version)
         assert closed.state is State.CLOSED
+
+        reopen_fenced = await storage.trip_open(name='svc', ttl=TTL, expected_version=tally.version)
+        assert reopen_fenced.state is State.CLOSED  # stale version: fenced out
     finally:
         await client.aclose()

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -347,3 +347,59 @@ def test__forced_open__retry_after__is_none(config: Config, fake_clock: FakeCloc
     machine.force_open()
 
     assert machine.retry_after() is None
+
+
+def test__record__stale_generation__not_counted_as_probe(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    stale_generation = machine.generation  # calls admitted while CLOSED carry this era
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True  # OPEN -> HALF_OPEN, first probe admitted
+
+    machine.record(Outcome.SUCCESS, generation=stale_generation)
+    machine.record(Outcome.SUCCESS, generation=stale_generation)
+
+    # Two stale CLOSED-era successes must not finish the probe round
+    # (permitted_calls_in_half_open=2 would otherwise close the breaker here).
+    assert machine.state is State.HALF_OPEN
+
+
+def test__record__current_generation__is_recorded(config: Config, fake_clock: FakeClock) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True
+    assert machine.acquire() is True
+    generation = machine.generation
+
+    machine.record(Outcome.SUCCESS, generation=generation)
+    machine.record(Outcome.SUCCESS, generation=generation)
+
+    assert machine.state is State.CLOSED
+
+
+def test__record__probe_settling_after_reset__does_not_pollute_fresh_window(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True  # probe in flight
+    generation = machine.generation
+    machine.reset()  # operator resets while the probe still runs
+
+    machine.record(Outcome.FAILURE, generation=generation)
+
+    assert machine.snapshot().total_calls == 0
+
+
+def test__generation__bumped_by_overrides(config: Config, fake_clock: FakeClock) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    stale_generation = machine.generation
+
+    machine.metrics_only()
+    machine.record(Outcome.FAILURE, generation=stale_generation)
+
+    assert machine.snapshot().total_calls == 0  # pre-override call not recorded into shadow window

--- a/tests/test_storage_contract.py
+++ b/tests/test_storage_contract.py
@@ -85,7 +85,7 @@ def test__begin_half_open__second_call__does_not_reseed() -> None:
     first = storage.begin_half_open_if_elapsed(
         name=NAME, wait_duration=WAIT, permitted=PERMITTED, ttl=TTL
     )
-    storage.lease_probe(name=NAME)
+    storage.lease_probe(name=NAME, ttl=TTL)
 
     again = storage.begin_half_open_if_elapsed(
         name=NAME, wait_duration=WAIT, permitted=PERMITTED, ttl=TTL
@@ -106,7 +106,7 @@ def test__lease_probe__grants_until_budget_exhausted() -> None:
     storage = InMemoryStorage(clock=clock)
     _half_open(storage, clock)
 
-    grants = [storage.lease_probe(name=NAME).granted for _ in range(PERMITTED + 1)]
+    grants = [storage.lease_probe(name=NAME, ttl=TTL).granted for _ in range(PERMITTED + 1)]
 
     assert grants == [True, True, True, False]
 
@@ -116,7 +116,7 @@ def test__lease_probe__not_half_open__is_denied() -> None:
     storage = InMemoryStorage(clock=clock)
     storage.trip_open(name=NAME, ttl=TTL)
 
-    lease = storage.lease_probe(name=NAME)
+    lease = storage.lease_probe(name=NAME, ttl=TTL)
 
     assert lease.granted is False
     assert lease.state.state is State.OPEN
@@ -143,7 +143,7 @@ def test__close__returns_to_closed_and_clears_probes() -> None:
     clock = FakeClock()
     storage = InMemoryStorage(clock=clock)
     _half_open(storage, clock)
-    storage.lease_probe(name=NAME)
+    storage.lease_probe(name=NAME, ttl=TTL)
 
     state = storage.close(name=NAME, ttl=TTL)
 
@@ -151,6 +151,78 @@ def test__close__returns_to_closed_and_clears_probes() -> None:
     assert state.probes_permitted == 0
     assert state.probes_remaining == 0
     assert state.probes_completed == 0
+
+
+def test__record_probe__not_half_open__is_dropped() -> None:
+    clock = FakeClock()
+    storage = InMemoryStorage(clock=clock)
+    storage.trip_open(name=NAME, ttl=TTL)
+
+    state = storage.record_probe(name=NAME, outcome=Outcome.FAILURE, ttl=TTL)
+
+    assert state.state is State.OPEN
+    assert state.probes_completed == 0
+    assert state.probe_failures == 0
+
+
+def test__record_probe__absent_key__does_not_create_state() -> None:
+    storage = InMemoryStorage(clock=FakeClock())
+
+    state = storage.record_probe(name=NAME, outcome=Outcome.FAILURE, ttl=TTL)
+
+    assert state.state is State.CLOSED
+    assert state.probes_completed == 0
+    assert storage.read(NAME) is None
+
+
+def test__close__matching_expected_version__applies() -> None:
+    clock = FakeClock()
+    storage = InMemoryStorage(clock=clock)
+    _half_open(storage, clock)
+    current = storage.record_probe(name=NAME, outcome=Outcome.SUCCESS, ttl=TTL)
+
+    state = storage.close(name=NAME, ttl=TTL, expected_version=current.version)
+
+    assert state.state is State.CLOSED
+    assert state.version == current.version + 1
+
+
+def test__close__stale_expected_version__is_fenced_out() -> None:
+    clock = FakeClock()
+    storage = InMemoryStorage(clock=clock)
+    _half_open(storage, clock)
+    stale = storage.record_probe(name=NAME, outcome=Outcome.SUCCESS, ttl=TTL)
+    reopened = storage.trip_open(name=NAME, ttl=TTL)  # another instance reopened meanwhile
+
+    state = storage.close(name=NAME, ttl=TTL, expected_version=stale.version)
+
+    assert state.state is State.OPEN  # the delayed close must not win
+    assert state.version == reopened.version
+
+
+def test__trip_open__stale_expected_version__is_fenced_out() -> None:
+    clock = FakeClock()
+    storage = InMemoryStorage(clock=clock)
+    _half_open(storage, clock)
+    stale = storage.record_probe(name=NAME, outcome=Outcome.FAILURE, ttl=TTL)
+    closed = storage.close(name=NAME, ttl=TTL)  # another instance closed meanwhile
+
+    state = storage.trip_open(name=NAME, ttl=TTL, expected_version=stale.version)
+
+    assert state.state is State.CLOSED  # the delayed reopen must not win
+    assert state.version == closed.version
+
+
+def test__trip_open__matching_expected_version__applies() -> None:
+    clock = FakeClock()
+    storage = InMemoryStorage(clock=clock)
+    _half_open(storage, clock)
+    current = storage.record_probe(name=NAME, outcome=Outcome.FAILURE, ttl=TTL)
+
+    state = storage.trip_open(name=NAME, ttl=TTL, expected_version=current.version)
+
+    assert state.state is State.OPEN
+    assert state.version == current.version + 1
 
 
 def test__trip_open__from_half_open__reopens_with_fresh_time() -> None:
@@ -182,11 +254,17 @@ async def test__async__full_cycle__mirrors_sync_contract() -> None:
     )
     assert half.state is State.HALF_OPEN
 
-    lease = await storage.lease_probe(name=NAME)
+    lease = await storage.lease_probe(name=NAME, ttl=TTL)
     assert lease.granted is True
 
     tally = await storage.record_probe(name=NAME, outcome=Outcome.SUCCESS, ttl=TTL)
     assert tally.probes_completed == 1
 
-    closed = await storage.close(name=NAME, ttl=TTL)
+    fenced = await storage.close(name=NAME, ttl=TTL, expected_version=tally.version - 1)
+    assert fenced.state is State.HALF_OPEN  # stale version: fenced out
+
+    closed = await storage.close(name=NAME, ttl=TTL, expected_version=tally.version)
     assert closed.state is State.CLOSED
+
+    reopen_fenced = await storage.trip_open(name=NAME, ttl=TTL, expected_version=tally.version)
+    assert reopen_fenced.state is State.CLOSED  # stale version: fenced out


### PR DESCRIPTION
## Summary

Storage contract (protocols, RedisStorage/AsyncRedisStorage, in-memory reference):
- trip_open/close take optional expected_version — version-fenced CAS: a decision computed from a stale view (delayed "probes passed" close, delayed reopen) can no longer clobber a newer state; a fenced-out call performs no write, not even a TTL refresh
- record_probe tallies only while HALF_OPEN — a probe outcome arriving after the state moved on is dropped instead of polluting the next round's accounting (and no longer creates a stateless junk hash on an absent key)
- lease_probe takes ttl and refreshes key expiry, so every write renews the key's lifetime
- RedisStorage rejects TTLs under 1 ms (PEXPIRE 0 would delete the key)
- document the real server requirement (Redis >= 5.0 / Valkey: scripts call TIME before writing)

Core:
- StateMachine gains a generation era counter, bumped on every transition; Engine captures it at admission and record() drops outcomes from an older era — a call admitted in CLOSED can no longer settle as a HALF_OPEN probe, and a probe settling after close/reset no longer pollutes the fresh window
- Engine.reset() clears last_failure so CircuitOpenError after a reset does not report a pre-reset exception

Tests: fencing and stale-outcome guard contract tests on both backends, forward-compat test (unknown hash field ignored on read), generation/era tests for the state machine and engine.
