### PR TITLE
fix: isolate EventListener failures from protected calls and lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- An `EventListener` that raises can no longer damage the breaker it observes.
+  Hooks were invoked directly at every call site, so a bug in a listener —
+  a metrics exporter, a logging handler, a custom sink — could replace a
+  successful protected result with an observability exception or mask the
+  dependency's own error. In coordinated (storage-backed) mode the damage was
+  worse and silent: a raising `on_state_change` propagated out of the
+  background lane's poll tick and terminated the lane for good, after which
+  the breaker never refreshed the shared view or flushed queued writes again;
+  and the same exception raised during a queued write was reported to the
+  application as a *storage* failure through `on_storage_degraded`. Every hook
+  now goes through one dispatcher: an `Exception` is logged to the `interlock`
+  logger at `ERROR` with its traceback and then ignored, while
+  `BaseException` — cancellation, shutdown — still propagates untouched. Hooks
+  are dispatched by name and only if defined, so a listener may implement just
+  the ones it needs. User-supplied *policy* callbacks keep their previous
+  behaviour and still raise: a `FailureClassifier`, a pipeline fallback
+  function, a tenacity `before_sleep` hook.
+
 ## [2.1.3] - 2026-07-31
 
 ### Fixed

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -19,13 +19,46 @@ class EventListener(Protocol):
 ```
 
 Listeners are called **outside** the breaker's lock, after the protected call
-returns, so a slow listener never serialises throughput. Implementations must
-not raise back into the core.
+returns, so a slow listener never serialises throughput.
 
 The two storage hooks fire only for breakers coordinated through a shared
 [storage](../integrations/redis.md); the three pipeline hooks fire from
-[pipeline strategies](pipeline.md) given a `listener=`. All optional hooks
-are dispatched only if present — a listener without them keeps working.
+[pipeline strategies](pipeline.md) given a `listener=`. Every hook is
+dispatched only if present — a listener that defines just the ones it cares
+about keeps working.
+
+## Listener failures are isolated
+
+Observability is optional; the protected call is not. A listener runs on the
+breaker's own paths, so a bug in one — a metrics exporter with a stale label,
+a logging handler with a full queue — would otherwise become a new failure
+source. interlock guarantees it cannot:
+
+- an `Exception` raised by a hook is logged to the `interlock` logger at
+  `ERROR` (with the traceback) and then ignored;
+- the protected call keeps its result, and a failing call keeps *its own*
+  exception — a listener never masks the dependency's error;
+- state transitions, probe accounting and the coordinated-mode background lane
+  continue unaffected;
+- a raising hook is never reported as storage degradation.
+
+`BaseException` is **not** caught: `KeyboardInterrupt` and
+`asyncio.CancelledError` propagate from a hook exactly as they do everywhere
+else in interlock.
+
+This covers `EventListener` hooks only. User-supplied *policy* callbacks are
+part of the call's behaviour rather than observations of it, and keep raising
+as before: a [`FailureClassifier`](failure-classification.md), a
+[fallback](pipeline.md) function, a tenacity `before_sleep` hook.
+
+To be notified when your own listener misbehaves, watch the `interlock`
+logger:
+
+```python
+import logging
+
+logging.getLogger('interlock').setLevel(logging.ERROR)
+```
 
 Attach one per breaker, or share one across a `Registry`:
 
@@ -81,9 +114,8 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 
 ## Custom listeners
 
-Any object with the four core methods satisfies the protocol — no base class to
-inherit (the two storage hooks are dispatched only if present). The core calls
-all four, so define each one, leaving the hooks you do not need as no-ops:
+Any object with the hooks you care about satisfies the protocol — no base class
+to inherit, and no need to stub out the rest:
 
 ```python
 class RejectionCounter:
@@ -92,8 +124,7 @@ class RejectionCounter:
 
     def on_rejected(self, *, name: str) -> None:
         self.rejected += 1
-
-    def on_state_change(self, *, name, old, new) -> None: ...
-    def on_call(self, *, name, outcome, duration) -> None: ...
-    def on_reset(self, *, name) -> None: ...
 ```
+
+Implement the full protocol when you want static checking to catch a typo in a
+hook name; a misspelled hook is simply never called, since dispatch is by name.

--- a/docs/guides/pipeline.md
+++ b/docs/guides/pipeline.md
@@ -190,10 +190,14 @@ pipeline = (
 )
 ```
 
