### PR TITLE
fix(breaker): make snapshots atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `CircuitBreaker.snapshot()` now reads the sliding window under the engine
+  lock, so concurrent call settlement cannot expose mixed counters from a
+  partially completed update. The count-based snapshot path remains O(1).
 - Local manual controls now take precedence over shared state for coordinated
   breakers. `force_open()` rejects locally, while `disable()` and
   `metrics_only()` admit locally without consuming a shared `HALF_OPEN` probe.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3095,7 +3095,8 @@ A named breaker for sync and async callables.
 - **Use as** a decorator (`@breaker`), a sync/async context manager
   (`with` / `async with`), or `breaker.call(fn, *args, **kwargs)`.
 - **Properties:** `name: str`, `state: State`.
-- **`snapshot() -> WindowSnapshot`** — current window aggregates.
+- **`snapshot() -> WindowSnapshot`** — current, self-consistent window aggregates;
+  concurrent call settlement cannot expose a partially updated window.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
 - **`storage`** — optional shared backend (`Storage` or `AsyncStorage`) for
   coordinated state across instances; see the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,7 +15,8 @@ A named breaker for sync and async callables.
 - **Use as** a decorator (`@breaker`), a sync/async context manager
   (`with` / `async with`), or `breaker.call(fn, *args, **kwargs)`.
 - **Properties:** `name: str`, `state: State`.
-- **`snapshot() -> WindowSnapshot`** — current window aggregates.
+- **`snapshot() -> WindowSnapshot`** — current, self-consistent window aggregates;
+  concurrent call settlement cannot expose a partially updated window.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
 - **`storage`** — optional shared backend (`Storage` or `AsyncStorage`) for
   coordinated state across instances; see the

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -1,10 +1,11 @@
 """The ``call()`` primitive: detect, dispatch, time, classify, record.
 
 This is the I/O-aware layer wrapping the I/O-free ``StateMachine``. It owns a
-single ``threading.Lock`` and holds it only around the two await-free critical
-sections — admitting a call (``acquire``) and recording its outcome
-(``record``). The protected callable runs *outside* the lock, so a slow
-downstream never serialises throughput and a re-entrant call cannot deadlock.
+single ``threading.Lock`` and holds it only around await-free state-machine
+access — admitting a call (``acquire``), recording its outcome (``record``),
+or reading its window (``snapshot``). The protected callable runs *outside*
+the lock, so a slow downstream never serialises throughput and a re-entrant
+call cannot deadlock.
 
 A single instance serves both sync and async callers: ``call`` detects the
 callable's nature via ``is_async_callable`` and dispatches to ``call_sync`` or
@@ -156,7 +157,8 @@ class Engine:
 
     def snapshot(self) -> WindowSnapshot:
         """An immutable view of the current window aggregates."""
-        return self._machine.snapshot()
+        with self._lock:
+            return self._machine.snapshot()
 
     def call(
         self,

--- a/interlock/_state_machine.py
+++ b/interlock/_state_machine.py
@@ -37,8 +37,8 @@ _PERMIT_ALL = frozenset({State.CLOSED, State.DISABLED, State.METRICS_ONLY})
 class StateMachine:
     """Owns breaker state and drives transitions from recorded outcomes.
 
-    Not thread-safe on its own: the call layer serialises ``acquire`` and
-    ``record`` under a single lock. Time is read only through the injected
+    Not thread-safe on its own: the call layer serialises ``acquire``, ``record``,
+    and ``snapshot`` under a single lock. Time is read only through the injected
     ``Clock``.
     """
 

--- a/tests/test_breaker.py
+++ b/tests/test_breaker.py
@@ -6,6 +6,47 @@ import pytest
 
 from conftest import FakeClock, RecordingListener
 from interlock import CircuitBreaker, CircuitOpenError, Config, State
+from interlock.outcome import Outcome
+from interlock.window import WindowSnapshot
+
+
+class _PausingWindow:
+    def __init__(self) -> None:
+        self.update_started = threading.Event()
+        self.allow_update = threading.Event()
+        self._total = 0
+        self._failed = 0
+        self._slow = 0
+
+    def record(self, outcome: Outcome) -> None:
+        self._total += 1
+        self.update_started.set()
+        if not self.allow_update.wait(5.0):
+            raise AssertionError('window update was not released')
+        self._failed += outcome.is_failure
+        self._slow += outcome.is_slow
+
+    def snapshot(self) -> WindowSnapshot:
+        return WindowSnapshot(
+            total_calls=self._total,
+            failed_calls=self._failed,
+            slow_calls=self._slow,
+        )
+
+
+class _ObservedLock:
+    def __init__(self) -> None:
+        self.contention_seen = threading.Event()
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> None:
+        if self._lock.acquire(blocking=False):
+            return
+        self.contention_seen.set()
+        self._lock.acquire()
+
+    def __exit__(self, *_args: object) -> None:
+        self._lock.release()
 
 
 @pytest.fixture
@@ -111,6 +152,41 @@ def test__context_manager__success__records_call(breaker: CircuitBreaker) -> Non
     snapshot = breaker.snapshot()
     assert snapshot.total_calls == 1
     assert snapshot.failed_calls == 0
+
+
+def test__snapshot__concurrent_settlement__waits_for_complete_window_update(
+    breaker: CircuitBreaker, fake_clock: FakeClock
+) -> None:
+    window = _PausingWindow()
+    lock = _ObservedLock()
+    breaker._engine._machine._window = window
+    breaker._engine._lock = lock
+
+    def slow_call() -> None:
+        fake_clock.advance(2.0)
+
+    call_thread = threading.Thread(target=breaker.call, args=(slow_call,))
+    call_thread.start()
+    assert window.update_started.wait(5.0)
+
+    snapshots: list[WindowSnapshot] = []
+
+    def take_snapshot() -> None:
+        snapshots.append(breaker.snapshot())
+
+    snapshot_thread = threading.Thread(target=take_snapshot)
+    snapshot_thread.start()
+    try:
+        assert lock.contention_seen.wait(5.0)
+        assert snapshots == []
+    finally:
+        window.allow_update.set()
+        call_thread.join(5.0)
+        snapshot_thread.join(5.0)
+
+    assert not call_thread.is_alive()
+    assert not snapshot_thread.is_alive()
+    assert snapshots == [WindowSnapshot(total_calls=1, failed_calls=0, slow_calls=1)]
 
 
 def test__context_manager__failure__records_and_propagates(breaker: CircuitBreaker) -> None:


### PR DESCRIPTION
## Summary

- Serialize `CircuitBreaker.snapshot()` with call settlement using the existing engine lock.
- Add a deterministic concurrency test proving snapshots cannot observe partially updated window counters.
- Keep window implementations lock-free and preserve O(1) count-based snapshots.
- Document the concurrency guarantee and update the changelog.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy` and `uv run pyright` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #80