### PR TITLE
feat: wire optional shared storage into the breaker with graceful deg…

### DIFF
--- a/interlock/_coordination.py
+++ b/interlock/_coordination.py
@@ -1,0 +1,474 @@
+"""Coordination between a local breaker and a shared ``Storage`` backend.
+
+Active only when an ``Engine`` is constructed with a ``storage``. The local
+state machine keeps owning the CLOSED window and trip detection; the backend
+owns the shared OPEN/HALF_OPEN state and the global probe budget. This module
+is the plumbing between the two, built so the protected path stays fast:
+
+- The engine admits calls against a locally cached view of the shared state —
+  zero inline I/O in CLOSED and OPEN. The single inline network operation is
+  ``lease_probe`` in the short HALF_OPEN window.
+- All writes (trip on local threshold, probe outcomes, the final close/reopen
+  decision) are fire-and-forget: they run on a background *lane* (one daemon
+  thread for a sync storage, one asyncio task for an async one) that doubles as
+  the poller refreshing the cached view every ``poll_interval``.
+- Storage failures never reach the protected path (T3.1): any storage error
+  flips the coordinator into degraded mode — the breaker runs on local state,
+  writes are dropped, and the lane keeps retrying after ``retry_backoff``
+  seconds. Degradation and recovery surface through the engine's listener
+  callbacks (T3.2); on recovery the shared view becomes authoritative again
+  (T3.3).
+
+Tuning knobs are read from optional attributes on the storage object
+(``state_ttl``, ``poll_interval``, ``retry_backoff``) with conservative
+defaults, so the ``Storage`` protocol itself stays minimal and the core
+``Config`` stays storage-agnostic.
+
+The probe-round decision is the one piece of threshold policy applied here:
+after the last probe the lane computes the same rate checks as the local state
+machine (single source of policy: ``Config``) and sends ``close`` /
+``trip_open`` fenced with ``expected_version``, so a stale decision can never
+clobber a newer shared state.
+"""
+
+import asyncio
+import queue
+import threading
+import weakref
+from collections.abc import Awaitable, Callable
+
+from interlock.config import Config
+from interlock.outcome import Outcome
+from interlock.protocols import AsyncStorage, Clock, Storage
+from interlock.shared import SharedState
+from interlock.state import State
+
+__all__ = ('AsyncCoordinator', 'SyncCoordinator')
+
+_DEFAULT_STATE_TTL = 300.0
+_DEFAULT_POLL_INTERVAL = 1.0
+_DEFAULT_RETRY_BACKOFF = 5.0
+
+_SyncOp = Callable[[], None]
+_AsyncOp = Callable[[], Awaitable[None]]
+
+
+class _CoordinatorBase:
+    """State and policy shared by the sync and async coordinators.
+
+    Everything here is I/O-free; subclasses supply the storage calls and the
+    background lane. ``on_view`` / ``on_degraded`` / ``on_recovered`` are engine
+    callbacks — they must be fast and must not raise.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        config: Config,
+        clock: Clock,
+        storage: object,
+        on_view: Callable[[SharedState], None],
+        on_degraded: Callable[[BaseException], None],
+        on_recovered: Callable[[], None],
+    ) -> None:
+        self._name = name
+        self._config = config
+        self._clock = clock
+        self._on_view = on_view
+        self._on_degraded = on_degraded
+        self._on_recovered = on_recovered
+        self._ttl = float(getattr(storage, 'state_ttl', _DEFAULT_STATE_TTL))
+        self._interval = float(getattr(storage, 'poll_interval', _DEFAULT_POLL_INTERVAL))
+        self._backoff = float(getattr(storage, 'retry_backoff', _DEFAULT_RETRY_BACKOFF))
+        self._lock = threading.Lock()
+        self._degraded = False
+        self._retry_at = 0.0
+        self._last_view: SharedState | None = None
+        self._lane_started = False
+
+    def _gate_open(self) -> bool:
+        """Whether the storage may be touched now (not degraded, or retry due)."""
+        with self._lock:
+            return not self._degraded or self._clock.monotonic() >= self._retry_at
+
+    def _accept(self, view: SharedState) -> None:
+        with self._lock:
+            changed = view != self._last_view
+            self._last_view = view
+
+        if changed:
+            self._on_view(view)
+
+    def _degrade(self, error: BaseException) -> None:
+        with self._lock:
+            first = not self._degraded
+            self._degraded = True
+            self._retry_at = self._clock.monotonic() + self._backoff
+
+        if first:
+            self._on_degraded(error)
+
+    def _mark_available(self) -> None:
+        with self._lock:
+            was_degraded = self._degraded
+            self._degraded = False
+
+        if was_degraded:
+            self._on_recovered()
+
+    def _round_finished(self, view: SharedState) -> bool:
+        return (
+            view.state is State.HALF_OPEN
+            and view.probes_permitted > 0
+            and view.probes_completed >= view.probes_permitted
+        )
+
+    def _round_failed(self, view: SharedState) -> bool:
+        # Same threshold policy as StateMachine._evaluate_probes — Config is the
+        # single source; only the mechanism differs (shared counters, not local).
+        completed = view.probes_completed
+        return (
+            view.probe_failures / completed >= self._config.failure_rate_threshold
+            or view.probe_slows / completed >= self._config.slow_call_rate_threshold
+        )
+
+
+class SyncCoordinator(_CoordinatorBase):
+    """Coordinates a sync ``Storage``; the lane is a daemon thread."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        config: Config,
+        clock: Clock,
+        storage: Storage,
+        on_view: Callable[[SharedState], None],
+        on_degraded: Callable[[BaseException], None],
+        on_recovered: Callable[[], None],
+    ) -> None:
+        super().__init__(
+            name=name,
+            config=config,
+            clock=clock,
+            storage=storage,
+            on_view=on_view,
+            on_degraded=on_degraded,
+            on_recovered=on_recovered,
+        )
+        self._storage = storage
+        self._work: queue.Queue[_SyncOp] = queue.Queue()
+
+    def ensure_lane(self) -> None:
+        """Start the background lane once; safe to call on every admission."""
+        with self._lock:
+            if self._lane_started:
+                return
+            self._lane_started = True
+
+        thread = threading.Thread(
+            target=_sync_lane,
+            args=(weakref.ref(self), self._work, self._interval),
+            name=f'interlock-coordinator-{self._name}',
+            daemon=True,
+        )
+        thread.start()
+
+    def try_lease(self) -> bool | None:
+        """Claim one shared probe slot inline; ``None`` means storage degraded."""
+        if not self._gate_open():
+            return None
+
+        try:
+            lease = self._storage.lease_probe(name=self._name, ttl=self._ttl)
+        except Exception as error:
+            self._degrade(error)
+            return None
+
+        self._mark_available()
+        self._accept(lease.state)
+        return lease.granted
+
+    def notify_local_trip(self) -> None:
+        """Propagate a local threshold trip to the shared state (fire-and-forget)."""
+
+        def op() -> None:
+            self._accept(self._storage.trip_open(name=self._name, ttl=self._ttl))
+
+        self._enqueue(op)
+
+    def notify_probe_outcome(self, outcome: Outcome) -> None:
+        """Tally a probe outcome; decide close/reopen after the final probe."""
+
+        def op() -> None:
+            view = self._storage.record_probe(name=self._name, outcome=outcome, ttl=self._ttl)
+            self._accept(view)
+            if not self._round_finished(view):
+                return
+
+            if self._round_failed(view):
+                final = self._storage.trip_open(
+                    name=self._name, ttl=self._ttl, expected_version=view.version
+                )
+            else:
+                final = self._storage.close(
+                    name=self._name, ttl=self._ttl, expected_version=view.version
+                )
+            self._accept(final)
+
+        self._enqueue(op)
+
+    def poll_once(self) -> None:
+        """One poll tick: refresh the cached view, driving OPEN → HALF_OPEN.
+
+        While the shared state is OPEN the poll doubles as the transition
+        attempt — ``begin_half_open_if_elapsed`` is a server-side no-op until
+        the wait elapses and returns the current view either way.
+        """
+        if not self._gate_open():
+            return
+
+        with self._lock:
+            last_state = self._last_view.state if self._last_view is not None else None
+
+        try:
+            if last_state is State.OPEN:
+                view = self._storage.begin_half_open_if_elapsed(
+                    name=self._name,
+                    wait_duration=self._config.wait_duration_in_open,
+                    permitted=self._config.permitted_calls_in_half_open,
+                    ttl=self._ttl,
+                )
+            else:
+                view = self._storage.read(self._name) or SharedState.closed()
+        except Exception as error:
+            self._degrade(error)
+            return
+
+        self._mark_available()
+        self._accept(view)
+
+    def wait_idle(self) -> None:
+        """Block until every queued write has been processed (test helper)."""
+        self._work.join()
+
+    def _enqueue(self, op: _SyncOp) -> None:
+        self._work.put(op)
+        self.ensure_lane()
+
+    def execute_op(self, op: _SyncOp) -> None:
+        """Run one queued write under degradation protection (lane-internal)."""
+        if not self._gate_open():
+            return  # degraded: drop the write, run local until the backend is back
+
+        try:
+            op()
+        except Exception as error:
+            self._degrade(error)
+        else:
+            self._mark_available()
+
+
+def _sync_lane_tick(
+    ref: 'weakref.ref[SyncCoordinator]',
+    work: 'queue.Queue[_SyncOp]',
+    interval: float,
+) -> bool:
+    """One lane iteration: run a queued write, or poll on timeout.
+
+    Returns whether the lane should keep running. The lane holds only a weak
+    reference between iterations so an abandoned breaker can be collected and
+    its lane exits on the next tick.
+    """
+    try:
+        op = work.get(timeout=interval)
+    except queue.Empty:
+        op = None
+
+    coordinator = ref()
+    if coordinator is None:
+        return False
+
+    if op is None:
+        coordinator.poll_once()
+    else:
+        try:
+            coordinator.execute_op(op)
+        finally:
+            work.task_done()
+
+    return True
+
+
+def _sync_lane(
+    ref: 'weakref.ref[SyncCoordinator]',
+    work: 'queue.Queue[_SyncOp]',
+    interval: float,
+) -> None:
+    while _sync_lane_tick(ref, work, interval):
+        pass
+
+
+class AsyncCoordinator(_CoordinatorBase):
+    """Coordinates an ``AsyncStorage``; the lane is an asyncio task."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        config: Config,
+        clock: Clock,
+        storage: AsyncStorage,
+        on_view: Callable[[SharedState], None],
+        on_degraded: Callable[[BaseException], None],
+        on_recovered: Callable[[], None],
+    ) -> None:
+        super().__init__(
+            name=name,
+            config=config,
+            clock=clock,
+            storage=storage,
+            on_view=on_view,
+            on_degraded=on_degraded,
+            on_recovered=on_recovered,
+        )
+        self._storage = storage
+        self._work: asyncio.Queue[_AsyncOp] = asyncio.Queue()
+        self._lane_task: asyncio.Task[None] | None = None
+
+    def ensure_lane(self) -> None:
+        """Start the lane task once; must be called with a running event loop."""
+        with self._lock:
+            if self._lane_started:
+                return
+            self._lane_started = True
+
+        self._lane_task = asyncio.get_running_loop().create_task(
+            _async_lane(weakref.ref(self), self._work, self._interval),
+            name=f'interlock-coordinator-{self._name}',
+        )
+
+    async def try_lease(self) -> bool | None:
+        """Claim one shared probe slot inline; ``None`` means storage degraded."""
+        if not self._gate_open():
+            return None
+
+        try:
+            lease = await self._storage.lease_probe(name=self._name, ttl=self._ttl)
+        except Exception as error:
+            self._degrade(error)
+            return None
+
+        self._mark_available()
+        self._accept(lease.state)
+        return lease.granted
+
+    def notify_local_trip(self) -> None:
+        """Propagate a local threshold trip to the shared state (fire-and-forget)."""
+
+        async def op() -> None:
+            self._accept(await self._storage.trip_open(name=self._name, ttl=self._ttl))
+
+        self._enqueue(op)
+
+    def notify_probe_outcome(self, outcome: Outcome) -> None:
+        """Tally a probe outcome; decide close/reopen after the final probe."""
+
+        async def op() -> None:
+            view = await self._storage.record_probe(name=self._name, outcome=outcome, ttl=self._ttl)
+            self._accept(view)
+            if not self._round_finished(view):
+                return
+
+            if self._round_failed(view):
+                final = await self._storage.trip_open(
+                    name=self._name, ttl=self._ttl, expected_version=view.version
+                )
+            else:
+                final = await self._storage.close(
+                    name=self._name, ttl=self._ttl, expected_version=view.version
+                )
+            self._accept(final)
+
+        self._enqueue(op)
+
+    async def poll_once(self) -> None:
+        """One poll tick: refresh the cached view, driving OPEN → HALF_OPEN."""
+        if not self._gate_open():
+            return
+
+        with self._lock:
+            last_state = self._last_view.state if self._last_view is not None else None
+
+        try:
+            if last_state is State.OPEN:
+                view = await self._storage.begin_half_open_if_elapsed(
+                    name=self._name,
+                    wait_duration=self._config.wait_duration_in_open,
+                    permitted=self._config.permitted_calls_in_half_open,
+                    ttl=self._ttl,
+                )
+            else:
+                view = await self._storage.read(self._name) or SharedState.closed()
+        except Exception as error:
+            self._degrade(error)
+            return
+
+        self._mark_available()
+        self._accept(view)
+
+    async def wait_idle(self) -> None:
+        """Wait until every queued write has been processed (test helper)."""
+        await self._work.join()
+
+    def _enqueue(self, op: _AsyncOp) -> None:
+        self._work.put_nowait(op)
+        self.ensure_lane()
+
+    async def execute_op(self, op: _AsyncOp) -> None:
+        """Run one queued write under degradation protection (lane-internal)."""
+        if not self._gate_open():
+            return  # degraded: drop the write, run local until the backend is back
+
+        try:
+            await op()
+        except Exception as error:
+            self._degrade(error)
+        else:
+            self._mark_available()
+
+
+async def _async_lane_tick(
+    ref: 'weakref.ref[AsyncCoordinator]',
+    work: 'asyncio.Queue[_AsyncOp]',
+    interval: float,
+) -> bool:
+    """One lane iteration: run a queued write, or poll on timeout."""
+    try:
+        op = await asyncio.wait_for(work.get(), timeout=interval)
+    except TimeoutError:
+        op = None
+
+    coordinator = ref()
+    if coordinator is None:
+        return False
+
+    if op is None:
+        await coordinator.poll_once()
+    else:
+        try:
+            await coordinator.execute_op(op)
+        finally:
+            work.task_done()
+
+    return True
+
+
+async def _async_lane(
+    ref: 'weakref.ref[AsyncCoordinator]',
+    work: 'asyncio.Queue[_AsyncOp]',
+    interval: float,
+) -> None:
+    while await _async_lane_tick(ref, work, interval):
+        pass

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -14,16 +14,20 @@ never ``await``; it is correct for threads and for a single event loop alike.
 
 import threading
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from inspect import iscoroutinefunction
 from typing import cast
 
 from interlock._classify import DefaultFailureClassifier
+from interlock._coordination import AsyncCoordinator, SyncCoordinator
 from interlock._detect import is_async_callable
 from interlock._state_machine import StateMachine
 from interlock._typing import AsyncCallable, P, R, SyncCallable
 from interlock.config import Config
-from interlock.errors import CircuitOpenError
+from interlock.errors import CircuitOpenError, InterlockError
 from interlock.outcome import Outcome
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import AsyncStorage, Clock, EventListener, FailureClassifier, Storage
+from interlock.shared import SharedState
 from interlock.state import State
 from interlock.window import WindowSnapshot
 
@@ -35,6 +39,9 @@ _OUTCOME_BY_FLAGS = {
     (False, True): Outcome.SLOW_SUCCESS,
     (True, True): Outcome.SLOW_FAILURE,
 }
+
+# Shared states that override local admission (a shared CLOSED defers to local).
+_SHARED_AUTHORITATIVE = frozenset({State.OPEN, State.HALF_OPEN})
 
 
 class _NoopListener:
@@ -48,9 +55,26 @@ class _NoopListener:
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
     def on_rejected(self, *, name: str) -> None: ...
     def on_reset(self, *, name: str) -> None: ...
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
+    def on_storage_recovered(self, *, name: str) -> None: ...
 
 
 _NOOP_LISTENER: EventListener = _NoopListener()
+
+
+def _notify_safely(listener: EventListener, hook: str, **kwargs: object) -> None:
+    """Dispatch a storage hook via ``getattr`` so pre-1.2 listeners keep working."""
+    method = getattr(listener, hook, None)
+    if callable(method):
+        method(**kwargs)
+
+
+@dataclass(frozen=True, slots=True)
+class Admission:
+    """What ``_admit`` granted: the era it happened in, and probe provenance."""
+
+    generation: int
+    probe: bool = False
 
 
 class Engine:
@@ -63,6 +87,10 @@ class Engine:
         classifier: Decides which outcomes count as failures. Defaults to
             ``DefaultFailureClassifier`` (any raised exception is a failure).
         listener: Observability hooks. Defaults to a no-op listener.
+        storage: Optional shared backend for coordinated, distributed state.
+            ``None`` (the default) keeps the breaker purely local. A coordinated
+            breaker matches its storage's runtime: a sync ``Storage`` serves
+            only the sync API, an ``AsyncStorage`` only the async one.
     """
 
     def __init__(
@@ -73,6 +101,7 @@ class Engine:
         clock: Clock,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        storage: Storage | AsyncStorage | None = None,
     ) -> None:
         self._name = name
         self._config = config
@@ -84,11 +113,42 @@ class Engine:
         self._last_failure: BaseException | None = None
         self._timer: threading.Timer | None = None
         self._timer_lock = threading.Lock()
+        self._shared_view: SharedState | None = None
+        self._storage_degraded = False
+        self._sync_coordinator: SyncCoordinator | None = None
+        self._async_coordinator: AsyncCoordinator | None = None
+        if storage is not None:
+            if iscoroutinefunction(storage.read):
+                self._async_coordinator = AsyncCoordinator(
+                    name=name,
+                    config=config,
+                    clock=clock,
+                    storage=cast('AsyncStorage', storage),
+                    on_view=self._on_shared_view,
+                    on_degraded=self._on_storage_degraded,
+                    on_recovered=self._on_storage_recovered,
+                )
+            else:
+                self._sync_coordinator = SyncCoordinator(
+                    name=name,
+                    config=config,
+                    clock=clock,
+                    storage=cast('Storage', storage),
+                    on_view=self._on_shared_view,
+                    on_degraded=self._on_storage_degraded,
+                    on_recovered=self._on_storage_recovered,
+                )
 
     @property
     def state(self) -> State:
-        """The breaker's current lifecycle state."""
-        return self._machine.state
+        """The breaker's effective lifecycle state.
+
+        In coordinated mode a shared OPEN/HALF_OPEN overrides the local state
+        (it governs admission); otherwise — including while the storage is
+        degraded — the local state machine's state is reported.
+        """
+        with self._lock:
+            return self._effective_state_locked()
 
     def snapshot(self) -> WindowSnapshot:
         """An immutable view of the current window aggregates."""