-The hooks are dispatched via safe `getattr` — listeners written before v2.0
-keep working unchanged. `LoggingEventListener` logs retries at INFO and
-bulkhead rejections / fallbacks at WARNING; `OTelEventListener` counts all
-three in the `interlock.pipeline.events` counter.
+Strategy hooks go through the same dispatcher as the breaker's own: dispatched
+only if defined (listeners written before v2.0 keep working unchanged), and a
+hook that raises is logged and ignored rather than failing the call — see
+[listener failures are isolated](observability.md#listener-failures-are-isolated).
+A `fallback` function is *not* a hook: it shapes the result, so its errors
+propagate. `LoggingEventListener` logs retries at INFO and bulkhead rejections
+/ fallbacks at WARNING; `OTelEventListener` counts all three in the
+`interlock.pipeline.events` counter.
 
 ## Custom strategies
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1494,13 +1494,46 @@ class EventListener(Protocol):
 ```
 
 Listeners are called **outside** the breaker's lock, after the protected call
-returns, so a slow listener never serialises throughput. Implementations must
-not raise back into the core.
+returns, so a slow listener never serialises throughput.
 
 The two storage hooks fire only for breakers coordinated through a shared
 [storage](../integrations/redis.md); the three pipeline hooks fire from
-[pipeline strategies](pipeline.md) given a `listener=`. All optional hooks
-are dispatched only if present — a listener without them keeps working.
+[pipeline strategies](pipeline.md) given a `listener=`. Every hook is
+dispatched only if present — a listener that defines just the ones it cares
+about keeps working.
+
+## Listener failures are isolated
+
+Observability is optional; the protected call is not. A listener runs on the
+breaker's own paths, so a bug in one — a metrics exporter with a stale label,
+a logging handler with a full queue — would otherwise become a new failure
+source. interlock guarantees it cannot:
+
+- an `Exception` raised by a hook is logged to the `interlock` logger at
+  `ERROR` (with the traceback) and then ignored;
+- the protected call keeps its result, and a failing call keeps *its own*
+  exception — a listener never masks the dependency's error;
+- state transitions, probe accounting and the coordinated-mode background lane
+  continue unaffected;
+- a raising hook is never reported as storage degradation.
+
+`BaseException` is **not** caught: `KeyboardInterrupt` and
+`asyncio.CancelledError` propagate from a hook exactly as they do everywhere
+else in interlock.
+
+This covers `EventListener` hooks only. User-supplied *policy* callbacks are
+part of the call's behaviour rather than observations of it, and keep raising
+as before: a [`FailureClassifier`](failure-classification.md), a
+[fallback](pipeline.md) function, a tenacity `before_sleep` hook.
+
+To be notified when your own listener misbehaves, watch the `interlock`
+logger:
+
+```python
+import logging
+
+logging.getLogger('interlock').setLevel(logging.ERROR)
+```
 
 Attach one per breaker, or share one across a `Registry`:
 
@@ -1556,9 +1589,8 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 
 ## Custom listeners
 
-Any object with the four core methods satisfies the protocol — no base class to
-inherit (the two storage hooks are dispatched only if present). The core calls
-all four, so define each one, leaving the hooks you do not need as no-ops:
+Any object with the hooks you care about satisfies the protocol — no base class
+to inherit, and no need to stub out the rest:
 
 ```python
 class RejectionCounter:
@@ -1567,11 +1599,10 @@ class RejectionCounter:
 
     def on_rejected(self, *, name: str) -> None:
         self.rejected += 1
-
-    def on_state_change(self, *, name, old, new) -> None: ...
-    def on_call(self, *, name, outcome, duration) -> None: ...
-    def on_reset(self, *, name) -> None: ...
 ```
+
+Implement the full protocol when you want static checking to catch a typo in a
+hook name; a misspelled hook is simply never called, since dispatch is by name.
 
 ---
 
@@ -1990,10 +2021,14 @@ pipeline = (
 )
 ```
 
-The hooks are dispatched via safe `getattr` — listeners written before v2.0
-keep working unchanged. `LoggingEventListener` logs retries at INFO and
-bulkhead rejections / fallbacks at WARNING; `OTelEventListener` counts all
-three in the `interlock.pipeline.events` counter.
+Strategy hooks go through the same dispatcher as the breaker's own: dispatched
+only if defined (listeners written before v2.0 keep working unchanged), and a
+hook that raises is logged and ignored rather than failing the call — see
+[listener failures are isolated](observability.md#listener-failures-are-isolated).
+A `fallback` function is *not* a hook: it shapes the result, so its errors
+propagate. `LoggingEventListener` logs retries at INFO and bulkhead rejections
+/ fallbacks at WARNING; `OTelEventListener` counts all three in the
+`interlock.pipeline.events` counter.
 
 ## Custom strategies
 

--- a/interlock/_coordination.py
+++ b/interlock/_coordination.py
@@ -57,7 +57,10 @@ class _CoordinatorBase:
 
     Everything here is I/O-free; subclasses supply the storage calls and the
     background lane. ``on_view`` / ``on_degraded`` / ``on_recovered`` are engine
-    callbacks — they must be fast and must not raise.
+    callbacks — they must be fast and must not raise. They notify the user's
+    listener, which is why every hook goes through ``_notify.notify``: a raising
+    listener would otherwise kill the lane (``poll_once`` calls back outside its
+    ``try``) or be misreported as a storage failure (inside ``execute_op``).
     """
 
     def __init__(

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -22,6 +22,7 @@ from typing import cast
 from interlock._classify import DefaultFailureClassifier
 from interlock._coordination import AsyncCoordinator, SyncCoordinator
 from interlock._detect import is_async_callable
+from interlock._notify import notify
 from interlock._state_machine import StateMachine
 from interlock._typing import AsyncCallable, P, R, SyncCallable
 from interlock.config import Config
@@ -46,34 +47,6 @@ _SHARED_AUTHORITATIVE = frozenset({State.OPEN, State.HALF_OPEN})
 _MANUAL_STATES = frozenset({State.FORCED_OPEN, State.DISABLED, State.METRICS_ONLY})
 
 
-class _NoopListener:
-    """Null EventListener used when none is configured.
-
-    Lets the engine always call ``self._listener.<hook>(...)`` without a None
-    check; every hook is a no-op.
-    """
-
-    def on_state_change(self, *, name: str, old: State, new: State) -> None: ...
-    def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
-    def on_rejected(self, *, name: str) -> None: ...
-    def on_reset(self, *, name: str) -> None: ...
-    def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
-    def on_storage_recovered(self, *, name: str) -> None: ...
-    def on_retry(self, *, name: str, attempt: int, delay: float) -> None: ...
-    def on_bulkhead_rejected(self, *, name: str) -> None: ...
-    def on_fallback(self, *, name: str, error: BaseException) -> None: ...
-
-
-_NOOP_LISTENER: EventListener = _NoopListener()
-
-
-def _notify_safely(listener: EventListener, hook: str, **kwargs: object) -> None:
-    """Dispatch a storage hook via ``getattr`` so pre-1.2 listeners keep working."""
-    method = getattr(listener, hook, None)
-    if callable(method):
-        method(**kwargs)
-
-
 @dataclass(frozen=True, slots=True)
 class Admission:
     """What ``_admit`` granted: the era it happened in, and probe provenance."""
@@ -91,7 +64,8 @@ class Engine:
         clock: Time source; injected for deterministic tests.
         classifier: Decides which outcomes count as failures. Defaults to
             ``DefaultFailureClassifier`` (any raised exception is a failure).
-        listener: Observability hooks. Defaults to a no-op listener.
+        listener: Observability hooks, dispatched through ``notify`` — a hook
+            that raises is logged and ignored. Defaults to none at all.
         storage: Optional shared backend for coordinated, distributed state.
             ``None`` (the default) keeps the breaker purely local. A coordinated
             breaker matches its storage's runtime: a sync ``Storage`` serves
@@ -112,7 +86,7 @@ class Engine:
         self._config = config
         self._clock = clock
         self._classifier = classifier if classifier is not None else DefaultFailureClassifier()
-        self._listener = listener if listener is not None else _NOOP_LISTENER
+        self._listener = listener
         self._machine = StateMachine(config=config, clock=clock)
         self._lock = threading.Lock()
         self._last_failure: BaseException | None = None
@@ -267,7 +241,7 @@ class Engine:
             self._last_failure = None
 
         self._emit_transitions(before, after, effective_before, effective_after)
-        self._listener.on_reset(name=self._name)
+        notify(self._listener, 'on_reset', name=self._name)
 
     def force_open(self) -> None:
         """Override to ``FORCED_OPEN``: reject all traffic until reset."""
@@ -351,7 +325,8 @@ class Engine:
             last_failure = self._last_failure
 
         if shared is State.OPEN:
-            self._listener.on_rejected(name=self._name)
+            if self._listener is not None:
+                notify(self._listener, 'on_rejected', name=self._name)
             raise CircuitOpenError(self._name, retry_after=None, last_failure=last_failure)
 
         return shared if shared is State.HALF_OPEN else None
@@ -363,7 +338,8 @@ class Engine:
             last_failure = self._last_failure
 
         if not granted:
-            self._listener.on_rejected(name=self._name)
+            if self._listener is not None:
+                notify(self._listener, 'on_rejected', name=self._name)
             raise CircuitOpenError(self._name, retry_after=None, last_failure=last_failure)
 
         return Admission(generation=generation, probe=True)
@@ -382,7 +358,8 @@ class Engine:
 
         self._emit_transitions(before, after, effective_before, effective_after)
         if not admitted:
-            self._listener.on_rejected(name=self._name)
+            if self._listener is not None:
+                notify(self._listener, 'on_rejected', name=self._name)
             raise CircuitOpenError(
                 self._name,
                 retry_after=retry_after,
@@ -423,7 +400,11 @@ class Engine:
             if failure and exception is not None:
                 self._last_failure = exception
 
-        self._listener.on_call(name=self._name, outcome=outcome, duration=duration)
+        # Pre-checked here and on the rejection paths — the two that run per
+        # call. Passing through ``notify`` would pack a kwargs dict on every
+        # protected call before it could discover there is no listener.
+        if self._listener is not None:
+            notify(self._listener, 'on_call', name=self._name, outcome=outcome, duration=duration)
         self._emit_transitions(before, after, effective_before, effective_after)
 
         coordinator = self._sync_coordinator or self._async_coordinator
@@ -457,8 +438,12 @@ class Engine:
         OPEN → HALF_OPEN). In local mode the two are identical.
         """
         if effective_after != effective_before:
-            self._listener.on_state_change(
-                name=self._name, old=effective_before, new=effective_after
+            notify(
+                self._listener,
+                'on_state_change',
+                name=self._name,
+                old=effective_before,
+                new=effective_after,
             )
 
         if machine_after == machine_before:
@@ -501,7 +486,7 @@ class Engine:
             self._storage_degraded = True
             effective_after = self._effective_state_locked()
 
-        _notify_safely(self._listener, 'on_storage_degraded', name=self._name, error=error)
+        notify(self._listener, 'on_storage_degraded', name=self._name, error=error)
         self._emit_transitions(machine_state, machine_state, effective_before, effective_after)
 
     def _on_storage_recovered(self) -> None:
@@ -512,7 +497,7 @@ class Engine:
             self._storage_degraded = False
             effective_after = self._effective_state_locked()
 
-        _notify_safely(self._listener, 'on_storage_recovered', name=self._name)
+        notify(self._listener, 'on_storage_recovered', name=self._name)
         self._emit_transitions(machine_state, machine_state, effective_before, effective_after)
 
     def _schedule_auto_transition(self) -> None:

--- a/interlock/_notify.py
+++ b/interlock/_notify.py
@@ -1,0 +1,56 @@
+"""The single safe dispatcher for every ``EventListener`` hook.
+
+Observability is optional; the protected call is not. A listener is
+user-supplied code running on the breaker's own paths — the protected call, the
+transition bookkeeping, the coordinator lane — so a bug in it would otherwise
+replace a successful result with a metrics exception, mask the dependency's
+error, or kill the background lane of a coordinated breaker. Every hook
+therefore goes through ``notify``, which is the only place a listener is ever
+invoked.
+
+The policy (documented in ``docs/guides/observability.md``):
+
+- ordinary ``Exception`` from a hook is logged with context and swallowed;
+- ``BaseException`` (``KeyboardInterrupt``, ``asyncio.CancelledError``) is not
+  caught — cancellation and shutdown keep propagating, as everywhere else;
+- a hook the listener does not define is skipped, so listeners written before a
+  hook existed keep working unchanged.
+
+This applies to ``EventListener`` hooks only. User-supplied *policy* callbacks —
+a ``FailureClassifier``, a fallback function, a tenacity ``before_sleep`` — are
+part of the call's behaviour, not observations of it, and keep raising.
+"""
+
+import logging
+from typing import Final
+
+from interlock.protocols import EventListener
+
+__all__ = ('notify',)
+
+_logger: Final = logging.getLogger('interlock')
+
+
+def notify(listener: EventListener | None, hook: str, /, *, name: str, **kwargs: object) -> None:
+    """Invoke one listener hook, isolating its failure from the caller.
+
+    Args:
+        listener: The configured listener, or ``None`` when there is none.
+        hook: Name of the hook to invoke, e.g. ``'on_state_change'``.
+        name: Breaker or strategy name; passed to the hook and used as log
+            context.
+        kwargs: The hook's remaining keyword arguments.
+    """
+    if listener is None:
+        return
+
+    method = getattr(listener, hook, None)
+    if not callable(method):
+        return
+
+    try:
+        method(name=name, **kwargs)
+    # The one deliberate exception to "no silent exceptions": a blind catch is
+    # the whole point here. It is not silent — the traceback is logged.
+    except Exception:
+        _logger.exception('listener hook %s raised for %r; ignored', hook, name)

--- a/interlock/integrations/tenacity.py
+++ b/interlock/integrations/tenacity.py
@@ -67,6 +67,7 @@ except ImportError as exc:
         "install it with `pip install 'interlock-cb[tenacity]'`"
     ) from exc
 
+from interlock._notify import notify
 from interlock.errors import CircuitOpenError
 from interlock.protocols import EventListener
 
@@ -209,13 +210,17 @@ class RetryStrategy:
         self._listener = listener
 
     def _on_before_sleep(self, retry_state: RetryCallState) -> None:
-        """Emit ``on_retry`` (safe getattr — pre-2.0 listeners fine), then the user hook."""
-        if self._listener is not None:
-            next_action = retry_state.next_action
-            delay = next_action.sleep if next_action is not None else 0.0
-            method = getattr(self._listener, 'on_retry', None)
-            if callable(method):
-                method(name=self._name, attempt=retry_state.attempt_number, delay=delay)
+        """Emit ``on_retry`` (isolated from the retry loop), then the user hook."""
+        next_action = retry_state.next_action
+        notify(
+            self._listener,
+            'on_retry',
+            name=self._name,
+            attempt=retry_state.attempt_number,
+            delay=next_action.sleep if next_action is not None else 0.0,
+        )
+        # The user's before_sleep is retry policy, not observability: it keeps
+        # its own error semantics and is not swallowed.
         if self._before_sleep is not None:
             self._before_sleep(retry_state)
 

--- a/interlock/pipeline.py
+++ b/interlock/pipeline.py
@@ -33,6 +33,7 @@ from typing import (
 )
 
 from interlock._detect import is_async_callable
+from interlock._notify import notify
 from interlock._typing import AsyncCallable, P, R, SyncCallable
 from interlock.breaker import CircuitBreaker
 from interlock.errors import BulkheadFullError
@@ -55,15 +56,6 @@ __all__ = (
 
 T = TypeVar('T')
 F_co = TypeVar('F_co', covariant=True)
-
-
-def _notify(listener: EventListener | None, hook: str, **kwargs: object) -> None:
-    """Dispatch a pipeline hook via ``getattr`` so pre-2.0 listeners keep working."""
-    if listener is None:
-        return
-    method = getattr(listener, hook, None)
-    if callable(method):
-        method(**kwargs)
 
 
 @runtime_checkable
@@ -322,7 +314,7 @@ class BulkheadStrategy:
         else:
             acquired = self._sync_semaphore.acquire(blocking=False)
         if not acquired:
-            _notify(self._listener, 'on_bulkhead_rejected', name=self._name)
+            notify(self._listener, 'on_bulkhead_rejected', name=self._name)
             raise BulkheadFullError(self._max_concurrent, max_wait=self._max_wait)
 
         try:
@@ -340,7 +332,7 @@ class BulkheadStrategy:
             async with asyncio.timeout(self._max_wait):
                 await self._async_semaphore.acquire()
         except TimeoutError as exc:
-            _notify(self._listener, 'on_bulkhead_rejected', name=self._name)
+            notify(self._listener, 'on_bulkhead_rejected', name=self._name)
             raise BulkheadFullError(self._max_concurrent, max_wait=self._max_wait) from exc
 
         try:
@@ -406,7 +398,7 @@ class FallbackStrategy(Generic[F_co]):
         try:
             return call()
         except self._on as exc:
-            _notify(self._listener, 'on_fallback', name=self._name, error=exc)
+            notify(self._listener, 'on_fallback', name=self._name, error=exc)
             return self._fallback(exc)
 
     async def execute_async(self, call: Callable[[], Awaitable[T]]) -> T | F_co:
@@ -414,7 +406,7 @@ class FallbackStrategy(Generic[F_co]):
         try:
             return await call()
         except self._on as exc:
-            _notify(self._listener, 'on_fallback', name=self._name, error=exc)
+            notify(self._listener, 'on_fallback', name=self._name, error=exc)
             return self._fallback(exc)
 
 

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -171,7 +171,18 @@ class FailureClassifier(Protocol):
 
 @runtime_checkable
 class EventListener(Protocol):
-    """Hooks for observability. Implementations must not raise into the core."""
+    """Hooks for observability, isolated from the paths they observe.
+
+    A hook that raises an ``Exception`` is logged to the ``interlock`` logger
+    and ignored: the protected call keeps its result, a failing call keeps its
+    own exception, transition bookkeeping completes, and a coordinated
+    breaker's background lane keeps running. ``BaseException`` — cancellation,
+    shutdown — still propagates.
+
+    Every hook is dispatched by name and only if defined, so a listener may
+    implement just the ones it needs and one written before a hook existed
+    keeps working unchanged. See ``docs/guides/observability.md``.
+    """
 
     def on_state_change(self, *, name: str, old: State, new: State) -> None:
         """Called after the breaker transitions between states."""
@@ -193,9 +204,9 @@ class EventListener(Protocol):
         """Called when the shared storage backend becomes unavailable.
 
         The breaker keeps working on local state; this event makes the
-        degradation observable instead of silent. The engine invokes the two
-        storage hooks via safe ``getattr``, so listeners written before they
-        existed keep working unchanged.
+        degradation observable instead of silent. It reports storage failures
+        only — a listener of your own that raises is logged, never reported
+        here.
         """
         ...
 
@@ -207,9 +218,7 @@ class EventListener(Protocol):
         """Called by a pipeline retry layer before it sleeps between attempts.
 
         ``attempt`` is the number of the attempt that just failed; ``delay``
-        is the upcoming backoff in seconds. Like the storage hooks, the three
-        pipeline hooks are dispatched via safe ``getattr`` — listeners written
-        before v2.0 keep working unchanged.
+        is the upcoming backoff in seconds.
         """
         ...
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,55 @@ def listener() -> RecordingListener:
     return RecordingListener()
 
 
+class ExplodingListener:
+    """An EventListener that records the hook it received, then raises.
+
+    The failure mode the safe-dispatch policy isolates. Recording *before*
+    raising is what makes the assertions possible: the hook fired, and the
+    caller survived it.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+    def _fire(self, hook: str) -> None:
+        self.events.append(hook)
+        msg = f'listener {hook} exploded'
+        raise RuntimeError(msg)
+
+    def on_state_change(self, *, name: str, old: State, new: State) -> None:
+        self._fire('on_state_change')
+
+    def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
+        self._fire('on_call')
+
+    def on_rejected(self, *, name: str) -> None:
+        self._fire('on_rejected')
+
+    def on_reset(self, *, name: str) -> None:
+        self._fire('on_reset')
+
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        self._fire('on_storage_degraded')
+
+    def on_storage_recovered(self, *, name: str) -> None:
+        self._fire('on_storage_recovered')
+
+    def on_retry(self, *, name: str, attempt: int, delay: float) -> None:
+        self._fire('on_retry')
+
+    def on_bulkhead_rejected(self, *, name: str) -> None:
+        self._fire('on_bulkhead_rejected')
+
+    def on_fallback(self, *, name: str, error: BaseException) -> None:
+        self._fire('on_fallback')
+
+
+@pytest.fixture
+def exploding() -> ExplodingListener:
+    return ExplodingListener()
+
+
 @dataclass
 class Upstream:
     """A thread-safe switch for a fake HTTP upstream's behaviour.

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,311 @@
+"""Listener failures never reach the protected path, the state machine or a lane.
+
+``EventListener`` implementations are optional observability. A bug in one must
+not replace a successful result, mask a dependency's exception, interrupt
+transition bookkeeping, or kill a coordinator lane — so every hook is dispatched
+through ``interlock._notify.notify``. These tests pin that policy end to end;
+the pipeline hooks are covered in ``test_pipeline.py`` / ``test_tenacity.py``.
+"""
+
+import logging
+import weakref
+from typing import cast
+
+import pytest
+
+from conftest import ExplodingListener, FakeClock, RecordingListener
+from inmemory_storage import AsyncInMemoryStorage, InMemoryStorage
+from interlock import CircuitBreaker, CircuitOpenError, Config, State
+from interlock._coordination import (
+    AsyncCoordinator,
+    SyncCoordinator,
+    _async_lane_tick,
+    _sync_lane_tick,
+)
+from interlock._notify import notify
+from interlock.protocols import AsyncStorage, EventListener, Storage
+from interlock.shared import SharedState
+
+NAME = 'svc'
+WAIT = 5.0
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config(
+        minimum_number_of_calls=2,
+        window_size=10,
+        failure_rate_threshold=0.5,
+        slow_call_duration_threshold=1.0,
+        permitted_calls_in_half_open=2,
+        max_concurrent_probes=2,
+        wait_duration_in_open=WAIT,
+    )
+
+
+def _breaker(
+    config: Config,
+    fake_clock: FakeClock,
+    exploding: ExplodingListener,
+    storage: Storage | AsyncStorage | None = None,
+) -> CircuitBreaker:
+    return CircuitBreaker(
+        name=NAME,
+        config=config,
+        clock=fake_clock,
+        storage=storage,
+        listener=cast('EventListener', exploding),
+    )
+
+
+@pytest.fixture
+def breaker(config: Config, fake_clock: FakeClock, exploding: ExplodingListener) -> CircuitBreaker:
+    return _breaker(config, fake_clock, exploding)
+
+
+def _boom() -> None:
+    msg = 'boom'
+    raise ValueError(msg)
+
+
+def _trip(breaker: CircuitBreaker) -> None:
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            breaker.call(_boom)
+
+
+# --- the dispatcher itself ---------------------------------------------------
+
+
+def test__notify__no_listener__does_nothing() -> None:
+    notify(None, 'on_rejected', name=NAME)
+
+
+def test__notify__listener_without_the_hook__skips_dispatch() -> None:
+    pre_v2 = cast('EventListener', RecordingListener())
+
+    notify(pre_v2, 'on_fallback', name=NAME, error=ValueError('x'))
+
+
+def test__notify__raising_hook__is_logged_with_context(
+    caplog: pytest.LogCaptureFixture, exploding: ExplodingListener
+) -> None:
+    with caplog.at_level(logging.ERROR, logger='interlock'):
+        notify(cast('EventListener', exploding), 'on_rejected', name=NAME)
+
+    record = caplog.records[-1]
+    assert record.levelno == logging.ERROR
+    assert 'on_rejected' in record.getMessage()
+    assert NAME in record.getMessage()
+    assert record.exc_info is not None  # the traceback is not swallowed
+
+
+def test__notify__base_exception__propagates() -> None:
+    class Cancelling:
+        def on_rejected(self, *, name: str) -> None:
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        notify(cast('EventListener', Cancelling()), 'on_rejected', name=NAME)
+
+
+# --- core hooks --------------------------------------------------------------
+
+
+def test__call__on_call_raises__returns_the_protected_result(
+    breaker: CircuitBreaker, exploding: ExplodingListener
+) -> None:
+    assert breaker.call(lambda: 'ok') == 'ok'
+    assert exploding.events == ['on_call']
+
+
+@pytest.mark.asyncio
+async def test__async_call__on_call_raises__returns_the_protected_result(
+    breaker: CircuitBreaker, exploding: ExplodingListener
+) -> None:
+    async def work() -> str:
+        return 'ok'
+
+    assert await breaker.call(work) == 'ok'
+    assert exploding.events == ['on_call']
+
+
+def test__call__on_call_raises__propagates_the_original_failure(breaker: CircuitBreaker) -> None:
+    with pytest.raises(ValueError, match='boom'):
+        breaker.call(_boom)  # the listener error must not mask the dependency's
+
+
+def test__guarded_block__on_call_raises__leaves_the_block_intact(
+    breaker: CircuitBreaker, exploding: ExplodingListener
+) -> None:
+    with breaker:
+        result = 'ok'
+
+    assert result == 'ok'
+    assert exploding.events == ['on_call']
+
+
+def test__on_state_change_raises__transition_still_recorded(
+    breaker: CircuitBreaker, exploding: ExplodingListener
+) -> None:
+    _trip(breaker)
+
+    assert breaker.state is State.OPEN
+    assert 'on_state_change' in exploding.events
+
+
+def test__on_rejected_raises__still_raises_circuit_open_error(breaker: CircuitBreaker) -> None:
+    _trip(breaker)
+
+    with pytest.raises(CircuitOpenError):
+        breaker.call(lambda: 'never')
+
+
+def test__on_reset_raises__reset_completes(
+    breaker: CircuitBreaker, exploding: ExplodingListener
+) -> None:
+    _trip(breaker)
+
+    breaker.reset()
+
+    assert breaker.state is State.CLOSED
+    assert 'on_reset' in exploding.events
+
+
+# --- storage hooks and the coordinator lane ----------------------------------
+
+
+class BrokenStorage(InMemoryStorage):
+    """In-memory storage whose reads can be made to fail, driving degradation."""
+
+    def __init__(self, clock: FakeClock) -> None:
+        super().__init__(clock=clock)
+        self.fail = False
+        self.poll_interval = 3600.0  # keep the real lane inert; tests poll manually
+
+    def read(self, name: str) -> SharedState | None:
+        if self.fail:
+            msg = 'storage down'
+            raise ConnectionError(msg)
+        return super().read(name)
+
+
+def _shared_storage(fake_clock: FakeClock) -> InMemoryStorage:
+    storage = InMemoryStorage(clock=fake_clock)
+    storage.poll_interval = 3600.0
+    return storage
+
+
+def _coordinator(breaker: CircuitBreaker) -> SyncCoordinator:
+    coordinator = breaker._engine._sync_coordinator
+    assert coordinator is not None
+    return coordinator
+
+
+def _async_coordinator(breaker: CircuitBreaker) -> AsyncCoordinator:
+    coordinator = breaker._engine._async_coordinator
+    assert coordinator is not None
+    return coordinator
+
+
+def test__on_storage_degraded_raises__degradation_still_applies(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = BrokenStorage(fake_clock)
+    breaker = _breaker(config, fake_clock, exploding, storage)
+    storage.fail = True
+
+    _coordinator(breaker).poll_once()
+
+    assert exploding.events == ['on_storage_degraded']
+    assert breaker.call(lambda: 'ok') == 'ok'  # local state took over
+
+
+def test__on_storage_recovered_raises__recovery_still_applies(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = BrokenStorage(fake_clock)
+    breaker = _breaker(config, fake_clock, exploding, storage)
+    storage.fail = True
+    _coordinator(breaker).poll_once()
+
+    storage.fail = False
+    fake_clock.advance(storage.retry_backoff)
+    _coordinator(breaker).poll_once()
+
+    assert exploding.events == ['on_storage_degraded', 'on_storage_recovered']
+    assert breaker.call(lambda: 'ok') == 'ok'
+
+
+def test__poll_once__on_state_change_raises__is_not_reported_as_degradation(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = _shared_storage(fake_clock)
+    storage.trip_open(name=NAME, ttl=60.0)  # a peer tripped; this poll adopts it
+    breaker = _breaker(config, fake_clock, exploding, storage)
+
+    _coordinator(breaker).poll_once()
+
+    assert exploding.events == ['on_state_change']  # a listener bug is not a storage failure
+    assert breaker.state is State.OPEN  # the shared view was still adopted
+
+
+def test__execute_op__on_state_change_raises__is_not_reported_as_degradation(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = _shared_storage(fake_clock)
+    breaker = _breaker(config, fake_clock, exploding, storage)
+    coordinator = _coordinator(breaker)
+
+    coordinator.execute_op(lambda: coordinator._accept(storage.trip_open(name=NAME, ttl=60.0)))
+
+    assert exploding.events == ['on_state_change']
+
+
+def test__denied_shared_probe__on_rejected_raises__still_rejects(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = _shared_storage(fake_clock)
+    storage.trip_open(name=NAME, ttl=60.0)
+    breaker = _breaker(config, fake_clock, exploding, storage)
+    coordinator = _coordinator(breaker)
+    coordinator.poll_once()  # adopt the shared OPEN
+    fake_clock.advance(WAIT)
+    coordinator.poll_once()  # OPEN -> HALF_OPEN
+    for _ in range(config.permitted_calls_in_half_open):
+        storage.lease_probe(name=NAME, ttl=60.0)  # peers take every probe slot
+
+    with pytest.raises(CircuitOpenError):
+        breaker.call(lambda: 'never')
+
+    assert exploding.events[-1] == 'on_rejected'
+
+
+def test__sync_lane_tick__on_state_change_raises__lane_keeps_running(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = _shared_storage(fake_clock)
+    storage.trip_open(name=NAME, ttl=60.0)
+    breaker = _breaker(config, fake_clock, exploding, storage)
+    coordinator = _coordinator(breaker)
+
+    alive = _sync_lane_tick(weakref.ref(coordinator), coordinator._work, 0.001)
+
+    assert alive is True  # a raising listener must not terminate the lane
+    assert exploding.events == ['on_state_change']
+
+
+@pytest.mark.asyncio
+async def test__async_lane_tick__on_state_change_raises__lane_keeps_running(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = AsyncInMemoryStorage(clock=fake_clock)
+    storage.poll_interval = 3600.0
+    await storage.trip_open(name=NAME, ttl=60.0)
+    breaker = _breaker(config, fake_clock, exploding, storage)
+    coordinator = _async_coordinator(breaker)
+
+    alive = await _async_lane_tick(weakref.ref(coordinator), coordinator._work, 0.001)
+
+    assert alive is True
+    assert exploding.events == ['on_state_change']

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,7 +9,7 @@ from typing import TypeVar
 import pytest
 
 import interlock
-from conftest import FakeClock
+from conftest import ExplodingListener, FakeClock
 from interlock import BulkheadFullError, CallTimeoutError, CircuitBreaker, CircuitOpenError, Config
 from interlock._detect import is_async_callable
 from interlock.pipeline import (
@@ -804,6 +804,55 @@ def test__pipeline_observability__pre_v2_listener__keeps_working() -> None:
     finally:
         release.set()
         worker.join(timeout=5)
+
+
+def test__bulkhead_strategy__raising_listener__still_rejects_the_call() -> None:
+    events = ExplodingListener()
+    pipeline = Pipeline(BulkheadStrategy(1, name='db-pool', listener=events))
+    inside = threading.Event()
+    release = threading.Event()
+
+    def hold() -> str:
+        inside.set()
+        release.wait(5)
+        return 'held'
+
+    worker = threading.Thread(target=pipeline.call, args=(hold,))
+    worker.start()
+    try:
+        assert inside.wait(5)
+        with pytest.raises(BulkheadFullError):
+            pipeline.call(lambda: 'rejected')  # not RuntimeError from the listener
+    finally:
+        release.set()
+        worker.join(timeout=5)
+
+    assert events.events == ['on_bulkhead_rejected']
+
+
+def test__fallback_strategy__raising_listener__still_substitutes_the_value() -> None:
+    events = ExplodingListener()
+    pipeline = Pipeline(
+        FallbackStrategy(lambda _exc: 'cached', on=(ValueError,), name='recs', listener=events)
+    )
+
+    def failing() -> str:
+        raise ValueError('down')
+
+    assert pipeline.call(failing) == 'cached'
+    assert events.events == ['on_fallback']
+
+
+@pytest.mark.asyncio
+async def test__fallback_strategy__async_raising_listener__still_substitutes_the_value() -> None:
+    events = ExplodingListener()
+    pipeline = Pipeline(FallbackStrategy(lambda _exc: 'cached', on=(ValueError,), listener=events))
+
+    async def failing() -> str:
+        raise ValueError('down')
+
+    assert await pipeline.call(failing) == 'cached'
+    assert events.events == ['on_fallback']
 
 
 def test__pipeline_builder__steps_pass_name_and_listener_through() -> None:

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -12,7 +12,7 @@ from tenacity import (
     stop_after_attempt,
     wait_fixed,
 )
-from tests.conftest import FakeClock
+from tests.conftest import ExplodingListener, FakeClock
 
 from interlock import CircuitBreaker, CircuitOpenError, Config, State
 from interlock.integrations.tenacity import RetryStrategy, retry_unless_open, wait_probe
@@ -540,6 +540,42 @@ def test__retry_strategy__user_before_sleep__invoked_alongside_the_listener() ->
         Pipeline(strategy).call(failing)
     assert observed == [1]
     assert [attempt for _, attempt, _ in events.retries] == [1]
+
+
+def test__retry_strategy__raising_listener__still_retries_and_returns() -> None:
+    events = ExplodingListener()
+    attempts = 0
+
+    def flaky() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 2:
+            raise ValueError('transient')
+        return 'ok'
+
+    strategy = RetryStrategy(attempts=2, sleep=_noop_sleep, listener=events)
+
+    assert Pipeline(strategy).call(flaky) == 'ok'
+    assert events.events == ['on_retry']
+
+
+def test__retry_strategy__raising_listener__user_before_sleep_still_runs() -> None:
+    events = ExplodingListener()
+    observed: list[int] = []
+
+    def failing() -> None:
+        raise ValueError('down')
+
+    strategy = RetryStrategy(
+        attempts=2,
+        sleep=_noop_sleep,
+        listener=events,
+        before_sleep=lambda retry_state: observed.append(retry_state.attempt_number),
+    )
+
+    with pytest.raises(ValueError, match='down'):
+        Pipeline(strategy).call(failing)
+    assert observed == [1]  # the listener failure must not skip the user's hook
 
 
 def test__retry_strategy__pre_v2_listener__keeps_working() -> None:


### PR DESCRIPTION
## Summary

An EventListener that raises could damage the breaker it observes. Hooks were invoked directly at every call site, so a bug in optional observability became a new failure source in a fault-tolerance library.

Three distinct consequences of one root cause, all confirmed in the code:

1. The protected call. `on_call` raising in `Engine._settle` replaced a successful result with an observability exception, or masked the dependency's own error.

2. Silent death of the coordinator lane. `poll_once` calls `_accept` outside its `try` (`interlock/_coordination.py:248, 417`), and `_accept → Engine._on_shared_view → _emit_transitions → on_state_change`. A raising listener propagated out of `_sync_lane_tick` / `_async_lane_tick` and terminated the daemon thread / asyncio task permanently. From then on the breaker never refreshed the shared view and never flushed queued writes again — with nothing surfaced anywhere.

3. False diagnosis. Inside `execute_op` the same exception was caught by the generic `except Exception` and routed to `_degrade`, so a listener bug was reported to the application as a storage failure via `on_storage_degraded`.

The fix. A new `interlock/_notify.py` holds `notify()` — now the only place an EventListener hook is ever invoked:

* dispatch by name via `getattr`, so every hook is optional and pre-1.2 / pre-2.0 listeners keep working;
* an `Exception` is logged to the interlock logger at `ERROR` with the traceback and hook/breaker context, then ignored;
* `BaseException` (`KeyboardInterrupt`, `asyncio.CancelledError`) is not caught — cancellation propagates as everywhere else in interlock.

Applied to core, storage and pipeline hooks (`_engine.py`, `pipeline.py`, `integrations/tenacity.py`). User-supplied policy callbacks deliberately keep their previous semantics and still raise — a `FailureClassifier`, a pipeline fallback function, a tenacity `before_sleep` hook — because they shape the call's behaviour rather than observe it.

Incidentally removes `_NoopListener`, `_NOOP_LISTENER` and two ad-hoc `_notify*` helpers: the engine now holds `EventListener | None`, and the no-listener path skips dispatch entirely instead of calling a no-op method.

No public API change. The EventListener protocol is unchanged; the guarantees around it got stronger. One behavioural nuance worth review: a hook missing from a listener is now skipped instead of raising `AttributeError`, which makes the whole protocol uniformly optional — consistent with how the storage and pipeline hooks already behaved, and static checkers still catch a missing core hook at the call site.

## Checklist

* [x] Tests added or updated (suite stays at 100% coverage) — new `tests/test_notify.py` (19 tests) + `ExplodingListener` fixture in `conftest.py`, 3 tests in `test_pipeline.py`, 2 in `test_tenacity.py`. Written test-first: 5 failed with `RuntimeError: listener ... exploded` before the fix. Total 517 passed / 2 skipped, coverage 100.00%.
* [x] `uv run ruff format --check` and `uv run ruff check` pass.
* [x] `uv run mypy` and `uv run pyright` pass (both strict).
* [x] Docs updated (`docs/`) — new "Listener failures are isolated" section in `docs/guides/observability.md`, updated `pipeline.md`, refreshed EventListener docstrings, `llms-full.txt` regenerated.
* [x] `CHANGELOG.md` `[Unreleased]` updated.
* [x] Commits follow Conventional Commits.

Standalone invariant holds: the entire v1 suite passes unmodified — in existing test files only import lines changed, not a single assertion. Benchmarks (`benchmarks/`, 21 tests) still pass; the no-listener hot path got marginally cheaper.

## Related issues

Closes #83.