### PR TITLE
docs: add Redis integration guide and prepare the 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-07
+
+### Added
+
+- **Distributed shared state** via the `redis` extra (`interlock.redis`):
+  `RedisStorage` (sync) and `AsyncRedisStorage` (async) coordinate breaker
+  state across processes and machines through one Redis hash per breaker.
+  Every transition runs as a Lua script (atomic across racing instances,
+  version-fenced against stale decisions), elapse checks use the Redis
+  server's `TIME`, and keys carry a TTL so abandoned state self-expires.
+  Works against Redis 5.0+, Valkey, or any RESP-compatible server.
+- `CircuitBreaker` and `Registry` accept an optional `storage`
+  (`Storage` / `AsyncStorage`). Without one, behaviour is unchanged and purely
+  local. With one, a shared OPEN gates admission on every instance, and
+  HALF_OPEN recovery probes are budgeted globally
+  (`permitted_calls_in_half_open` in total across the fleet) via an atomic
+  probe lease — the single inline storage operation on the protected path;
+  everything else is a locally cached view refreshed by a background poller
+  plus fire-and-forget writes. A coordinated breaker matches its storage's
+  runtime: a sync storage serves the sync API, an async storage the async one;
+  mixing styles raises `InterlockError`.
+- **Graceful degradation:** a storage failure never reaches the protected
+  path. The breaker falls back to its local state, leaves the backend alone
+  for `retry_backoff` seconds, and resynchronises (shared view authoritative
+  again) once the backend recovers.
+- `EventListener` gains `on_storage_degraded` / `on_storage_recovered`,
+  implemented by `LoggingEventListener` (WARNING/INFO) and `OTelEventListener`
+  (new `interlock.storage.events` counter). The engine dispatches the two new
+  hooks only if present, so existing listeners keep working unchanged.
+- Reworked `Storage` protocol (plus new `AsyncStorage`) as atomic *intent*
+  operations — `read`, `trip_open`, `begin_half_open_if_elapsed`,
+  `lease_probe`, `record_probe`, `close` — with new public DTOs `SharedState`
+  and `ProbeLease`. The previous `Storage` shape (`load`/`save`) was declared
+  but never consumed by the engine; this release gives it its first
+  functional form.
+
+### Fixed
+
+- Outcomes are now recorded into the state-machine era that admitted them:
+  a call admitted in CLOSED can no longer settle as a HALF_OPEN probe, and a
+  probe settling after a close or reset no longer pollutes the fresh window.
+- `reset()` clears the remembered last failure, so a `CircuitOpenError` raised
+  after a reset no longer reports a pre-reset exception.
+
 ## [1.1.0] - 2026-06-28
 
 ### Added
@@ -58,6 +102,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `InterlockDeprecationWarning` (subclasses `UserWarning`, visible by default).
 - `py.typed`; strict mypy and pyright; 100% test coverage.
 
-[Unreleased]: https://github.com/bagowix/interlock/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/bagowix/interlock/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/bagowix/interlock/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/bagowix/interlock/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/bagowix/interlock/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,6 @@ CI runs both.
 - **Update the docs and CHANGELOG.** User-facing changes update the relevant
   page under `docs/` and the `[Unreleased]` section of `CHANGELOG.md`.
 
-For coding conventions and architectural decisions, see
-[`AGENTS.md`](AGENTS.md) and [`planning/PLAN.md`](planning/PLAN.md).
-
 ## Proposing larger changes
 
 For anything beyond a small fix, open an issue first so we can agree on the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,8 @@ The core is pure standard library. External integrations are optional extras:
 ```bash
 uv add 'interlock-cb[otel]'    # OpenTelemetry metrics listener
 uv add 'interlock-cb[httpx2]'  # per-host httpx2 transport
+uv add 'interlock-cb[fastapi]' # CircuitOpenError -> 503 + Retry-After
+uv add 'interlock-cb[redis]'   # shared distributed state
 ```
 
 ## Create a breaker

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,11 +2,26 @@
 
 ## Install
 
-```bash
-uv add interlock-cb          # or: pip install interlock-cb
-```
+=== "uv"
 
-The core is pure standard library. External integrations are optional extras:
+    ```bash
+    uv add interlock-cb
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install interlock-cb
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add interlock-cb
+    ```
+
+The core is pure standard library. External integrations are optional extras —
+add the ones you need (same names with `pip install` / `poetry add`):
 
 ```bash
 uv add 'interlock-cb[otel]'    # OpenTelemetry metrics listener
@@ -29,8 +44,9 @@ breaker = CircuitBreaker(
 ```
 
 The defaults follow resilience4j: trip at a 50% failure rate over at least 10
-calls, stay open for 60s before allowing a single probe. See
-[Configuration](guides/configuration.md) for every option.
+calls, stay open for 60s, then admit up to 10 probe calls (one at a time) and
+decide from their outcomes. See [Configuration](guides/configuration.md) for
+every option.
 
 ## Three ways to protect work
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,6 +1,6 @@
 # Observability
 
-A breaker reports everything it does through an `EventListener`. The same four
+A breaker reports everything it does through an `EventListener`. The same
 hooks back logging, metrics, and any custom sink.
 
 ## The hooks
@@ -11,11 +11,17 @@ class EventListener(Protocol):
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
     def on_rejected(self, *, name: str) -> None: ...
     def on_reset(self, *, name: str) -> None: ...
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
+    def on_storage_recovered(self, *, name: str) -> None: ...
 ```
 
 Listeners are called **outside** the breaker's lock, after the protected call
 returns, so a slow listener never serialises throughput. Implementations must
 not raise back into the core.
+
+The two storage hooks fire only for breakers coordinated through a shared
+[storage](../integrations/redis.md), and the engine dispatches them only if
+present — a listener without them keeps working.
 
 Attach one per breaker, or share one across a `Registry`:
 
@@ -59,7 +65,7 @@ from interlock.otel import OTelEventListener
 breaker = CircuitBreaker(name='payments', listener=OTelEventListener())
 ```
 
-It records four instruments on the `interlock` meter (or a meter you pass in):
+It records five instruments on the `interlock` meter (or a meter you pass in):
 
 | Instrument | Type | Labels |
 |------------|------|--------|
@@ -67,12 +73,13 @@ It records four instruments on the `interlock` meter (or a meter you pass in):
 | `interlock.call.rejected` | counter | `breaker` |
 | `interlock.state.changes` | counter | `breaker`, `from`, `to` |
 | `interlock.reset` | counter | `breaker` |
+| `interlock.storage.events` | counter | `breaker`, `event` (`degraded`/`recovered`), `error` |
 
 ## Custom listeners
 
-Any object with the four methods satisfies the protocol — no base class to
-inherit. The core calls all four, so define each one, leaving the hooks you do
-not need as no-ops:
+Any object with the four core methods satisfies the protocol — no base class to
+inherit (the two storage hooks are dispatched only if present). The core calls
+all four, so define each one, leaving the hooks you do not need as no-ops:
 
 ```python
 class RejectionCounter:

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -8,8 +8,8 @@ A breaker has three core states plus three operator overrides.
 stateDiagram-v2
     CLOSED --> OPEN: failure/slow rate crosses threshold
     OPEN --> HALF_OPEN: first call after wait_duration_in_open (or timer, if auto_transition)
-    HALF_OPEN --> CLOSED: probes succeed
-    HALF_OPEN --> OPEN: a probe fails
+    HALF_OPEN --> CLOSED: probe round passes
+    HALF_OPEN --> OPEN: probe round fails
 ```
 
 - **`CLOSED`** — traffic flows; outcomes are recorded. When the failure rate (or
@@ -19,10 +19,12 @@ stateDiagram-v2
   `wait_duration_in_open` seconds, the **next** call lazily moves the breaker to
   `HALF_OPEN`. Enable [`auto_transition`](#proactive-transition-auto_transition)
   to have a timer make that move on its own.
-- **`HALF_OPEN`** — a limited number of probe calls are admitted, with a cap on
-  how many run concurrently, so a barely-recovered dependency is not hit by the
-  full parallel load at once. Probes succeeding closes the breaker; a probe
-  failing re-opens it.
+- **`HALF_OPEN`** — up to `permitted_calls_in_half_open` probe calls are
+  admitted, with a cap on how many run concurrently, so a barely-recovered
+  dependency is not hit by the full parallel load at once. Once the round
+  completes, the breaker decides from the probes' outcomes using the same
+  thresholds as `CLOSED`: rates below the thresholds close it, at or above
+  re-open it. Calls beyond the probe caps are rejected while the round runs.
 
 ## Proactive transition (`auto_transition`)
 
@@ -78,6 +80,15 @@ Shadow mode is the key to introducing a breaker without risk: it records the
 exact failure and slow-call rates real traffic produces, so you can tune
 thresholds against live data before letting the breaker reject anything. It
 costs almost nothing to leave on.
+
+## Coordinated state (optional)
+
+With a shared [storage](../integrations/redis.md), `OPEN` and `HALF_OPEN` can
+also be *adopted* from other instances: a trip anywhere in the fleet gates
+admission everywhere, and the HALF_OPEN probe budget is shared globally.
+`breaker.state` then reports the effective state — the shared one when it
+governs admission, the local one otherwise (including while the storage is
+unreachable).
 
 ## Observing transitions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,9 @@ integrations at the transport level.
   ships `py.typed` and passes mypy in strict mode.
 - **Zero-dependency core.** Standard library only; everything external lives in
   optional extras.
+- **Distributed state (optional).** Coordinate tripping and recovery probing
+  across instances through Redis/Valkey, with graceful degradation to local
+  state — see the [Redis integration](integrations/redis.md).
 
 ## Installation
 
@@ -25,6 +28,7 @@ uv add interlock-cb
 
 ## Status
 
-interlock ships v1.0-first: a polished core (state machine, windows,
-sync/async, slow-call detection) before breadth. Distributed state, retries,
-and a full resilience pipeline are planned for later releases.
+interlock shipped a polished core first (state machine, windows, sync/async,
+slow-call detection), then grew deliberately: v1.1 added timeouts, proactive
+`OPEN → HALF_OPEN` and FastAPI; v1.2 adds coordinated distributed state over
+Redis. Retries and a full resilience pipeline are planned for v2.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,44 @@ integrations at the transport level.
 
 ## Installation
 
-```bash
-uv add interlock-cb
+=== "uv"
+
+    ```bash
+    uv add interlock-cb
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install interlock-cb
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add interlock-cb
+    ```
+
+## At a glance
+
+```python
+from interlock import CircuitBreaker, CircuitOpenError
+
+breaker = CircuitBreaker(name='payments')
+
+@breaker
+def charge(amount: int) -> str:
+    return gateway.charge(amount)
+
+try:
+    charge(100)
+except CircuitOpenError as exc:
+    ...  # rejected fast: the dependency is unhealthy; retry after exc.retry_after
 ```
+
+The same instance protects async callables, works as a (sync and async) context
+manager, and can be called directly via `breaker.call(fn, ...)` — start with
+[Getting started](getting-started.md).
 
 ## Status
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -4,9 +4,23 @@ The `interlock-cb[fastapi]` extra protects a route's outgoing dependency with a
 shared `Registry` and turns a tripped breaker into a clean
 `503 Service Unavailable` response with a `Retry-After` header.
 
-```bash
-uv add 'interlock-cb[fastapi]'
-```
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[fastapi]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[fastapi]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[fastapi]'
+    ```
 
 ## Usage
 

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -4,9 +4,23 @@ The `interlock-cb[httpx2]` extra wraps an [httpx2](https://pypi.org/project/http
 transport so a circuit breaker is applied **per host** transparently — no
 decorators or `call` wrappers in your request code.
 
-```bash
-uv add 'interlock-cb[httpx2]'
-```
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[httpx2]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[httpx2]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[httpx2]'
+    ```
 
 ## Synchronous client
 

--- a/docs/integrations/redis.md
+++ b/docs/integrations/redis.md
@@ -4,9 +4,23 @@ The `interlock-cb[redis]` extra coordinates breaker state across processes and
 machines through Redis: when one instance trips, every instance backs off, and
 recovery probes are budgeted globally instead of per process.
 
-```bash
-uv add 'interlock-cb[redis]'
-```
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[redis]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[redis]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[redis]'
+    ```
 
 ## When to share state — and when not to
 

--- a/docs/integrations/redis.md
+++ b/docs/integrations/redis.md
@@ -1,0 +1,144 @@
+# Redis integration (shared state)
+
+The `interlock-cb[redis]` extra coordinates breaker state across processes and
+machines through Redis: when one instance trips, every instance backs off, and
+recovery probes are budgeted globally instead of per process.
+
+```bash
+uv add 'interlock-cb[redis]'
+```
+
+## When to share state — and when not to
+
+Per-instance state is the default for a reason. A local breaker reacts only to
+what *this* process observes, cannot be affected by another instance's problem,
+and keeps working when Redis does not.
+
+Reach for shared state when all of these hold:
+
+- Many instances call the **same downstream**, and its failure affects all of
+  them equally (a shared database, a rate-limited third-party API).
+- You want **coordinated back-off**: once the downstream is declared unhealthy,
+  no instance should keep hammering it just because its own window has not
+  filled yet.
+- You want **bounded recovery probing**: N instances should send at most
+  `permitted_calls_in_half_open` probes *in total*, not each.
+
+Stay local when instances see genuinely different views of the dependency
+(per-AZ endpoints, canary deployments), or when one instance's network problems
+must not silence the whole fleet. A shared OPEN gates traffic *everywhere* —
+that is the point, and the risk. It is a trade-off you opt into, not a default.
+
+## Usage
+
+Pass a storage to the breaker (or to a `Registry`, which hands it to every
+breaker it creates — each coordinates under its own name):
+
+```python
+import redis
+from interlock import CircuitBreaker, Registry
+from interlock.redis import RedisStorage
+
+storage = RedisStorage(redis.Redis(host='redis.internal'))
+breaker = CircuitBreaker(name='payments', storage=storage)
+
+registry = Registry(storage=storage)  # or share one storage across many breakers
+```
+
+Async services use the async client and storage:
+
+```python
+import redis.asyncio
+from interlock import CircuitBreaker
+from interlock.redis import AsyncRedisStorage
+
+storage = AsyncRedisStorage(redis.asyncio.Redis(host='redis.internal'))
+breaker = CircuitBreaker(name='payments', storage=storage)
+```
+
+A coordinated breaker matches its storage's runtime: a `RedisStorage` serves
+only the sync API (`with`, sync `call`), an `AsyncRedisStorage` only the async
+one (`async with`, async `call`); mixing the styles raises `InterlockError`
+with a clear message. A breaker *without* a storage stays fully dual.
+
+## How coordination works
+
+The local state machine keeps owning the sliding window and trip detection;
+Redis owns the shared OPEN/HALF_OPEN state and the global probe budget. All
+state for one breaker lives in a single hash (`interlock:cb:<name>` by
+default), and every transition runs as a Lua script, so racing instances stay
+consistent.
+
+The protected path stays fast:
+
+- **CLOSED / OPEN admission** reads a locally cached view of the shared state —
+  zero inline Redis calls. A background poller refreshes the cache every
+  `poll_interval` seconds, so a trip on one instance reaches the others within
+  roughly one interval.
+- **HALF_OPEN admission** is the single inline Redis operation: an atomic probe
+  lease that decrements the shared budget, bounding probes across the fleet.
+- **Writes** (propagating a local trip, tallying probe outcomes, the final
+  close-or-reopen decision) are fire-and-forget on a background worker; they
+  never block a protected call.
+
+Time comparisons ("has `wait_duration_in_open` elapsed?") use the *Redis
+server's* clock, since instance clocks are not comparable. After the last probe
+of a round, the deciding instance applies the same thresholds as the local
+state machine and writes the transition guarded by a version check, so a
+delayed decision can never overwrite a newer state.
+
+## Degradation: Redis down ≠ breaker down
+
+A storage error never reaches your calls. On the first failure the breaker
+switches to its local state and keeps protecting the process on its own window;
+pending shared writes are dropped, and Redis is left alone for `retry_backoff`
+seconds before the poller tries again. On the first successful operation the
+shared view becomes authoritative again — including adopting a shared OPEN that
+happened while this instance was cut off.
+
+Both edges are observable through the listener:
+
+```python
+class StorageWatch:
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        ...  # alert: running on local state
+
+    def on_storage_recovered(self, *, name: str) -> None:
+        ...  # back to coordinated state
+```
+
+`LoggingEventListener` logs degradation at `WARNING` and recovery at `INFO`;
+`OTelEventListener` counts both on `interlock.storage.events`. Listeners
+written before these hooks existed keep working — the engine calls them only if
+present.
+
+## Tuning
+
+All knobs live on the storage constructor; the core `Config` stays
+storage-agnostic:
+
+```python
+RedisStorage(
+    client,
+    key_prefix='interlock:cb:',  # hash key namespace
+    state_ttl=300.0,             # key lifetime (s); refreshed on every write
+    poll_interval=1.0,           # cache refresh cadence (s)
+    retry_backoff=5.0,           # local-only time after a storage failure (s)
+)
+```
+
+- **`state_ttl`** keeps abandoned state from lingering: if every instance
+  disappears, the key expires and the breaker starts CLOSED. Keep it well above
+  `wait_duration_in_open`.
+- **`poll_interval`** is the propagation latency of a coordinated trip. Each
+  breaker costs about one Redis read per interval.
+- **`retry_backoff`** bounds how often a degraded breaker re-tests Redis.
+
+## Compatibility
+
+`RedisStorage` speaks plain commands and `EVAL` — no server-specific features —
+so it works against Redis, [Valkey](https://valkey.io), or any RESP-compatible
+server. The scripts call `TIME` before writing, which requires effect-based
+script replication: **Redis 5.0 or newer**, or any Valkey release. (The
+`redis>=5.0.0` dependency pin is the *client* library's version, not the
+server's.)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -18,11 +18,26 @@ from the Markdown sources by ``scripts/build_llms_full.py`` — edit the pages i
 
 ## Install
 
-```bash
-uv add interlock-cb          # or: pip install interlock-cb
-```
+=== "uv"
 
-The core is pure standard library. External integrations are optional extras:
+    ```bash
+    uv add interlock-cb
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install interlock-cb
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add interlock-cb
+    ```
+
+The core is pure standard library. External integrations are optional extras —
+add the ones you need (same names with `pip install` / `poetry add`):
 
 ```bash
 uv add 'interlock-cb[otel]'    # OpenTelemetry metrics listener
@@ -45,8 +60,9 @@ breaker = CircuitBreaker(
 ```
 
 The defaults follow resilience4j: trip at a 50% failure rate over at least 10
-calls, stay open for 60s before allowing a single probe. See
-[Configuration](guides/configuration.md) for every option.
+calls, stay open for 60s, then admit up to 10 probe calls (one at a time) and
+decide from their outcomes. See [Configuration](guides/configuration.md) for
+every option.
 
 ## Three ways to protect work
 
@@ -225,8 +241,8 @@ A breaker has three core states plus three operator overrides.
 stateDiagram-v2
     CLOSED --> OPEN: failure/slow rate crosses threshold
     OPEN --> HALF_OPEN: first call after wait_duration_in_open (or timer, if auto_transition)
-    HALF_OPEN --> CLOSED: probes succeed
-    HALF_OPEN --> OPEN: a probe fails
+    HALF_OPEN --> CLOSED: probe round passes
+    HALF_OPEN --> OPEN: probe round fails
 ```
 
 - **`CLOSED`** — traffic flows; outcomes are recorded. When the failure rate (or
@@ -236,10 +252,12 @@ stateDiagram-v2
   `wait_duration_in_open` seconds, the **next** call lazily moves the breaker to
   `HALF_OPEN`. Enable [`auto_transition`](#proactive-transition-auto_transition)
   to have a timer make that move on its own.
-- **`HALF_OPEN`** — a limited number of probe calls are admitted, with a cap on
-  how many run concurrently, so a barely-recovered dependency is not hit by the
-  full parallel load at once. Probes succeeding closes the breaker; a probe
-  failing re-opens it.
+- **`HALF_OPEN`** — up to `permitted_calls_in_half_open` probe calls are
+  admitted, with a cap on how many run concurrently, so a barely-recovered
+  dependency is not hit by the full parallel load at once. Once the round
+  completes, the breaker decides from the probes' outcomes using the same
+  thresholds as `CLOSED`: rates below the thresholds close it, at or above
+  re-open it. Calls beyond the probe caps are rejected while the round runs.
 
 ## Proactive transition (`auto_transition`)
 
@@ -295,6 +313,15 @@ Shadow mode is the key to introducing a breaker without risk: it records the
 exact failure and slow-call rates real traffic produces, so you can tune
 thresholds against live data before letting the breaker reject anything. It
 costs almost nothing to leave on.
+
+## Coordinated state (optional)
+
+With a shared [storage](../integrations/redis.md), `OPEN` and `HALF_OPEN` can
+also be *adopted* from other instances: a trip anywhere in the fleet gates
+admission everywhere, and the HALF_OPEN probe budget is shared globally.
+`breaker.state` then reports the effective state — the shared one when it
+governs admission, the local one otherwise (including while the storage is
+unreachable).
 
 ## Observing transitions
 
@@ -557,9 +584,23 @@ The `interlock-cb[httpx2]` extra wraps an [httpx2](https://pypi.org/project/http
 transport so a circuit breaker is applied **per host** transparently — no
 decorators or `call` wrappers in your request code.
 
-```bash
-uv add 'interlock-cb[httpx2]'
-```
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[httpx2]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[httpx2]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[httpx2]'
+    ```
 
 ## Synchronous client
 
@@ -636,9 +677,23 @@ The `interlock-cb[fastapi]` extra protects a route's outgoing dependency with a
 shared `Registry` and turns a tripped breaker into a clean
 `503 Service Unavailable` response with a `Retry-After` header.
 
-```bash
-uv add 'interlock-cb[fastapi]'
-```
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[fastapi]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[fastapi]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[fastapi]'
+    ```
 
 ## Usage
 
@@ -740,9 +795,23 @@ The `interlock-cb[redis]` extra coordinates breaker state across processes and
 machines through Redis: when one instance trips, every instance backs off, and
 recovery probes are budgeted globally instead of per process.
 
-```bash
-uv add 'interlock-cb[redis]'
-```
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[redis]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[redis]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[redis]'
+    ```
 
 ## When to share state — and when not to
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -27,6 +27,8 @@ The core is pure standard library. External integrations are optional extras:
 ```bash
 uv add 'interlock-cb[otel]'    # OpenTelemetry metrics listener
 uv add 'interlock-cb[httpx2]'  # per-host httpx2 transport
+uv add 'interlock-cb[fastapi]' # CircuitOpenError -> 503 + Retry-After
+uv add 'interlock-cb[redis]'   # shared distributed state
 ```
 
 ## Create a breaker
@@ -373,7 +375,7 @@ which treats transport exceptions and the canonical retryable statuses
 
 # Observability
 
-A breaker reports everything it does through an `EventListener`. The same four
+A breaker reports everything it does through an `EventListener`. The same
 hooks back logging, metrics, and any custom sink.
 
 ## The hooks
@@ -384,11 +386,17 @@ class EventListener(Protocol):
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
     def on_rejected(self, *, name: str) -> None: ...
     def on_reset(self, *, name: str) -> None: ...
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
+    def on_storage_recovered(self, *, name: str) -> None: ...
 ```
 
 Listeners are called **outside** the breaker's lock, after the protected call
 returns, so a slow listener never serialises throughput. Implementations must
 not raise back into the core.
+
+The two storage hooks fire only for breakers coordinated through a shared
+[storage](../integrations/redis.md), and the engine dispatches them only if
+present — a listener without them keeps working.
 
 Attach one per breaker, or share one across a `Registry`:
 
@@ -432,7 +440,7 @@ from interlock.otel import OTelEventListener
 breaker = CircuitBreaker(name='payments', listener=OTelEventListener())
 ```
 
-It records four instruments on the `interlock` meter (or a meter you pass in):
+It records five instruments on the `interlock` meter (or a meter you pass in):
 
 | Instrument | Type | Labels |
 |------------|------|--------|
@@ -440,12 +448,13 @@ It records four instruments on the `interlock` meter (or a meter you pass in):
 | `interlock.call.rejected` | counter | `breaker` |
 | `interlock.state.changes` | counter | `breaker`, `from`, `to` |
 | `interlock.reset` | counter | `breaker` |
+| `interlock.storage.events` | counter | `breaker`, `event` (`degraded`/`recovered`), `error` |
 
 ## Custom listeners
 
-Any object with the four methods satisfies the protocol — no base class to
-inherit. The core calls all four, so define each one, leaving the hooks you do
-not need as no-ops:
+Any object with the four core methods satisfies the protocol — no base class to
+inherit (the two storage hooks are dispatched only if present). The core calls
+all four, so define each one, leaving the hooks you do not need as no-ops:
 
 ```python
 class RejectionCounter:
@@ -619,6 +628,259 @@ fail on `408 Request Timeout`.
 
 ---
 
+<!-- source: docs/integrations/fastapi.md -->
+
+# FastAPI integration
+
+The `interlock-cb[fastapi]` extra protects a route's outgoing dependency with a
+shared `Registry` and turns a tripped breaker into a clean
+`503 Service Unavailable` response with a `Retry-After` header.
+
+```bash
+uv add 'interlock-cb[fastapi]'
+```
+
+## Usage
+
+Install the exception handler once, then inject a per-name breaker into any route
+with `Depends`:
+
+```python
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from interlock import CircuitBreaker, Registry
+from interlock.fastapi import breaker_dependency, install_exception_handler
+
+app = FastAPI()
+registry = Registry()
+install_exception_handler(app)
+
+orders_db = breaker_dependency('orders-db', registry=registry)
+
+
+@app.get('/orders')
+async def orders(breaker: Annotated[CircuitBreaker, Depends(orders_db)]) -> list[dict]:
+    return await breaker.call(fetch_orders)
+```
+
+When `fetch_orders` fails often enough, the breaker opens. The next request is
+rejected with `CircuitOpenError` *before* `fetch_orders` runs, and the installed
+handler converts it into:
+
+```http
+HTTP/1.1 503 Service Unavailable
+Retry-After: 30
+Content-Type: application/json
+
+{"detail": "Circuit 'orders-db' is open"}
+```
+
+## How it works
+
+- **`breaker_dependency(name, *, registry)`** returns a FastAPI dependency that
+  yields the named breaker from the shared `Registry`. The breaker is created
+  lazily on first use and reused on every later request, so all requests to that
+  route share one breaker (and one view of the dependency's health).
+- **`install_exception_handler(app)`** registers a handler for
+  `CircuitOpenError`. It responds `503` and sets `Retry-After` to the breaker's
+  `retry_after` estimate, rounded up to whole seconds (per RFC 7231). The header
+  is omitted when there is no estimate (for example after `force_open()`).
+
+You protect the *outgoing* call (`breaker.call(...)`) rather than the route
+itself: only the dependency you wrap counts toward the breaker, and the breaker's
+own admission logic (probes, half-open) keeps working.
+
+## Sharing breakers across routes
+
+Reuse the same `name` (and the same `registry`) to share one breaker across
+several routes that all depend on the same downstream:
+
+```python
+orders_db = breaker_dependency('orders-db', registry=registry)
+
+
+@app.get('/orders')
+async def list_orders(breaker: Annotated[CircuitBreaker, Depends(orders_db)]) -> list[dict]:
+    return await breaker.call(fetch_orders)
+
+
+@app.get('/orders/{order_id}')
+async def get_order(
+    order_id: int, breaker: Annotated[CircuitBreaker, Depends(orders_db)]
+) -> dict:
+    return await breaker.call(fetch_order, order_id)
+```
+
+Pass `config`, `clock`, `classifier` or `listener` to the `Registry` to tune
+every breaker it creates, or override per name via `registry.get(name, config=...)`.
+
+## Custom responses
+
+For a different response shape, register your own handler instead of
+`install_exception_handler`:
+
+```python
+from fastapi import Request, Response
+from interlock import CircuitOpenError
+
+
+@app.exception_handler(CircuitOpenError)
+async def on_open(request: Request, exc: CircuitOpenError) -> Response:
+    ...
+```
+
+---
+
+<!-- source: docs/integrations/redis.md -->
+
+# Redis integration (shared state)
+
+The `interlock-cb[redis]` extra coordinates breaker state across processes and
+machines through Redis: when one instance trips, every instance backs off, and
+recovery probes are budgeted globally instead of per process.
+
+```bash
+uv add 'interlock-cb[redis]'
+```
+
+## When to share state — and when not to
+
+Per-instance state is the default for a reason. A local breaker reacts only to
+what *this* process observes, cannot be affected by another instance's problem,
+and keeps working when Redis does not.
+
+Reach for shared state when all of these hold:
+
+- Many instances call the **same downstream**, and its failure affects all of
+  them equally (a shared database, a rate-limited third-party API).
+- You want **coordinated back-off**: once the downstream is declared unhealthy,
+  no instance should keep hammering it just because its own window has not
+  filled yet.
+- You want **bounded recovery probing**: N instances should send at most
+  `permitted_calls_in_half_open` probes *in total*, not each.
+
+Stay local when instances see genuinely different views of the dependency
+(per-AZ endpoints, canary deployments), or when one instance's network problems
+must not silence the whole fleet. A shared OPEN gates traffic *everywhere* —
+that is the point, and the risk. It is a trade-off you opt into, not a default.
+
+## Usage
+
+Pass a storage to the breaker (or to a `Registry`, which hands it to every
+breaker it creates — each coordinates under its own name):
+
+```python
+import redis
+from interlock import CircuitBreaker, Registry
+from interlock.redis import RedisStorage
+
+storage = RedisStorage(redis.Redis(host='redis.internal'))
+breaker = CircuitBreaker(name='payments', storage=storage)
+
+registry = Registry(storage=storage)  # or share one storage across many breakers
+```
+
+Async services use the async client and storage:
+
+```python
+import redis.asyncio
+from interlock import CircuitBreaker
+from interlock.redis import AsyncRedisStorage
+
+storage = AsyncRedisStorage(redis.asyncio.Redis(host='redis.internal'))
+breaker = CircuitBreaker(name='payments', storage=storage)
+```
+
+A coordinated breaker matches its storage's runtime: a `RedisStorage` serves
+only the sync API (`with`, sync `call`), an `AsyncRedisStorage` only the async
+one (`async with`, async `call`); mixing the styles raises `InterlockError`
+with a clear message. A breaker *without* a storage stays fully dual.
+
+## How coordination works
+
+The local state machine keeps owning the sliding window and trip detection;
+Redis owns the shared OPEN/HALF_OPEN state and the global probe budget. All
+state for one breaker lives in a single hash (`interlock:cb:<name>` by
+default), and every transition runs as a Lua script, so racing instances stay
+consistent.
+
+The protected path stays fast:
+
+- **CLOSED / OPEN admission** reads a locally cached view of the shared state —
+  zero inline Redis calls. A background poller refreshes the cache every
+  `poll_interval` seconds, so a trip on one instance reaches the others within
+  roughly one interval.
+- **HALF_OPEN admission** is the single inline Redis operation: an atomic probe
+  lease that decrements the shared budget, bounding probes across the fleet.
+- **Writes** (propagating a local trip, tallying probe outcomes, the final
+  close-or-reopen decision) are fire-and-forget on a background worker; they
+  never block a protected call.
+
+Time comparisons ("has `wait_duration_in_open` elapsed?") use the *Redis
+server's* clock, since instance clocks are not comparable. After the last probe
+of a round, the deciding instance applies the same thresholds as the local
+state machine and writes the transition guarded by a version check, so a
+delayed decision can never overwrite a newer state.
+
+## Degradation: Redis down ≠ breaker down
+
+A storage error never reaches your calls. On the first failure the breaker
+switches to its local state and keeps protecting the process on its own window;
+pending shared writes are dropped, and Redis is left alone for `retry_backoff`
+seconds before the poller tries again. On the first successful operation the
+shared view becomes authoritative again — including adopting a shared OPEN that
+happened while this instance was cut off.
+
+Both edges are observable through the listener:
+
+```python
+class StorageWatch:
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        ...  # alert: running on local state
+
+    def on_storage_recovered(self, *, name: str) -> None:
+        ...  # back to coordinated state
+```
+
+`LoggingEventListener` logs degradation at `WARNING` and recovery at `INFO`;
+`OTelEventListener` counts both on `interlock.storage.events`. Listeners
+written before these hooks existed keep working — the engine calls them only if
+present.
+
+## Tuning
+
+All knobs live on the storage constructor; the core `Config` stays
+storage-agnostic:
+
+```python
+RedisStorage(
+    client,
+    key_prefix='interlock:cb:',  # hash key namespace
+    state_ttl=300.0,             # key lifetime (s); refreshed on every write
+    poll_interval=1.0,           # cache refresh cadence (s)
+    retry_backoff=5.0,           # local-only time after a storage failure (s)
+)
+```
+
+- **`state_ttl`** keeps abandoned state from lingering: if every instance
+  disappears, the key expires and the breaker starts CLOSED. Keep it well above
+  `wait_duration_in_open`.
+- **`poll_interval`** is the propagation latency of a coordinated trip. Each
+  breaker costs about one Redis read per interval.
+- **`retry_backoff`** bounds how often a degraded breaker re-tests Redis.
+
+## Compatibility
+
+`RedisStorage` speaks plain commands and `EVAL` — no server-specific features —
+so it works against Redis, [Valkey](https://valkey.io), or any RESP-compatible
+server. The scripts call `TIME` before writing, which requires effect-based
+script replication: **Redis 5.0 or newer**, or any Valkey release. (The
+`redis>=5.0.0` dependency pin is the *client* library's version, not the
+server's.)
+
+---
+
 <!-- source: docs/reference.md -->
 
 # API reference
@@ -630,7 +892,7 @@ dependency-free.
 ## `CircuitBreaker`
 
 ```python
-CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None)
+CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None, storage=None)
 ```
 
 A named breaker for sync and async callables.
@@ -640,6 +902,11 @@ A named breaker for sync and async callables.
 - **Properties:** `name: str`, `state: State`.
 - **`snapshot() -> WindowSnapshot`** — current window aggregates.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
+- **`storage`** — optional shared backend (`Storage` or `AsyncStorage`) for
+  coordinated state across instances; see the
+  [Redis integration](integrations/redis.md). A coordinated breaker matches its
+  storage's runtime (sync storage → sync API, async storage → async API);
+  without a storage the breaker stays fully dual.
 
 ## `Config`
 
@@ -650,12 +917,14 @@ See [Configuration](guides/configuration.md) for every field. Raises
 ## `Registry`
 
 ```python
-Registry(*, config=None, clock=None, classifier=None, listener=None)
+Registry(*, config=None, clock=None, classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
 ```
 
 Creates and caches named breakers. The same name always returns the same
-instance; the per-call `config` override applies only at creation.
+instance; the per-call `config` override applies only at creation. A `storage`
+is handed to every breaker the registry creates; each coordinates under its own
+name.
 
 ## Enums
 
@@ -701,11 +970,28 @@ Implement any of these to swap a core behaviour:
 
 - **`Clock`** — `monotonic() -> float`. Inject a fake for deterministic tests.
 - **`SlidingWindow`** — `record(outcome)`, `snapshot() -> WindowSnapshot`.
-- **`Storage`** — `load(name) -> State`, `save(*, name, state)`.
+- **`Storage`** / **`AsyncStorage`** — shared-state backend as atomic *intent*
+  operations: `read`, `trip_open`, `begin_half_open_if_elapsed`, `lease_probe`,
+  `record_probe`, `close`. `trip_open`/`close` take an optional
+  `expected_version` (version-fenced CAS); every write carries a `ttl`.
+  Mechanism only — threshold policy stays in the core. `AsyncStorage` is the
+  awaitable mirror. See the [Redis integration](integrations/redis.md).
 - **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`. See
   [Failure classification](guides/failure-classification.md).
-- **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`.
-  See [Observability](guides/observability.md).
+- **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`,
+  plus `on_storage_degraded` / `on_storage_recovered` for coordinated breakers
+  (dispatched only if present, so pre-1.2 listeners keep working). See
+  [Observability](guides/observability.md).
+
+## Shared-state types
+
+- **`SharedState`** — frozen snapshot of one breaker's coordinated state:
+  `state`, `opened_at` (backend time), `version` (for fencing), and the
+  HALF_OPEN probe accounting (`probes_permitted`, `probes_remaining`,
+  `probes_completed`, `probe_failures`, `probe_slows`).
+  `SharedState.closed()` is the baseline an absent key implies.
+- **`ProbeLease`** — result of `lease_probe`: `granted: bool` plus the
+  post-attempt `state: SharedState`.
 
 ## Listeners
 
@@ -735,3 +1021,18 @@ Extra `interlock-cb[fastapi]`, module `interlock.fastapi`:
   registration.
 
 See the [FastAPI integration](integrations/fastapi.md).
+
+## Redis adapters
+
+Extra `interlock-cb[redis]`, module `interlock.redis`:
+
+- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0)`** —
+  sync `Storage` over a `redis.Redis` client.
+- **`AsyncRedisStorage(client, *, ...)`** — async mirror over
+  `redis.asyncio.Redis`.
+
+One Redis hash per breaker; every transition is a Lua script (atomic across
+racing instances), elapse checks use the server's `TIME`. Works against Redis
+(5.0+), Valkey, or any RESP-compatible server.
+
+See the [Redis integration](integrations/redis.md).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,7 @@
 
 Key facts for answering questions about interlock:
 
-- Single public class `CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None)`.
+- Single public class `CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None, storage=None)`.
 - Three usage forms over one `call()` primitive: decorator `@breaker`, context
   manager (`with` and `async with`), and `breaker.call(fn, *args, **kwargs)`.
 - The context manager cannot do result-based classification (it sees only the
@@ -22,6 +22,11 @@ Key facts for answering questions about interlock:
 - Rejection raises `CircuitOpenError(breaker_name, retry_after, last_failure)`.
 - `timeout(seconds)` is an async context manager raising `CallTimeoutError`;
   `sync_timeout(seconds)` is the synchronous decorator equivalent (worker thread).
+- Optional distributed state: pass `storage=RedisStorage(...)` (sync) or
+  `AsyncRedisStorage(...)` (async) from `interlock.redis` — coordinated
+  tripping and a global recovery-probe budget across instances, with graceful
+  degradation to local state when Redis is unreachable. A coordinated breaker
+  matches its storage's runtime (sync storage → sync API only, async → async only).
 
 ## Docs
 
@@ -33,10 +38,11 @@ Key facts for answering questions about interlock:
 - [Timeout](guides/timeout.md): the async `timeout` and sync `sync_timeout` primitives.
 - [httpx2 integration](integrations/httpx2.md): per-host transport breaker.
 - [FastAPI integration](integrations/fastapi.md): Depends-injected breaker, 503 + Retry-After.
+- [Redis integration](integrations/redis.md): shared distributed state, coordinated tripping, degradation semantics.
 - [API reference](reference.md): the full public surface.
 
 ## Optional
 
 - [Full documentation](llms-full.txt): every page above inlined into one file.
-- Extras: `interlock-cb[otel]` (OpenTelemetry metrics), `interlock-cb[httpx2]` (transport), `interlock-cb[fastapi]` (FastAPI 503 mapping).
+- Extras: `interlock-cb[otel]` (OpenTelemetry metrics), `interlock-cb[httpx2]` (transport), `interlock-cb[fastapi]` (FastAPI 503 mapping), `interlock-cb[redis]` (shared distributed state).
 - Source and changelog: see the repository `CHANGELOG.md`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,7 +7,7 @@ dependency-free.
 ## `CircuitBreaker`
 
 ```python
-CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None)
+CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None, storage=None)
 ```
 
 A named breaker for sync and async callables.
@@ -17,6 +17,11 @@ A named breaker for sync and async callables.
 - **Properties:** `name: str`, `state: State`.
 - **`snapshot() -> WindowSnapshot`** — current window aggregates.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
+- **`storage`** — optional shared backend (`Storage` or `AsyncStorage`) for
+  coordinated state across instances; see the
+  [Redis integration](integrations/redis.md). A coordinated breaker matches its
+  storage's runtime (sync storage → sync API, async storage → async API);
+  without a storage the breaker stays fully dual.
 
 ## `Config`
 
@@ -27,12 +32,14 @@ See [Configuration](guides/configuration.md) for every field. Raises
 ## `Registry`
 
 ```python
-Registry(*, config=None, clock=None, classifier=None, listener=None)
+Registry(*, config=None, clock=None, classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
 ```
 
 Creates and caches named breakers. The same name always returns the same
-instance; the per-call `config` override applies only at creation.
+instance; the per-call `config` override applies only at creation. A `storage`
+is handed to every breaker the registry creates; each coordinates under its own
+name.
 
 ## Enums
 
@@ -78,11 +85,28 @@ Implement any of these to swap a core behaviour:
 
 - **`Clock`** — `monotonic() -> float`. Inject a fake for deterministic tests.
 - **`SlidingWindow`** — `record(outcome)`, `snapshot() -> WindowSnapshot`.
-- **`Storage`** — `load(name) -> State`, `save(*, name, state)`.
+- **`Storage`** / **`AsyncStorage`** — shared-state backend as atomic *intent*
+  operations: `read`, `trip_open`, `begin_half_open_if_elapsed`, `lease_probe`,
+  `record_probe`, `close`. `trip_open`/`close` take an optional
+  `expected_version` (version-fenced CAS); every write carries a `ttl`.
+  Mechanism only — threshold policy stays in the core. `AsyncStorage` is the
+  awaitable mirror. See the [Redis integration](integrations/redis.md).
 - **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`. See
   [Failure classification](guides/failure-classification.md).
-- **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`.
-  See [Observability](guides/observability.md).
+- **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`,
+  plus `on_storage_degraded` / `on_storage_recovered` for coordinated breakers
+  (dispatched only if present, so pre-1.2 listeners keep working). See
+  [Observability](guides/observability.md).
+
+## Shared-state types
+
+- **`SharedState`** — frozen snapshot of one breaker's coordinated state:
+  `state`, `opened_at` (backend time), `version` (for fencing), and the
+  HALF_OPEN probe accounting (`probes_permitted`, `probes_remaining`,
+  `probes_completed`, `probe_failures`, `probe_slows`).
+  `SharedState.closed()` is the baseline an absent key implies.
+- **`ProbeLease`** — result of `lease_probe`: `granted: bool` plus the
+  post-attempt `state: SharedState`.
 
 ## Listeners
 
@@ -112,3 +136,18 @@ Extra `interlock-cb[fastapi]`, module `interlock.fastapi`:
   registration.
 
 See the [FastAPI integration](integrations/fastapi.md).
+
+## Redis adapters
+
+Extra `interlock-cb[redis]`, module `interlock.redis`:
+
+- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0)`** —
+  sync `Storage` over a `redis.Redis` client.
+- **`AsyncRedisStorage(client, *, ...)`** — async mirror over
+  `redis.asyncio.Redis`.
+
+One Redis hash per breaker; every transition is a Lua script (atomic across
+racing instances), elapse checks use the server's `TIME`. Works against Redis
+(5.0+), Valkey, or any RESP-compatible server.
+
+See the [Redis integration](integrations/redis.md).

--- a/interlock/version.py
+++ b/interlock/version.py
@@ -7,7 +7,7 @@ and read at build time by hatchling (see ``[tool.hatch.version]`` in
 
 __all__ = ('VERSION',)
 
-VERSION = '1.1.0'
+VERSION = '1.2.0'
 """The installed version of interlock.
 
 Guaranteed to comply with PEP 440 version specifiers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ typeCheckingMode = "strict"
 plugins.MD013.enabled = false   # line-length limit disabled
 plugins.MD029.style = "ordered" # consistent ordered list numbering
 plugins.MD033.enabled = false   # allow inline HTML (useful for docs)
+plugins.MD046.enabled = false   # pymdownx.tabbed indents fenced blocks; the style check misfires
 plugins.MD041.enabled = false   # do not require an H1 at the top of every file
 
 [tool.pytest.ini_options]

--- a/scripts/build_llms_full.py
+++ b/scripts/build_llms_full.py
@@ -23,6 +23,8 @@ _PAGES = (
     'guides/observability.md',
     'guides/timeout.md',
     'integrations/httpx2.md',
+    'integrations/fastapi.md',
+    'integrations/redis.md',
     'reference.md',
 )
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -768,3 +768,40 @@ async def test__async__lane_op_failure_and_degraded_drop(
     assert len(listener.degraded) == 1
     await coordinator.execute_op(bad_op)  # gate closed: dropped, no second event
     assert len(listener.degraded) == 1
+
+
+def test__recovery__default_noop_listener__does_not_break(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    breaker = _breaker(config, fake_clock, flaky)  # no listener: default noop
+    flaky.fail = True
+    _coordinator(breaker).poll_once()  # degrade
+
+    flaky.fail = False
+    fake_clock.advance(flaky.retry_backoff)
+    _coordinator(breaker).poll_once()  # recover through the noop listener
+
+    assert breaker.call(lambda: 'ok') == 'ok'
+
+
+@pytest.mark.asyncio
+async def test__async__lease_failure_falls_back_to_local_admission(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    inner = AsyncInMemoryStorage(clock=fake_clock)
+    inner.poll_interval = 3600.0
+    await inner.trip_open(name=NAME, ttl=60.0)
+    flaky = AsyncFlakyStorage(inner)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    coordinator = _async_coordinator(breaker)
+    fake_clock.advance(WAIT)
+    await coordinator.poll_once()  # discovers the external OPEN
+    await coordinator.poll_once()  # drives OPEN -> HALF_OPEN
+    assert breaker.state is State.HALF_OPEN
+
+    flaky.fail = True
+    assert await breaker.call(_async_ok) == 'ok'  # lease failed -> local CLOSED admits
+
+    assert len(listener.degraded) == 1

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -49,3 +49,22 @@ def test__default_logger__uses_interlock_namespace(caplog: pytest.LogCaptureFixt
         listener.on_reset(name='svc')
 
     assert any(record.name == 'interlock' for record in caplog.records)
+
+
+def test__on_storage_degraded__logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    listener = LoggingEventListener(logging.getLogger('interlock.test'))
+
+    with caplog.at_level(logging.WARNING, logger='interlock.test'):
+        listener.on_storage_degraded(name='svc', error=ConnectionError('down'))
+
+    assert 'degraded' in caplog.text
+    assert 'down' in caplog.text
+
+
+def test__on_storage_recovered__logs_info(caplog: pytest.LogCaptureFixture) -> None:
+    listener = LoggingEventListener(logging.getLogger('interlock.test'))
+
+    with caplog.at_level(logging.INFO, logger='interlock.test'):
+        listener.on_storage_recovered(name='svc')
+
+    assert 'recovered' in caplog.text

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -62,3 +62,25 @@ def test__default_meter__constructs_and_is_usable() -> None:
     listener = OTelEventListener()
 
     listener.on_call(name='svc', outcome=Outcome.SUCCESS, duration=0.1)
+
+
+def test__on_storage_degraded__counts_event_with_error_label() -> None:
+    meter, instruments = _meter_with_named_instruments()
+    listener = OTelEventListener(meter=meter)
+
+    listener.on_storage_degraded(name='svc', error=ConnectionError('down'))
+
+    instruments['interlock.storage.events'].add.assert_called_once_with(
+        1, {'breaker': 'svc', 'event': 'degraded', 'error': 'ConnectionError'}
+    )
+
+
+def test__on_storage_recovered__counts_event() -> None:
+    meter, instruments = _meter_with_named_instruments()
+    listener = OTelEventListener(meter=meter)
+
+    listener.on_storage_recovered(name='svc')
+
+    instruments['interlock.storage.events'].add.assert_called_once_with(
+        1, {'breaker': 'svc', 'event': 'recovered'}
+    )

--- a/zensical.toml
+++ b/zensical.toml
@@ -10,7 +10,7 @@ nav = [
     { "Home" = "index.md" },
     { "Getting started" = "getting-started.md" },
     { "Guides" = ["guides/configuration.md", "guides/states.md", "guides/failure-classification.md", "guides/observability.md", "guides/timeout.md"] },
-    { "Integrations" = ["integrations/httpx2.md", "integrations/fastapi.md"] },
+    { "Integrations" = ["integrations/httpx2.md", "integrations/fastapi.md", "integrations/redis.md"] },
     { "API reference" = "reference.md" },
 ]
 


### PR DESCRIPTION
## Summary

* new docs/integrations/redis.md: when to share breaker state and when to
  stay local, sync/async usage, how coordination works (cached view, global
  probe budget, server-time elapse, version-fenced decisions), degradation
  semantics and observability, tuning knobs, Redis/Valkey compatibility
  (server >= 5.0)
* reference.md: storage parameter on CircuitBreaker/Registry, the current
  Storage/AsyncStorage contract (the page still described the old unused
  load/save shape), SharedState/ProbeLease, Redis adapters, the two new
  EventListener hooks
* observability guide: on_storage_degraded/on_storage_recovered and the
  interlock.storage.events counter
* llms.txt/nav/index/getting-started updated; llms-full.txt regenerated
* build_llms_full.py: sync the hardcoded page list with llms.txt — it was
  missing integrations/fastapi.md (never inlined) and now includes redis.md
* CHANGELOG [1.2.0] - 2026-07-07; version.py -> 1.2.0