@@ -118,16 +178,16 @@ class Engine:
         Raises:
             CircuitOpenError: If the breaker rejects the call.
         """
-        generation = self._admit()
+        admission = self._admit()
         start = self._clock.monotonic()
 
         try:
             result = fn(*args, **kwargs)
         except Exception as exc:
-            self._settle(result=None, exception=exc, start=start, generation=generation)
+            self._settle(result=None, exception=exc, start=start, admission=admission)
             raise
         else:
-            self._settle(result=result, exception=None, start=start, generation=generation)
+            self._settle(result=result, exception=None, start=start, admission=admission)
             return result
 
     async def call_async(self, fn: AsyncCallable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
@@ -135,48 +195,63 @@ class Engine:
 
         Raises:
             CircuitOpenError: If the breaker rejects the call.
+            InterlockError: If the breaker is coordinated through a sync storage.
         """
-        generation = self._admit()
+        admission = await self._admit_async()
         start = self._clock.monotonic()
 
         try:
             result = await fn(*args, **kwargs)
         except Exception as exc:
-            self._settle(result=None, exception=exc, start=start, generation=generation)
+            self._settle(result=None, exception=exc, start=start, admission=admission)
             raise
         else:
-            self._settle(result=result, exception=None, start=start, generation=generation)
+            self._settle(result=result, exception=None, start=start, admission=admission)
             return result
 
-    def enter_block(self) -> tuple[float, int]:
-        """Admit a guarded block; return its start time and admission generation.
+    def enter_block(self) -> tuple[float, Admission]:
+        """Admit a guarded block; return its start time and admission.
 
         Backs the context-manager surface, where there is no callable to run —
-        only a block whose exception and duration are observed. The generation
+        only a block whose exception and duration are observed. The admission
         is handed back to ``exit_block`` so a block that outlives a state
         transition is not recorded into the wrong era.
 
         Raises:
             CircuitOpenError: If the breaker rejects the block.
         """
-        generation = self._admit()
-        return self._clock.monotonic(), generation
+        admission = self._admit()
+        return self._clock.monotonic(), admission
 
-    def exit_block(self, *, start: float, generation: int, exception: BaseException | None) -> None:
+    async def enter_block_async(self) -> tuple[float, Admission]:
+        """Admit a guarded ``async with`` block; the async mirror of ``enter_block``.
+
+        Raises:
+            CircuitOpenError: If the breaker rejects the block.
+            InterlockError: If the breaker is coordinated through a sync storage.
+        """
+        admission = await self._admit_async()
+        return self._clock.monotonic(), admission
+
+    def exit_block(
+        self, *, start: float, admission: Admission, exception: BaseException | None
+    ) -> None:
         """Record a guarded block's outcome from its exception and duration."""
         if exception is not None and not isinstance(exception, Exception):
             return  # mirror call(): cancellation/shutdown are not downstream failures
-        self._settle(result=None, exception=exception, start=start, generation=generation)
+        self._settle(result=None, exception=exception, start=start, admission=admission)
 
     def reset(self) -> None:
         """Return to ``CLOSED`` with a fresh window, discarding past metrics."""
         with self._lock:
+            effective_before = self._effective_state_locked()
             before = self._machine.state
             self._machine.reset()
             after = self._machine.state
+            effective_after = self._effective_state_locked()
             self._last_failure = None
 
-        self._on_transition(before, after)
+        self._emit_transitions(before, after, effective_before, effective_after)
         self._listener.on_reset(name=self._name)
 
     def force_open(self) -> None:
@@ -193,23 +268,102 @@ class Engine:
 
     def _override(self, mutate: Callable[[], None]) -> None:
         with self._lock:
+            effective_before = self._effective_state_locked()
             before = self._machine.state
             mutate()
             after = self._machine.state
+            effective_after = self._effective_state_locked()
 
-        self._on_transition(before, after)
+        self._emit_transitions(before, after, effective_before, effective_after)
 
-    def _admit(self) -> int:
-        """Admit one call and return the generation it was admitted in."""
+    def _admit(self) -> Admission:
+        """Admit one synchronous call.
+
+        Raises:
+            CircuitOpenError: If the breaker rejects the call.
+            InterlockError: If the breaker is coordinated through an async storage.
+        """
+        if self._async_coordinator is not None:
+            msg = (
+                f'circuit {self._name!r} is coordinated through an async storage; '
+                f'only its async API may be used'
+            )
+            raise InterlockError(msg)
+
+        coordinator = self._sync_coordinator
+        if coordinator is not None:
+            coordinator.ensure_lane()
+            if self._shared_gate() is State.HALF_OPEN:
+                granted = coordinator.try_lease()
+                if granted is not None:
+                    return self._finish_lease(granted=granted)
+                # storage degraded mid-lease: fall through to local admission
+
+        return self._admit_local()
+
+    async def _admit_async(self) -> Admission:
+        """Admit one asynchronous call; the async mirror of ``_admit``."""
+        if self._sync_coordinator is not None:
+            msg = (
+                f'circuit {self._name!r} is coordinated through a sync storage; '
+                f'only its sync API may be used'
+            )
+            raise InterlockError(msg)
+
+        coordinator = self._async_coordinator
+        if coordinator is not None:
+            coordinator.ensure_lane()
+            if self._shared_gate() is State.HALF_OPEN:
+                granted = await coordinator.try_lease()
+                if granted is not None:
+                    return self._finish_lease(granted=granted)
+
+        return self._admit_local()
+
+    def _shared_gate(self) -> State | None:
+        """The shared state governing admission, or ``None`` when local rules.
+
+        Raises ``CircuitOpenError`` directly for a shared OPEN — no probe can be
+        admitted there, and local state must not overrule a coordinated trip.
+        """
         with self._lock:
+            view = self._shared_view
+            if view is None or self._storage_degraded:
+                return None
+            shared = view.state
+            last_failure = self._last_failure
+
+        if shared is State.OPEN:
+            self._listener.on_rejected(name=self._name)
+            raise CircuitOpenError(self._name, retry_after=None, last_failure=last_failure)
+
+        return shared if shared is State.HALF_OPEN else None
+
+    def _finish_lease(self, *, granted: bool) -> Admission:
+        """Turn a shared probe-lease outcome into an admission or a rejection."""
+        with self._lock:
+            generation = self._machine.generation
+            last_failure = self._last_failure
+
+        if not granted:
+            self._listener.on_rejected(name=self._name)
+            raise CircuitOpenError(self._name, retry_after=None, last_failure=last_failure)
+
+        return Admission(generation=generation, probe=True)
+
+    def _admit_local(self) -> Admission:
+        """Admit one call by local state alone (the only path when not coordinated)."""
+        with self._lock:
+            effective_before = self._effective_state_locked()
             before = self._machine.state
             admitted = self._machine.acquire()
             after = self._machine.state
+            effective_after = self._effective_state_locked()
             generation = self._machine.generation
             retry_after = None if admitted else self._machine.retry_after()
             last_failure = self._last_failure
 
-        self._on_transition(before, after)
+        self._emit_transitions(before, after, effective_before, effective_after)
         if not admitted:
             self._listener.on_rejected(name=self._name)
             raise CircuitOpenError(
@@ -218,10 +372,10 @@ class Engine:
                 last_failure=last_failure,
             )
 
-        return generation
+        return Admission(generation=generation)
 
     def _settle(
-        self, *, result: object, exception: Exception | None, start: float, generation: int
+        self, *, result: object, exception: Exception | None, start: float, admission: Admission
     ) -> None:
         duration = self._clock.monotonic() - start
         failure = self._classifier.is_failure(result=result, exception=exception)
@@ -229,24 +383,102 @@ class Engine:
         outcome = _OUTCOME_BY_FLAGS[failure, slow]
 
         with self._lock:
+            effective_before = self._effective_state_locked()
             before = self._machine.state
-            self._machine.record(outcome, generation=generation)
+            self._machine.record(outcome, generation=admission.generation)
             after = self._machine.state
+            effective_after = self._effective_state_locked()
             if failure and exception is not None:
                 self._last_failure = exception
 
         self._listener.on_call(name=self._name, outcome=outcome, duration=duration)
-        self._on_transition(before, after)
+        self._emit_transitions(before, after, effective_before, effective_after)
 
-    def _on_transition(self, before: State, after: State) -> None:
-        if after == before:
+        coordinator = self._sync_coordinator or self._async_coordinator
+        if coordinator is not None:
+            if admission.probe:
+                coordinator.notify_probe_outcome(outcome)
+            if before is State.CLOSED and after is State.OPEN:
+                coordinator.notify_local_trip()
+
+    def _effective_state_locked(self) -> State:
+        """The state that governs admission; caller must hold ``self._lock``."""
+        view = self._shared_view
+        if view is not None and not self._storage_degraded and view.state in _SHARED_AUTHORITATIVE:
+            return view.state
+        return self._machine.state
+
+    def _emit_transitions(
+        self,
+        machine_before: State,
+        machine_after: State,
+        effective_before: State,
+        effective_after: State,
+    ) -> None:
+        """Emit the observable transition and manage the auto-transition timer.
+
+        Events reflect the *effective* state (what callers experience); the
+        timer tracks the *local machine* (only it performs the lazy
+        OPEN → HALF_OPEN). In local mode the two are identical.
+        """
+        if effective_after != effective_before:
+            self._listener.on_state_change(
+                name=self._name, old=effective_before, new=effective_after
+            )
+
+        if machine_after == machine_before:
             return
-
-        self._listener.on_state_change(name=self._name, old=before, new=after)
-        if after is State.OPEN:
+        if machine_after is State.OPEN:
             self._schedule_auto_transition()
-        elif before is State.OPEN:
+        elif machine_before is State.OPEN:
             self._cancel_auto_transition()
+
+    def _on_shared_view(self, view: SharedState) -> None:
+        """Coordinator callback: adopt a fresh shared view (any thread).
+
+        A shared transition to CLOSED with a newer version means some
+        instance's probes passed globally — a locally open machine adopts the
+        recovery (fresh window) instead of waiting out its own OPEN.
+        """
+        with self._lock:
+            previous = self._shared_view
+            effective_before = self._effective_state_locked()
+            before = self._machine.state
+            self._shared_view = view
+            if (
+                view.state is State.CLOSED
+                and previous is not None
+                and previous.state in _SHARED_AUTHORITATIVE
+                and view.version > previous.version
+                and self._machine.state in _SHARED_AUTHORITATIVE
+            ):
+                self._machine.reset()
+            after = self._machine.state
+            effective_after = self._effective_state_locked()
+
+        self._emit_transitions(before, after, effective_before, effective_after)
+
+    def _on_storage_degraded(self, error: BaseException) -> None:
+        """Coordinator callback: storage failed; local state takes over."""
+        with self._lock:
+            effective_before = self._effective_state_locked()
+            machine_state = self._machine.state
+            self._storage_degraded = True
+            effective_after = self._effective_state_locked()
+
+        _notify_safely(self._listener, 'on_storage_degraded', name=self._name, error=error)
+        self._emit_transitions(machine_state, machine_state, effective_before, effective_after)
+
+    def _on_storage_recovered(self) -> None:
+        """Coordinator callback: storage is back; the shared view is authoritative."""
+        with self._lock:
+            effective_before = self._effective_state_locked()
+            machine_state = self._machine.state
+            self._storage_degraded = False
+            effective_after = self._effective_state_locked()
+
+        _notify_safely(self._listener, 'on_storage_recovered', name=self._name)
+        self._emit_transitions(machine_state, machine_state, effective_before, effective_after)
 
     def _schedule_auto_transition(self) -> None:
         """Arm a timer to fire the proactive OPEN → HALF_OPEN once the wait ends.
@@ -286,8 +518,10 @@ class Engine:
         and the event fires exactly once.
         """
         with self._lock:
+            effective_before = self._effective_state_locked()
             before = self._machine.state
             self._machine.attempt_auto_transition()
             after = self._machine.state
+            effective_after = self._effective_state_locked()
 
-        self._on_transition(before, after)
+        self._emit_transitions(before, after, effective_before, effective_after)

--- a/interlock/breaker.py
+++ b/interlock/breaker.py
@@ -22,10 +22,10 @@ from typing import Literal, Self, cast, overload
 
 from interlock._clock import SystemClock
 from interlock._detect import is_async_callable
-from interlock._engine import Engine
+from interlock._engine import Admission, Engine
 from interlock._typing import AsyncCallable, P, R, SyncCallable
 from interlock.config import Config
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import AsyncStorage, Clock, EventListener, FailureClassifier, Storage
 from interlock.state import State
 from interlock.window import WindowSnapshot
 
@@ -44,6 +44,11 @@ class CircuitBreaker:
             raised exception being a failure.
         listener: Observability hooks (state changes, calls, rejections,
             resets). Defaults to no observation.
+        storage: Optional shared backend (e.g. ``interlock.redis.RedisStorage``)
+            for coordinated state across instances. Defaults to purely local
+            state. A coordinated breaker matches its storage's runtime: a sync
+            ``Storage`` serves only the sync API, an ``AsyncStorage`` only the
+            async one; without a storage the breaker stays fully dual.
     """
 
     def __init__(
@@ -54,6 +59,7 @@ class CircuitBreaker:
         clock: Clock | None = None,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        storage: Storage | AsyncStorage | None = None,
     ) -> None:
         self._name = name
         self._engine = Engine(
@@ -62,8 +68,9 @@ class CircuitBreaker:
             clock=clock if clock is not None else SystemClock(),
             classifier=classifier,
             listener=listener,
+            storage=storage,
         )
-        self._blocks: list[tuple[float, int]] = []
+        self._blocks: list[tuple[float, Admission]] = []
 
     @property
     def name(self) -> str:
@@ -152,12 +159,12 @@ class CircuitBreaker:
         exc: BaseException | None,
         _traceback: TracebackType | None,
     ) -> Literal[False]:
-        start, generation = self._blocks.pop()
-        self._engine.exit_block(start=start, generation=generation, exception=exc)
+        start, admission = self._blocks.pop()
+        self._engine.exit_block(start=start, admission=admission, exception=exc)
         return False
 
     async def __aenter__(self) -> Self:
-        self._blocks.append(self._engine.enter_block())
+        self._blocks.append(await self._engine.enter_block_async())
         return self
 
     async def __aexit__(
@@ -166,6 +173,6 @@ class CircuitBreaker:
         exc: BaseException | None,
         _traceback: TracebackType | None,
     ) -> Literal[False]:
-        start, generation = self._blocks.pop()
-        self._engine.exit_block(start=start, generation=generation, exception=exc)
+        start, admission = self._blocks.pop()
+        self._engine.exit_block(start=start, admission=admission, exception=exc)
         return False

--- a/interlock/listeners.py
+++ b/interlock/listeners.py
@@ -36,3 +36,11 @@ class LoggingEventListener:
     def on_reset(self, *, name: str) -> None:
         """Log a manual reset at INFO."""
         self._log.info('circuit %r: reset', name)
+
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        """Log a storage degradation at WARNING."""
+        self._log.warning('circuit %r: shared storage degraded, running local: %s', name, error)
+
+    def on_storage_recovered(self, *, name: str) -> None:
+        """Log a storage recovery at INFO."""
+        self._log.info('circuit %r: shared storage recovered', name)

--- a/interlock/otel.py
+++ b/interlock/otel.py
@@ -46,6 +46,10 @@ class OTelEventListener:
             'interlock.reset',
             description='Manual breaker resets.',
         )
+        self._storage_events = meter.create_counter(
+            'interlock.storage.events',
+            description='Shared storage degradations and recoveries.',
+        )
 
     def on_state_change(self, *, name: str, old: State, new: State) -> None:
         """Count a state transition, labelled with the breaker and direction."""
@@ -62,3 +66,13 @@ class OTelEventListener:
     def on_reset(self, *, name: str) -> None:
         """Count a manual reset, labelled with the breaker."""
         self._resets.add(1, {'breaker': name})
+
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        """Count a storage degradation, labelled with the breaker and error type."""
+        self._storage_events.add(
+            1, {'breaker': name, 'event': 'degraded', 'error': type(error).__name__}
+        )
+
+    def on_storage_recovered(self, *, name: str) -> None:
+        """Count a storage recovery, labelled with the breaker."""
+        self._storage_events.add(1, {'breaker': name, 'event': 'recovered'})

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -188,3 +188,17 @@ class EventListener(Protocol):
     def on_reset(self, *, name: str) -> None:
         """Called when the breaker is manually reset."""
         ...
+
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        """Called when the shared storage backend becomes unavailable.
+
+        The breaker keeps working on local state; this event makes the
+        degradation observable instead of silent. The engine invokes the two
+        storage hooks via safe ``getattr``, so listeners written before they
+        existed keep working unchanged.
+        """
+        ...
+
+    def on_storage_recovered(self, *, name: str) -> None:
+        """Called when the shared storage backend becomes reachable again."""
+        ...

--- a/interlock/redis.py
+++ b/interlock/redis.py
@@ -194,17 +194,44 @@ def _shared_from_map(mapping: dict[Any, Any]) -> SharedState | None:
     return _shared_from_values([fields.get(name) for name in order])
 
 
+def _positive(name: str, value: float) -> float:
+    if value <= 0:
+        msg = f'{name} must be positive, got {value!r}'
+        raise ValueError(msg)
+    return value
+
+
 class RedisStorage:
     """Synchronous ``Storage`` backed by a ``redis.Redis`` client.
+
+    The three keyword floats are the coordination tuning knobs the engine reads
+    off the storage object: how long state keys live without a refresh
+    (``state_ttl``), how often the cached shared view is refreshed
+    (``poll_interval``), and how long the breaker runs purely locally after a
+    storage failure before retrying (``retry_backoff``).
 
     Args:
         client: A connected ``redis.Redis`` instance.
         key_prefix: Namespace prepended to every breaker name.
+        state_ttl: Key lifetime in seconds; refreshed on every write.
+        poll_interval: Seconds between background view refreshes.
+        retry_backoff: Seconds to stay degraded after a storage failure.
     """
 
-    def __init__(self, client: redis.Redis, *, key_prefix: str = _DEFAULT_PREFIX) -> None:
+    def __init__(
+        self,
+        client: redis.Redis,
+        *,
+        key_prefix: str = _DEFAULT_PREFIX,
+        state_ttl: float = 300.0,
+        poll_interval: float = 1.0,
+        retry_backoff: float = 5.0,
+    ) -> None:
         self._client = client
         self._prefix = key_prefix
+        self.state_ttl = _positive('state_ttl', state_ttl)
+        self.poll_interval = _positive('poll_interval', poll_interval)
+        self.retry_backoff = _positive('retry_backoff', retry_backoff)
 
     def _key(self, name: str) -> str:
         return f'{self._prefix}{name}'
@@ -265,14 +292,30 @@ class RedisStorage:
 class AsyncRedisStorage:
     """Asynchronous ``AsyncStorage`` backed by a ``redis.asyncio.Redis`` client.
 
+    See ``RedisStorage`` for the coordination tuning knobs.
+
     Args:
         client: A connected ``redis.asyncio.Redis`` instance.
         key_prefix: Namespace prepended to every breaker name.
+        state_ttl: Key lifetime in seconds; refreshed on every write.
+        poll_interval: Seconds between background view refreshes.
+        retry_backoff: Seconds to stay degraded after a storage failure.
     """
 
-    def __init__(self, client: redis.asyncio.Redis, *, key_prefix: str = _DEFAULT_PREFIX) -> None:
+    def __init__(
+        self,
+        client: redis.asyncio.Redis,
+        *,
+        key_prefix: str = _DEFAULT_PREFIX,
+        state_ttl: float = 300.0,
+        poll_interval: float = 1.0,
+        retry_backoff: float = 5.0,
+    ) -> None:
         self._client = client
         self._prefix = key_prefix
+        self.state_ttl = _positive('state_ttl', state_ttl)
+        self.poll_interval = _positive('poll_interval', poll_interval)
+        self.retry_backoff = _positive('retry_backoff', retry_backoff)
 
     def _key(self, name: str) -> str:
         return f'{self._prefix}{name}'

--- a/interlock/registry.py
+++ b/interlock/registry.py
@@ -10,7 +10,7 @@ import threading
 from interlock._clock import SystemClock
 from interlock.breaker import CircuitBreaker
 from interlock.config import Config
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import AsyncStorage, Clock, EventListener, FailureClassifier, Storage
 
 __all__ = ('Registry',)
 
@@ -26,6 +26,8 @@ class Registry:
             breaker's own default (any raised exception is a failure).
         listener: Observability hooks shared by every breaker. Defaults to
             no observation.
+        storage: Shared backend for coordinated state, handed to every breaker
+            (each coordinates under its own name). Defaults to local state.
     """
 
     def __init__(
@@ -35,11 +37,13 @@ class Registry:
         clock: Clock | None = None,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        storage: Storage | AsyncStorage | None = None,
     ) -> None:
         self._config = config if config is not None else Config()
         self._clock = clock if clock is not None else SystemClock()
         self._classifier = classifier
         self._listener = listener
+        self._storage = storage
         self._breakers: dict[str, CircuitBreaker] = {}
         self._lock = threading.Lock()
 
@@ -63,6 +67,7 @@ class Registry:
                     clock=self._clock,
                     classifier=self._classifier,
                     listener=self._listener,
+                    storage=self._storage,
                 )
                 self._breakers[name] = breaker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,16 @@ ban-relative-imports = "all"
 "scripts/**/*.py" = [
   "INP001",  # scripts is a run-directly directory, not an importable package
 ]
+"interlock/_coordination.py" = [
+  "BLE001",  # storage failures of any type must degrade, never reach the protected path
+  "PLR0913", # coordinators take keyword-only collaborators injected by the engine
+]
+"interlock/_engine.py" = [
+  "PLR0913", # the engine takes keyword-only collaborators (config/clock/classifier/...)
+]
+"interlock/breaker.py" = [
+  "PLR0913", # the public constructor mirrors the engine's keyword-only collaborators
+]
 "tests/**/*.py" = [
   "S101",    # asserts are the point of tests
   "PLR2004", # magic values are fine in tests
@@ -106,6 +116,7 @@ ban-relative-imports = "all"
   "INP001",  # tests is not an importable package
   "FBT001",  # boolean params come from @parametrize, not real flag args
   "ARG002",  # test doubles accept protocol args they intentionally ignore
+  "SLF001",  # coordination tests drive internal lanes/coordinators deterministically
 ]
 
 [tool.mypy]

--- a/tests/inmemory_storage.py
+++ b/tests/inmemory_storage.py
@@ -117,6 +117,10 @@ class InMemoryStorage:
 
     def __init__(self, *, clock: Clock) -> None:
         self._core = _Core(clock)
+        # Coordination tuning knobs, mirroring RedisStorage (tests override them).
+        self.state_ttl = 300.0
+        self.poll_interval = 1.0
+        self.retry_backoff = 5.0
 
     def read(self, name: str) -> SharedState | None:
         return self._core.read(name)
@@ -148,6 +152,10 @@ class AsyncInMemoryStorage:
 
     def __init__(self, *, clock: Clock) -> None:
         self._core = _Core(clock)
+        # Coordination tuning knobs, mirroring AsyncRedisStorage.
+        self.state_ttl = 300.0
+        self.poll_interval = 1.0
+        self.retry_backoff = 5.0
 
     async def read(self, name: str) -> SharedState | None:
         return self._core.read(name)

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1,0 +1,770 @@
+"""Coordinated (distributed) breaker behaviour over a shared ``Storage``.
+
+Deterministic: a shared ``FakeClock`` drives both the engines and the in-memory
+storage, background lanes are made inert with a huge ``poll_interval``, poll
+ticks run via ``poll_once()``, and fire-and-forget writes are awaited with
+``wait_idle()`` — no sleeps, no real Redis.
+"""
+
+import asyncio
+import gc
+import weakref
+
+import pytest
+
+from conftest import FakeClock, RecordingListener
+from inmemory_storage import AsyncInMemoryStorage, InMemoryStorage
+from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, Registry, State
+from interlock._coordination import (
+    AsyncCoordinator,
+    SyncCoordinator,
+    _async_lane_tick,
+    _sync_lane,
+    _sync_lane_tick,
+)
+from interlock.errors import InterlockError
+from interlock.shared import ProbeLease, SharedState
+
+NAME = 'svc'
+WAIT = 5.0
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config(
+        minimum_number_of_calls=2,
+        window_size=10,
+        failure_rate_threshold=0.5,
+        slow_call_duration_threshold=1.0,
+        permitted_calls_in_half_open=2,
+        max_concurrent_probes=2,
+        wait_duration_in_open=WAIT,
+    )
+
+
+@pytest.fixture
+def storage(fake_clock: FakeClock) -> InMemoryStorage:
+    store = InMemoryStorage(clock=fake_clock)
+    store.poll_interval = 3600.0  # keep the background lane inert; tests poll manually
+    return store
+
+
+class StorageEventsListener(RecordingListener):
+    """RecordingListener extended with the 1.2 storage hooks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.degraded: list[BaseException] = []
+        self.recovered: int = 0
+
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        self.degraded.append(error)
+
+    def on_storage_recovered(self, *, name: str) -> None:
+        self.recovered += 1
+
+
+class FlakyStorage:
+    """In-memory storage whose every operation can be made to raise."""
+
+    def __init__(self, inner: InMemoryStorage) -> None:
+        self._inner = inner
+        self.fail = False
+        self.state_ttl = inner.state_ttl
+        self.poll_interval = inner.poll_interval
+        self.retry_backoff = inner.retry_backoff
+
+    def _check(self) -> None:
+        if self.fail:
+            raise ConnectionError('storage down')
+
+    def read(self, name: str) -> SharedState | None:
+        self._check()
+        return self._inner.read(name)
+
+    def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        self._check()
+        return self._inner.trip_open(name=name, ttl=ttl, expected_version=expected_version)
+
+    def begin_half_open_if_elapsed(
+        self, *, name: str, wait_duration: float, permitted: int, ttl: float
+    ) -> SharedState:
+        self._check()
+        return self._inner.begin_half_open_if_elapsed(
+            name=name, wait_duration=wait_duration, permitted=permitted, ttl=ttl
+        )
+
+    def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
+        self._check()
+        return self._inner.lease_probe(name=name, ttl=ttl)
+
+    def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
+        self._check()
+        return self._inner.record_probe(name=name, outcome=outcome, ttl=ttl)
+
+    def close(self, *, name: str, ttl: float, expected_version: int | None = None) -> SharedState:
+        self._check()
+        return self._inner.close(name=name, ttl=ttl, expected_version=expected_version)
+
+
+def _breaker(
+    config: Config,
+    fake_clock: FakeClock,
+    storage: object,
+    listener: RecordingListener | None = None,
+) -> CircuitBreaker:
+    return CircuitBreaker(
+        name=NAME, config=config, clock=fake_clock, storage=storage, listener=listener
+    )
+
+
+def _coordinator(breaker: CircuitBreaker) -> SyncCoordinator:
+    coordinator = breaker._engine._sync_coordinator
+    assert coordinator is not None
+    return coordinator
+
+
+def _boom() -> None:
+    raise ValueError('boom')
+
+
+def _trip(breaker: CircuitBreaker) -> None:
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            breaker.call(_boom)
+
+
+# --- propagation and coordinated admission ---
+
+
+def test__local_trip__propagates_to_shared_storage(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+
+    _trip(breaker)
+    _coordinator(breaker).wait_idle()
+
+    shared = storage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN
+    assert breaker.state is State.OPEN
+
+
+def test__follower__adopts_shared_open__rejects_without_local_failures(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    tripper = _breaker(config, fake_clock, storage)
+    listener = RecordingListener()
+    follower = _breaker(config, fake_clock, storage, listener)
+    _trip(tripper)
+    _coordinator(tripper).wait_idle()
+
+    _coordinator(follower).poll_once()
+
+    assert follower.state is State.OPEN
+    assert listener.state_changes[-1] == (State.CLOSED, State.OPEN)
+    executed = []
+    with pytest.raises(CircuitOpenError):
+        follower.call(lambda: executed.append(1))
+    assert executed == []  # rejected before the callable ran
+
+
+def test__half_open__probe_budget_is_global(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    a = _breaker(config, fake_clock, storage)
+    b = _breaker(config, fake_clock, storage)
+    _trip(a)
+    _coordinator(a).wait_idle()
+    fake_clock.advance(WAIT)
+    _coordinator(a).poll_once()  # OPEN -> HALF_OPEN via server-side elapse
+    _coordinator(b).poll_once()
+
+    assert a.call(lambda: 'probe-a') == 'probe-a'  # lease 1 of 2
+    assert b.call(lambda: 'probe-b') == 'probe-b'  # lease 2 of 2
+    with pytest.raises(CircuitOpenError):
+        b.call(lambda: 'probe-c')  # budget exhausted across instances
+
+
+def test__successful_probe_round__closes_all_instances(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    a = _breaker(config, fake_clock, storage)
+    b = _breaker(config, fake_clock, storage)
+    _trip(a)
+    _coordinator(a).wait_idle()
+    _coordinator(b).poll_once()
+    assert (a.state, b.state) == (State.OPEN, State.OPEN)
+
+    fake_clock.advance(WAIT)
+    _coordinator(a).poll_once()
+    _coordinator(b).poll_once()
+    assert a.call(lambda: 'ok') == 'ok'
+    _coordinator(a).wait_idle()  # probe 1 of 2 tallied
+    assert b.call(lambda: 'ok') == 'ok'
+    _coordinator(b).wait_idle()  # final probe: decision -> close
+    _coordinator(a).poll_once()
+
+    assert a.state is State.CLOSED  # the tripper's local OPEN adopted the recovery
+    assert b.state is State.CLOSED
+    assert a.call(lambda: 'back') == 'back'
+    shared = storage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.CLOSED
+
+
+def test__failed_probe_round__reopens_globally(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    a = _breaker(config, fake_clock, storage)
+    _trip(a)
+    _coordinator(a).wait_idle()
+    fake_clock.advance(WAIT)
+    _coordinator(a).poll_once()
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            a.call(_boom)
+        _coordinator(a).wait_idle()
+
+    shared = storage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN
+    assert shared.probes_completed == 0  # fresh OPEN, probe accounting cleared
+    assert a.state is State.OPEN
+
+
+def test__registry__passes_storage_through(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    registry = Registry(config=config, clock=fake_clock, storage=storage)
+    breaker = registry.get(NAME)
+
+    _trip(breaker)
+    _coordinator(breaker).wait_idle()
+
+    shared = storage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN
+
+
+# --- T3.1/T3.2/T3.3: degradation, observability, recovery ---
+
+
+def test__storage_failure__degrades_to_local_state(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    tripper = _breaker(config, fake_clock, storage)
+    listener = StorageEventsListener()
+    follower = _breaker(config, fake_clock, flaky, listener)
+    _trip(tripper)
+    _coordinator(tripper).wait_idle()
+    _coordinator(follower).poll_once()
+    assert follower.state is State.OPEN  # shared OPEN adopted
+
+    flaky.fail = True
+    fake_clock.advance(flaky.retry_backoff)
+    _coordinator(follower).poll_once()
+
+    assert len(listener.degraded) == 1
+    assert isinstance(listener.degraded[0], ConnectionError)
+    assert follower.state is State.CLOSED  # local state governs while degraded
+    assert follower.call(lambda: 'local') == 'local'
+
+
+def test__degraded__repeat_failures__single_event(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    flaky.fail = True
+
+    _coordinator(breaker).poll_once()
+    fake_clock.advance(flaky.retry_backoff)
+    _coordinator(breaker).poll_once()  # retry due, fails again
+
+    assert len(listener.degraded) == 1
+    assert listener.recovered == 0
+
+
+def test__degraded__backoff_gates_storage_access(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    flaky.fail = True
+    _coordinator(breaker).poll_once()
+
+    flaky.fail = False
+    _coordinator(breaker).poll_once()  # backoff not elapsed: storage untouched
+
+    assert listener.recovered == 0  # would have recovered had the gate been open
+
+
+def test__degraded__writes_dropped_but_local_protection_works(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    breaker = _breaker(config, fake_clock, flaky)
+    flaky.fail = True
+    _coordinator(breaker).poll_once()  # enter degraded mode
+
+    _trip(breaker)  # local trip still protects this instance
+    _coordinator(breaker).wait_idle()
+
+    assert storage.read(NAME) is None  # the trip write was dropped, not raised
+    assert breaker.state is State.OPEN
+    with pytest.raises(CircuitOpenError):
+        breaker.call(lambda: 'nope')
+
+
+def test__recovery__emits_event_and_shared_becomes_authoritative(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    storage.trip_open(name=NAME, ttl=60.0)
+    flaky = FlakyStorage(storage)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    flaky.fail = True
+    _coordinator(breaker).poll_once()
+    assert len(listener.degraded) == 1
+
+    flaky.fail = False
+    fake_clock.advance(flaky.retry_backoff)
+    _coordinator(breaker).poll_once()
+
+    assert listener.recovered == 1
+    assert breaker.state is State.OPEN  # shared OPEN authoritative again (T3.3)
+    with pytest.raises(CircuitOpenError):
+        breaker.call(lambda: 'nope')
+
+
+def test__lease_failure__falls_back_to_local_admission(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    storage.trip_open(name=NAME, ttl=60.0)
+    fake_clock.advance(WAIT)
+    _coordinator(breaker).poll_once()  # first tick discovers the external OPEN
+    _coordinator(breaker).poll_once()  # second tick drives OPEN -> HALF_OPEN
+    assert breaker.state is State.HALF_OPEN
+
+    flaky.fail = True
+    assert breaker.call(lambda: 'local') == 'local'  # lease failed -> local CLOSED admits
+
+    assert len(listener.degraded) == 1
+
+
+def test__degradation__old_style_listener_does_not_break(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    listener = RecordingListener()  # pre-1.2 shape: no storage hooks
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    flaky.fail = True
+
+    _coordinator(breaker).poll_once()  # must not raise AttributeError
+
+    assert breaker.call(lambda: 'ok') == 'ok'
+
+
+# --- runtime matching (D8) ---
+
+
+def test__sync_storage__async_api__clear_error(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+
+    async def fn() -> None: ...
+
+    with pytest.raises(InterlockError, match='sync storage'):
+        asyncio.run(breaker.call(fn))  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test__sync_storage__async_block__clear_error(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+
+    with pytest.raises(InterlockError, match='sync storage'):
+        async with breaker:
+            pass
+
+
+def test__async_storage__sync_api__clear_error(config: Config, fake_clock: FakeClock) -> None:
+    astorage = AsyncInMemoryStorage(clock=fake_clock)
+    breaker = _breaker(config, fake_clock, astorage)
+
+    with pytest.raises(InterlockError, match='async storage'):
+        breaker.call(lambda: 'nope')
+    with pytest.raises(InterlockError, match='async storage'), breaker:
+        pass
+
+
+# --- async mirror ---
+
+
+def _async_coordinator(breaker: CircuitBreaker) -> AsyncCoordinator:
+    coordinator = breaker._engine._async_coordinator
+    assert coordinator is not None
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test__async__coordinated_trip_and_recovery(config: Config, fake_clock: FakeClock) -> None:
+    astorage = AsyncInMemoryStorage(clock=fake_clock)
+    astorage.poll_interval = 3600.0
+    breaker = _breaker(config, fake_clock, astorage)
+
+    async def boom() -> None:
+        raise ValueError('boom')
+
+    async def ok() -> str:
+        return 'ok'
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            await breaker.call(boom)
+    coordinator = _async_coordinator(breaker)
+    await coordinator.wait_idle()
+    shared = await astorage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN
+    assert breaker.state is State.OPEN
+
+    fake_clock.advance(WAIT)
+    await coordinator.poll_once()
+    assert breaker.state is State.HALF_OPEN
+
+    assert await breaker.call(ok) == 'ok'
+    await coordinator.wait_idle()
+    assert await breaker.call(ok) == 'ok'
+    await coordinator.wait_idle()  # final probe -> coordinated close
+
+    assert breaker.state is State.CLOSED
+    async with breaker:  # blocks admitted again
+        pass
+
+
+@pytest.mark.asyncio
+async def test__async__lease_rejection_when_budget_exhausted(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    astorage = AsyncInMemoryStorage(clock=fake_clock)
+    astorage.poll_interval = 3600.0
+    breaker = _breaker(config, fake_clock, astorage)
+    await astorage.trip_open(name=NAME, ttl=60.0)
+    fake_clock.advance(WAIT)
+    coordinator = _async_coordinator(breaker)
+    await coordinator.poll_once()  # discovers the external OPEN
+    await coordinator.poll_once()  # drives OPEN -> HALF_OPEN
+
+    assert await coordinator.try_lease() is True
+    assert await coordinator.try_lease() is True
+    with pytest.raises(CircuitOpenError):
+        async with breaker:
+            pass
+
+
+class AsyncFlakyStorage:
+    """Async in-memory storage whose reads can be made to raise."""
+
+    def __init__(self, inner: AsyncInMemoryStorage) -> None:
+        self._inner = inner
+        self.fail = False
+        self.state_ttl = inner.state_ttl
+        self.poll_interval = inner.poll_interval
+        self.retry_backoff = inner.retry_backoff
+
+    def _check(self) -> None:
+        if self.fail:
+            raise ConnectionError('storage down')
+
+    async def read(self, name: str) -> SharedState | None:
+        self._check()
+        return await self._inner.read(name)
+
+    async def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        self._check()
+        return await self._inner.trip_open(name=name, ttl=ttl, expected_version=expected_version)
+
+    async def begin_half_open_if_elapsed(
+        self, *, name: str, wait_duration: float, permitted: int, ttl: float
+    ) -> SharedState:
+        self._check()
+        return await self._inner.begin_half_open_if_elapsed(
+            name=name, wait_duration=wait_duration, permitted=permitted, ttl=ttl
+        )
+
+    async def lease_probe(self, *, name: str, ttl: float) -> ProbeLease:
+        self._check()
+        return await self._inner.lease_probe(name=name, ttl=ttl)
+
+    async def record_probe(self, *, name: str, outcome: Outcome, ttl: float) -> SharedState:
+        self._check()
+        return await self._inner.record_probe(name=name, outcome=outcome, ttl=ttl)
+
+    async def close(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        self._check()
+        return await self._inner.close(name=name, ttl=ttl, expected_version=expected_version)
+
+
+@pytest.mark.asyncio
+async def test__async__degradation_and_recovery(config: Config, fake_clock: FakeClock) -> None:
+    inner = AsyncInMemoryStorage(clock=fake_clock)
+    inner.poll_interval = 3600.0
+    await inner.trip_open(name=NAME, ttl=60.0)
+    flaky = AsyncFlakyStorage(inner)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    coordinator = _async_coordinator(breaker)
+
+    flaky.fail = True
+    await coordinator.poll_once()
+    assert len(listener.degraded) == 1
+    assert await coordinator.try_lease() is None  # degraded: no storage access
+    assert await breaker.call(_async_ok) == 'ok'  # local CLOSED admits
+
+    flaky.fail = False
+    fake_clock.advance(flaky.retry_backoff)
+    await coordinator.poll_once()
+    assert listener.recovered == 1
+    assert breaker.state is State.OPEN  # shared authoritative again
+
+
+async def _async_ok() -> str:
+    return 'ok'
+
+
+# --- background lane plumbing ---
+
+
+def test__sync_lane_tick__timeout_polls(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    storage.trip_open(name=NAME, ttl=60.0)
+    coordinator = _coordinator(breaker)
+
+    alive = _sync_lane_tick(weakref.ref(coordinator), coordinator._work, 0.001)
+
+    assert alive is True
+    assert breaker.state is State.OPEN  # the timeout tick polled and adopted the view
+
+
+def test__sync_lane_tick__runs_queued_op(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    coordinator = _coordinator(breaker)
+    ran = []
+    coordinator._work.put(lambda: ran.append(1))
+
+    alive = _sync_lane_tick(weakref.ref(coordinator), coordinator._work, 0.001)
+
+    assert alive is True
+    assert ran == [1]
+    coordinator.wait_idle()  # task_done was called: join must not hang
+
+
+def test__sync_lane_tick__dead_coordinator_stops_lane(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    coordinator = SyncCoordinator(
+        name=NAME,
+        config=config,
+        clock=fake_clock,
+        storage=storage,
+        on_view=lambda _view: None,
+        on_degraded=lambda _error: None,
+        on_recovered=lambda: None,
+    )
+    work = coordinator._work
+    ref = weakref.ref(coordinator)
+    del coordinator
+    gc.collect()
+
+    assert ref() is None
+    assert _sync_lane_tick(ref, work, 0.001) is False
+
+
+@pytest.mark.asyncio
+async def test__async_lane_tick__timeout_polls(config: Config, fake_clock: FakeClock) -> None:
+    astorage = AsyncInMemoryStorage(clock=fake_clock)
+    await astorage.trip_open(name=NAME, ttl=60.0)
+    breaker = _breaker(config, fake_clock, astorage)
+    coordinator = _async_coordinator(breaker)
+
+    alive = await _async_lane_tick(weakref.ref(coordinator), coordinator._work, 0.001)
+
+    assert alive is True
+    assert breaker.state is State.OPEN
+
+
+@pytest.mark.asyncio
+async def test__async_lane_tick__runs_queued_op_and_dead_ref_stops(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    astorage = AsyncInMemoryStorage(clock=fake_clock)
+    breaker = _breaker(config, fake_clock, astorage)
+    coordinator = _async_coordinator(breaker)
+    ran = []
+
+    async def op() -> None:
+        ran.append(1)
+
+    coordinator._work.put_nowait(op)
+    assert await _async_lane_tick(weakref.ref(coordinator), coordinator._work, 0.001) is True
+    assert ran == [1]
+    await coordinator.wait_idle()
+
+    work = coordinator._work
+    ref = weakref.ref(coordinator)
+    del coordinator
+    breaker._engine._async_coordinator = None
+    gc.collect()
+    assert await _async_lane_tick(ref, work, 0.001) is False
+
+
+def test__lane_thread__starts_once_and_processes_writes(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    storage.poll_interval = 3600.0
+    breaker = _breaker(config, fake_clock, storage)
+
+    _trip(breaker)  # admissions + settle start the real lane thread
+    _coordinator(breaker).wait_idle()
+
+    shared = storage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN
+
+
+def test__degraded__lease_gate_closed__falls_back_to_local(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    breaker = _breaker(config, fake_clock, flaky)
+    storage.trip_open(name=NAME, ttl=60.0)
+    fake_clock.advance(WAIT)
+    _coordinator(breaker).poll_once()
+    _coordinator(breaker).poll_once()  # HALF_OPEN now cached
+    flaky.fail = True
+    _coordinator(breaker).poll_once()  # degrade; backoff not yet elapsed
+
+    assert _coordinator(breaker).try_lease() is None  # gate closed: no storage access
+    assert breaker.call(lambda: 'local') == 'local'
+
+
+def test__lane_op_failure__degrades(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, storage, listener)
+    coordinator = _coordinator(breaker)
+
+    def bad_op() -> None:
+        raise ConnectionError('down mid-write')
+
+    coordinator.execute_op(bad_op)
+
+    assert len(listener.degraded) == 1
+    coordinator.execute_op(bad_op)  # gate closed: dropped without a second event
+    assert len(listener.degraded) == 1
+
+
+def test__sync_lane__exits_on_dead_coordinator(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    coordinator = SyncCoordinator(
+        name=NAME,
+        config=config,
+        clock=fake_clock,
+        storage=storage,
+        on_view=lambda _view: None,
+        on_degraded=lambda _error: None,
+        on_recovered=lambda: None,
+    )
+    work = coordinator._work
+    ref = weakref.ref(coordinator)
+    del coordinator
+    gc.collect()
+
+    _sync_lane(ref, work, 0.001)  # returns instead of looping forever
+
+
+@pytest.mark.asyncio
+async def test__async__lease_failure_degrades(config: Config, fake_clock: FakeClock) -> None:
+    inner = AsyncInMemoryStorage(clock=fake_clock)
+    flaky = AsyncFlakyStorage(inner)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    coordinator = _async_coordinator(breaker)
+    flaky.fail = True
+
+    assert await coordinator.try_lease() is None
+
+    assert len(listener.degraded) == 1
+    await coordinator.poll_once()  # gate closed: no storage access, no new event
+    assert len(listener.degraded) == 1
+
+
+@pytest.mark.asyncio
+async def test__async__failed_probe_round_reopens(config: Config, fake_clock: FakeClock) -> None:
+    astorage = AsyncInMemoryStorage(clock=fake_clock)
+    astorage.poll_interval = 3600.0
+    breaker = _breaker(config, fake_clock, astorage)
+
+    async def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            await breaker.call(boom)
+    coordinator = _async_coordinator(breaker)
+    await coordinator.wait_idle()
+    fake_clock.advance(WAIT)
+    await coordinator.poll_once()
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            await breaker.call(boom)
+        await coordinator.wait_idle()
+
+    shared = await astorage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN
+    assert shared.probes_completed == 0  # fresh OPEN after the failed round
+
+
+@pytest.mark.asyncio
+async def test__async__lane_op_failure_and_degraded_drop(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    inner = AsyncInMemoryStorage(clock=fake_clock)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, inner, listener)
+    coordinator = _async_coordinator(breaker)
+
+    async def bad_op() -> None:
+        raise ConnectionError('down mid-write')
+
+    await coordinator.execute_op(bad_op)
+
+    assert len(listener.degraded) == 1
+    await coordinator.execute_op(bad_op)  # gate closed: dropped, no second event
+    assert len(listener.degraded) == 1

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -220,12 +220,12 @@ async def test__call_async__open_circuit__rejects_without_executing(engine: Engi
 def test__stale_block__settling_in_half_open__not_counted_as_probe(
     engine: Engine, fake_clock: FakeClock
 ) -> None:
-    start, generation = engine.enter_block()  # admitted while CLOSED
+    start, admission = engine.enter_block()  # admitted while CLOSED
     _trip_to_open(engine)  # breaker trips while the block is still running
     fake_clock.advance(5.0)
     assert engine.call_sync(lambda: 'probe') == 'probe'  # -> HALF_OPEN, first probe succeeds
 
-    engine.exit_block(start=start, generation=generation, exception=None)
+    engine.exit_block(start=start, admission=admission, exception=None)
 
     # permitted_calls_in_half_open=2: had the stale block counted as the second
     # probe, the round would have finished and the breaker would have closed.

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -23,7 +23,7 @@ import pytest
 import redis.asyncio as aredis
 
 import redis as redis_mod
-from interlock import Outcome, State
+from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, State
 from interlock.redis import AsyncRedisStorage, RedisStorage
 
 REDIS_URL = os.environ.get('INTERLOCK_TEST_REDIS_URL')
@@ -360,3 +360,54 @@ async def test__async__full_cycle(prefix: str) -> None:
         assert reopen_fenced.state is State.CLOSED  # stale version: fenced out
     finally:
         await client.aclose()
+
+
+def test__constructor__rejects_non_positive_knobs(redis_client: redis_mod.Redis) -> None:
+    with pytest.raises(ValueError, match='state_ttl'):
+        RedisStorage(redis_client, state_ttl=0.0)
+    with pytest.raises(ValueError, match='poll_interval'):
+        RedisStorage(redis_client, poll_interval=-1.0)
+    with pytest.raises(ValueError, match='retry_backoff'):
+        RedisStorage(redis_client, retry_backoff=0.0)
+
+
+# --- e2e: coordinated breaker over RedisStorage ---
+
+
+def test__e2e__coordinated_breaker_trips_and_recovers_over_redis(
+    redis_client: redis_mod.Redis, prefix: str
+) -> None:
+    storage = RedisStorage(redis_client, key_prefix=prefix, poll_interval=3600.0)
+    config = Config(
+        minimum_number_of_calls=2,
+        window_size=10,
+        permitted_calls_in_half_open=1,
+        wait_duration_in_open=0.1,  # shared elapse runs on server TIME: real wait
+    )
+    tripper = CircuitBreaker(name='svc', config=config, storage=storage)
+    follower = CircuitBreaker(name='svc', config=config, storage=storage)
+
+    def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            tripper.call(boom)
+    tripper._engine._sync_coordinator.wait_idle()
+
+    follower._engine._sync_coordinator.poll_once()
+    assert follower.state is State.OPEN
+    with pytest.raises(CircuitOpenError):
+        follower.call(lambda: 'nope')
+
+    time.sleep(0.15)  # sanctioned: shared elapse is server-side TIME
+    follower._engine._sync_coordinator.poll_once()
+    follower._engine._sync_coordinator.poll_once()
+    assert follower.state is State.HALF_OPEN
+    assert follower.call(lambda: 'probe') == 'probe'  # the single permitted probe
+    follower._engine._sync_coordinator.wait_idle()  # final probe -> coordinated close
+
+    tripper._engine._sync_coordinator.poll_once()
+    assert tripper.state is State.CLOSED
+    assert follower.state is State.CLOSED
+    assert tripper.call(lambda: 'back') == 'back'


### PR DESCRIPTION
## Summary

Coordination (new interlock/_coordination.py):

* Engine/CircuitBreaker/Registry accept an optional storage; None keeps the
  breaker purely local with unchanged behaviour
* admission runs against a locally cached shared view — zero inline I/O in
  CLOSED and OPEN; the single inline network call is lease_probe in the short
  HALF_OPEN window, bounding probes globally across instances
* all writes (local trip, probe outcomes, the fenced close/reopen decision
  after the final probe) are fire-and-forget on a background lane — a daemon
  thread for sync storages, an asyncio task for async ones — which doubles as
  the poller that refreshes the view and drives OPEN -> HALF_OPEN on server
  time; the lane holds only a weakref so abandoned breakers can be collected
* a coordinated breaker matches its storage's runtime (sync Storage -> sync
  API, AsyncStorage -> async API); mixing styles raises a clear InterlockError
* the breaker reports its effective state: a shared OPEN/HALF_OPEN overrides
  the local machine, a shared CLOSED with a newer version resets a locally
  open machine (coordinated recovery)

Degradation:

* any storage failure degrades the breaker to local state: writes are
  dropped, storage access is gated by retry_backoff, and no storage error
  ever reaches the protected path; recovery makes the shared view
  authoritative again
* EventListener gains on_storage_degraded/on_storage_recovered (implemented
  by Logging/OTel listeners); the engine dispatches them via safe getattr so
  pre-existing listeners keep working
* RedisStorage/AsyncRedisStorage expose the tuning knobs (state_ttl,
  poll_interval, retry_backoff), validated positive
