### PR TITLE
feat: add an explicit shutdown API for lanes and the auto-transition timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,33 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `CircuitBreaker.close()` / `aclose()` and `Registry.close_all()` /
+  `aclose_all()` — a deterministic way to release a breaker's background work.
+  Until now a coordinated breaker's lane (a daemon thread for a sync storage,
+  an asyncio task for an async one) and the `auto_transition` timer ended only
+  when the object was garbage collected, so a service could not flush queued
+  shared writes, could not know when its threads were gone, and an async lane
+  outliving `asyncio.run()` produced "task was destroyed but it is pending".
+  `close()` drains the queued writes in order, wakes the lane instead of
+  waiting out `poll_interval`, joins it, and cancels the timer without arming
+  another. It is idempotent, safe to call from any thread, and terminal: the
+  lane never restarts, and afterwards the breaker keeps protecting calls on
+  local state while shared writes are dropped — the same behaviour as a
+  degraded storage. The cached shared view is dropped with the lane, since
+  nothing would refresh it and a peer's `OPEN` would otherwise never expire.
+  This is teardown, not a state change: `close()` does not close the circuit
+  (`reset()` does). The weakref-based collection path stays as the safety net
+  for abandoned breakers.
+
 ### Fixed
 
+- A coordinator lane that exited while an op was in flight left the work queue
+  permanently unfinished: the op was dequeued before the weak reference was
+  resolved, so a lane stopping on a collected coordinator never called
+  `task_done()` and a join on that queue could never return. Both lanes now
+  release the dequeued op on the drop path.
 - An `EventListener` that raises can no longer damage the breaker it observes.
   Hooks were invoked directly at every call site, so a bug in a listener —
   a metrics exporter, a logging handler, a custom sink — could replace a

--- a/docs/integrations/redis.md
+++ b/docs/integrations/redis.md
@@ -135,6 +135,55 @@ class StorageWatch:
 written before these hooks existed keep working — the engine calls them only if
 present.
 
+## Shutdown
+
+A coordinated breaker owns a background lane — a daemon thread for a sync
+storage, an asyncio task for an async one. It polls the shared view and drains
+fire-and-forget writes. Left alone, it ends only when the breaker is garbage
+collected, which is why an async lane can outlive `asyncio.run()` and log
+"task was destroyed but it is pending".
+
+`close()` (or `aclose()` for an async storage) ends it deterministically:
+
+```python
+breaker = CircuitBreaker(name='payments', storage=storage)
+try:
+    ...  # serve traffic
+finally:
+    breaker.close()  # drains queued writes, stops the lane, joins it
+```
+
+`Registry` does the whole set at once:
+
+```python
+registry = Registry(storage=storage)
+...
+registry.close_all()  # or: await registry.aclose_all()
+```
+
+What it guarantees:
+
+- **Queued writes are drained first.** Ops already on the queue run in order
+  before the lane exits, so a trip recorded just before shutdown still reaches
+  Redis. Writes that the degraded gate would drop are still dropped.
+- **No waiting out `poll_interval`.** A parked lane is woken immediately.
+- **The `auto_transition` timer is cancelled**, and no new one is armed.
+- **It is idempotent** and safe to call from any thread.
+
+Two consequences worth knowing:
+
+- **Shutdown is terminal.** The lane never restarts. Afterwards the breaker
+  keeps protecting calls on its local state, and shared writes are dropped —
+  the same behaviour as a degraded storage. `Registry.get()` keeps returning the
+  closed instance rather than silently starting a fresh lane.
+- **The cached shared view is dropped.** Nothing refreshes it once the lane is
+  gone, so keeping it would pin the breaker in whatever a peer last published —
+  a shared `OPEN` would never expire. The fallback to local state is reported
+  through `on_state_change` like any other.
+
+`close()` is teardown, not a state change: it does **not** close the circuit.
+That is `reset()`.
+
 ## Tuning
 
 All knobs live on the storage constructor; the core `Config` stays

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3000,6 +3000,55 @@ class StorageWatch:
 written before these hooks existed keep working — the engine calls them only if
 present.
 
+## Shutdown
+
+A coordinated breaker owns a background lane — a daemon thread for a sync
+storage, an asyncio task for an async one. It polls the shared view and drains
+fire-and-forget writes. Left alone, it ends only when the breaker is garbage
+collected, which is why an async lane can outlive `asyncio.run()` and log
+"task was destroyed but it is pending".
+
+`close()` (or `aclose()` for an async storage) ends it deterministically:
+
+```python
+breaker = CircuitBreaker(name='payments', storage=storage)
+try:
+    ...  # serve traffic
+finally:
+    breaker.close()  # drains queued writes, stops the lane, joins it
+```
+
+`Registry` does the whole set at once:
+
+```python
+registry = Registry(storage=storage)
+...
+registry.close_all()  # or: await registry.aclose_all()
+```
+
+What it guarantees:
+
+- **Queued writes are drained first.** Ops already on the queue run in order
+  before the lane exits, so a trip recorded just before shutdown still reaches
+  Redis. Writes that the degraded gate would drop are still dropped.
+- **No waiting out `poll_interval`.** A parked lane is woken immediately.
+- **The `auto_transition` timer is cancelled**, and no new one is armed.
+- **It is idempotent** and safe to call from any thread.
+
+Two consequences worth knowing:
+
+- **Shutdown is terminal.** The lane never restarts. Afterwards the breaker
+  keeps protecting calls on its local state, and shared writes are dropped —
+  the same behaviour as a degraded storage. `Registry.get()` keeps returning the
+  closed instance rather than silently starting a fresh lane.
+- **The cached shared view is dropped.** Nothing refreshes it once the lane is
+  gone, so keeping it would pin the breaker in whatever a peer last published —
+  a shared `OPEN` would never expire. The fallback to local state is reported
+  through `on_state_change` like any other.
+
+`close()` is teardown, not a state change: it does **not** close the circuit.
+That is `reset()`.
+
 ## Tuning
 
 All knobs live on the storage constructor; the core `Config` stays
@@ -3148,6 +3197,10 @@ A named breaker for sync and async callables.
 - **`snapshot() -> WindowSnapshot`** — current, self-consistent window aggregates;
   concurrent call settlement cannot expose a partially updated window.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
+- **`close()` / `aclose()`** — release background resources: the coordinator
+  lane and the `auto_transition` timer. Teardown, not a state change: neither
+  closes the circuit (`reset()` does). Idempotent, and terminal — the lane never
+  restarts. See [Shutdown](integrations/redis.md#shutdown).
 - **`storage`** — optional shared backend (`Storage` or `AsyncStorage`) for
   coordinated state across instances; see the
   [Redis integration](integrations/redis.md). A coordinated breaker matches its
@@ -3165,12 +3218,17 @@ See [Configuration](guides/configuration.md) for every field. Raises
 ```python
 Registry(*, config=None, clock=None, classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
+registry.close_all() / await registry.aclose_all()
 ```
 
 Creates and caches named breakers. The same name always returns the same
 instance; the per-call `config` override applies only at creation. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
 name.
+
+`close_all()` / `aclose_all()` close every breaker created so far. The cache is
+kept, so `get()` keeps returning the same, torn-down instances instead of
+silently starting a fresh lane after shutdown.
 
 ## Enums
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -18,6 +18,10 @@ A named breaker for sync and async callables.
 - **`snapshot() -> WindowSnapshot`** — current, self-consistent window aggregates;
   concurrent call settlement cannot expose a partially updated window.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
+- **`close()` / `aclose()`** — release background resources: the coordinator
+  lane and the `auto_transition` timer. Teardown, not a state change: neither
+  closes the circuit (`reset()` does). Idempotent, and terminal — the lane never
+  restarts. See [Shutdown](integrations/redis.md#shutdown).
 - **`storage`** — optional shared backend (`Storage` or `AsyncStorage`) for
   coordinated state across instances; see the
   [Redis integration](integrations/redis.md). A coordinated breaker matches its
@@ -35,12 +39,17 @@ See [Configuration](guides/configuration.md) for every field. Raises
 ```python
 Registry(*, config=None, clock=None, classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
+registry.close_all() / await registry.aclose_all()
 ```
 
 Creates and caches named breakers. The same name always returns the same
 instance; the per-call `config` override applies only at creation. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
 name.
+
+`close_all()` / `aclose_all()` close every breaker created so far. The cache is
+kept, so `get()` keeps returning the same, torn-down instances instead of
+silently starting a fresh lane after shutdown.
 
 ## Enums
 

--- a/interlock/_coordination.py
+++ b/interlock/_coordination.py
@@ -52,6 +52,14 @@ _SyncOp = Callable[[], None]
 _AsyncOp = Callable[[], Awaitable[None]]
 
 
+def _sync_stop() -> None:
+    """Queue sentinel: identity-compared by the lane, never invoked."""
+
+
+async def _async_stop() -> None:
+    """Queue sentinel: identity-compared by the lane, never invoked."""
+
+
 class _CoordinatorBase:
     """State and policy shared by the sync and async coordinators.
 
@@ -61,6 +69,12 @@ class _CoordinatorBase:
     listener, which is why every hook goes through ``_notify.notify``: a raising
     listener would otherwise kill the lane (``poll_once`` calls back outside its
     ``try``) or be misreported as a storage failure (inside ``execute_op``).
+
+    ``shutdown`` is terminal: the lane never restarts, and later writes are
+    dropped exactly as they are while the storage is degraded. Everything that
+    touches ``_stopped``, the lane handle and ``_work.put`` happens under
+    ``_lock``, so a write can never be enqueued onto a lane that will not run
+    to consume it — which would leave ``wait_idle`` unable to return.
     """
 
     def __init__(
@@ -87,7 +101,7 @@ class _CoordinatorBase:
         self._degraded = False
         self._retry_at = 0.0
         self._last_view: SharedState | None = None
-        self._lane_started = False
+        self._stopped = False
 
     def _gate_open(self) -> bool:
         """Whether the storage may be touched now (not degraded, or retry due)."""
@@ -161,21 +175,29 @@ class SyncCoordinator(_CoordinatorBase):
         )
         self._storage = storage
         self._work: queue.Queue[_SyncOp] = queue.Queue()
+        self._thread: threading.Thread | None = None
 
     def ensure_lane(self) -> None:
         """Start the background lane once; safe to call on every admission."""
         with self._lock:
-            if self._lane_started:
-                return
-            self._lane_started = True
+            self._start_lane_locked()
 
-        thread = threading.Thread(
-            target=_sync_lane,
-            args=(weakref.ref(self), self._work, self._interval),
-            name=f'interlock-coordinator-{self._name}',
-            daemon=True,
-        )
-        thread.start()
+    def shutdown(self) -> None:
+        """Drain the queued writes, stop the lane and join it. Idempotent.
+
+        The sentinel wakes a lane parked in ``get`` immediately, so shutdown
+        never waits out ``poll_interval``. Writes already queued run first
+        (FIFO); ones the degraded gate would drop are still dropped.
+        """
+        with self._lock:
+            first = not self._stopped
+            self._stopped = True
+            thread = self._thread
+            if first and thread is not None:
+                self._work.put(_sync_stop)
+
+        if thread is not None:
+            thread.join()  # outside the lock: the lane takes it in poll_once
 
     def try_lease(self) -> bool | None:
         """Claim one shared probe slot inline; ``None`` means storage degraded."""
@@ -256,8 +278,23 @@ class SyncCoordinator(_CoordinatorBase):
         self._work.join()
 
     def _enqueue(self, op: _SyncOp) -> None:
-        self._work.put(op)
-        self.ensure_lane()
+        with self._lock:
+            if self._stopped:
+                return  # shut down: drop the write, as the degraded gate does
+            self._work.put(op)
+            self._start_lane_locked()
+
+    def _start_lane_locked(self) -> None:
+        if self._thread is not None or self._stopped:
+            return
+
+        self._thread = threading.Thread(
+            target=_sync_lane,
+            args=(weakref.ref(self), self._work, self._interval),
+            name=f'interlock-coordinator-{self._name}',
+            daemon=True,
+        )
+        self._thread.start()
 
     def execute_op(self, op: _SyncOp) -> None:
         """Run one queued write under degradation protection (lane-internal)."""
@@ -279,9 +316,12 @@ def _sync_lane_tick(
 ) -> bool:
     """One lane iteration: run a queued write, or poll on timeout.
 
-    Returns whether the lane should keep running. The lane holds only a weak
-    reference between iterations so an abandoned breaker can be collected and
-    its lane exits on the next tick.
+    Returns whether the lane should keep running. It stops on the shutdown
+    sentinel, and on a dead weak reference — the lane holds only a weak
+    reference between iterations, so an abandoned breaker can be collected and
+    its lane exits on the next tick. Either way a dequeued op is marked done,
+    or ``unfinished_tasks`` would stay positive and ``wait_idle`` could never
+    return.
     """
     try:
         op = work.get(timeout=interval)
@@ -289,7 +329,9 @@ def _sync_lane_tick(
         op = None
 
     coordinator = ref()
-    if coordinator is None:
+    if coordinator is None or op is _sync_stop:
+        if op is not None:
+            work.task_done()
         return False
 
     if op is None:
@@ -342,14 +384,23 @@ class AsyncCoordinator(_CoordinatorBase):
     def ensure_lane(self) -> None:
         """Start the lane task once; must be called with a running event loop."""
         with self._lock:
-            if self._lane_started:
-                return
-            self._lane_started = True
+            self._start_lane_locked()
 
-        self._lane_task = asyncio.get_running_loop().create_task(
-            _async_lane(weakref.ref(self), self._work, self._interval),
-            name=f'interlock-coordinator-{self._name}',
-        )
+    async def shutdown(self) -> None:
+        """Drain the queued writes, stop the lane and await it. Idempotent.
+
+        The async mirror of ``SyncCoordinator.shutdown``; awaiting the task is
+        what keeps a pending lane from outliving ``asyncio.run``.
+        """
+        with self._lock:
+            first = not self._stopped
+            self._stopped = True
+            task = self._lane_task
+            if first and task is not None:
+                self._work.put_nowait(_async_stop)
+
+        if task is not None:
+            await task
 
     async def try_lease(self) -> bool | None:
         """Claim one shared probe slot inline; ``None`` means storage degraded."""
@@ -425,8 +476,20 @@ class AsyncCoordinator(_CoordinatorBase):
         await self._work.join()
 
     def _enqueue(self, op: _AsyncOp) -> None:
-        self._work.put_nowait(op)
-        self.ensure_lane()
+        with self._lock:
+            if self._stopped:
+                return  # shut down: drop the write, as the degraded gate does
+            self._work.put_nowait(op)
+            self._start_lane_locked()
+
+    def _start_lane_locked(self) -> None:
+        if self._lane_task is not None or self._stopped:
+            return
+
+        self._lane_task = asyncio.get_running_loop().create_task(
+            _async_lane(weakref.ref(self), self._work, self._interval),
+            name=f'interlock-coordinator-{self._name}',
+        )
 
     async def execute_op(self, op: _AsyncOp) -> None:
         """Run one queued write under degradation protection (lane-internal)."""
@@ -453,7 +516,9 @@ async def _async_lane_tick(
         op = None
 
     coordinator = ref()
-    if coordinator is None:
+    if coordinator is None or op is _async_stop:
+        if op is not None:
+            work.task_done()
         return False
 
     if op is None:

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -92,6 +92,7 @@ class Engine:
         self._last_failure: BaseException | None = None
         self._timer: threading.Timer | None = None
         self._timer_lock = threading.Lock()
+        self._closed = False
         self._shared_view: SharedState | None = None
         self._storage_degraded = False
         self._sync_coordinator: SyncCoordinator | None = None
@@ -255,6 +256,69 @@ class Engine:
         """Override to ``METRICS_ONLY``: admit all traffic, record but never trip."""
         self._override(self._machine.metrics_only)
 
+    def close(self) -> None:
+        """Stop background work: cancel the auto-transition timer, stop the lane.
+
+        Teardown, not a state change — the circuit is left exactly as it is
+        (``reset`` is what closes it). The breaker keeps serving calls on local
+        state afterwards; shutdown is terminal, so the lane never restarts and
+        later shared writes are dropped. Idempotent.
+
+        Raises:
+            InterlockError: If the breaker is coordinated through an async
+                storage; use ``aclose`` there.
+        """
+        self._require_sync_runtime()
+        self._shutdown_timer()
+        if self._sync_coordinator is not None:
+            self._sync_coordinator.shutdown()
+            self._detach_shared_view()
+
+    async def aclose(self) -> None:
+        """Stop background work; the async mirror of ``close``.
+
+        Raises:
+            InterlockError: If the breaker is coordinated through a sync
+                storage; use ``close`` there.
+        """
+        self._require_async_runtime()
+        self._shutdown_timer()
+        if self._async_coordinator is not None:
+            await self._async_coordinator.shutdown()
+            self._detach_shared_view()
+
+    def _detach_shared_view(self) -> None:
+        """Drop the cached shared view once its lane is gone.
+
+        Called only after the lane has been joined, so no in-flight write can
+        re-adopt a view. Nothing refreshes the cache any more, so keeping it
+        would pin the breaker in whatever a peer last published — a shared OPEN
+        would never expire. Local state takes over, exactly as when degraded.
+        """
+        with self._lock:
+            effective_before = self._effective_state_locked()
+            machine_state = self._machine.state
+            self._shared_view = None
+            effective_after = self._effective_state_locked()
+
+        self._emit_transitions(machine_state, machine_state, effective_before, effective_after)
+
+    def _require_sync_runtime(self) -> None:
+        if self._async_coordinator is not None:
+            msg = (
+                f'circuit {self._name!r} is coordinated through an async storage; '
+                f'only its async API may be used'
+            )
+            raise InterlockError(msg)
+
+    def _require_async_runtime(self) -> None:
+        if self._sync_coordinator is not None:
+            msg = (
+                f'circuit {self._name!r} is coordinated through a sync storage; '
+                f'only its sync API may be used'
+            )
+            raise InterlockError(msg)
+
     def _override(self, mutate: Callable[[], None]) -> None:
         with self._lock:
             effective_before = self._effective_state_locked()
@@ -272,12 +336,7 @@ class Engine:
             CircuitOpenError: If the breaker rejects the call.
             InterlockError: If the breaker is coordinated through an async storage.
         """
-        if self._async_coordinator is not None:
-            msg = (
-                f'circuit {self._name!r} is coordinated through an async storage; '
-                f'only its async API may be used'
-            )
-            raise InterlockError(msg)
+        self._require_sync_runtime()
 
         coordinator = self._sync_coordinator
         if coordinator is not None:
@@ -292,12 +351,7 @@ class Engine:
 
     async def _admit_async(self) -> Admission:
         """Admit one asynchronous call; the async mirror of ``_admit``."""
-        if self._sync_coordinator is not None:
-            msg = (
-                f'circuit {self._name!r} is coordinated through a sync storage; '
-                f'only its sync API may be used'
-            )
-            raise InterlockError(msg)
+        self._require_async_runtime()
 
         coordinator = self._async_coordinator
         if coordinator is not None:
@@ -514,6 +568,8 @@ class Engine:
         timer = threading.Timer(self._config.wait_duration_in_open, self._fire_auto_transition)
         timer.daemon = True
         with self._timer_lock:
+            if self._closed:
+                return  # torn down: never arm a timer nobody is left to cancel
             self._cancel_timer_locked()
             self._timer = timer
 
@@ -521,6 +577,12 @@ class Engine:
 
     def _cancel_auto_transition(self) -> None:
         with self._timer_lock:
+            self._cancel_timer_locked()
+
+    def _shutdown_timer(self) -> None:
+        """Cancel the pending timer and refuse to arm another one."""
+        with self._timer_lock:
+            self._closed = True
             self._cancel_timer_locked()
 
     def _cancel_timer_locked(self) -> None:

--- a/interlock/breaker.py
+++ b/interlock/breaker.py
@@ -96,6 +96,33 @@ class CircuitBreaker:
         """Clear local control and metrics, then resume the shared state if present."""
         self._engine.reset()
 
+    def close(self) -> None:
+        """Release background resources: the coordinator lane and any timer.
+
+        This is teardown, *not* a state change — it does not close the circuit
+        (``reset`` does). Call it once traffic has stopped: the breaker keeps
+        serving calls on local state afterwards, but shutdown is terminal, so
+        the lane never restarts and later shared writes are dropped. Idempotent,
+        and usable as ``with contextlib.closing(breaker):``.
+
+        Raises:
+            InterlockError: If the breaker is coordinated through an async
+                storage; use ``aclose`` there.
+        """
+        self._engine.close()
+
+    async def aclose(self) -> None:
+        """Release background resources; the async mirror of ``close``.
+
+        Awaiting the lane task here is what keeps it from outliving
+        ``asyncio.run`` as a pending task.
+
+        Raises:
+            InterlockError: If the breaker is coordinated through a sync
+                storage; use ``close`` there.
+        """
+        await self._engine.aclose()
+
     def force_open(self) -> None:
         """Force the breaker ``FORCED_OPEN``: reject all traffic until reset."""
         self._engine.force_open()

--- a/interlock/registry.py
+++ b/interlock/registry.py
@@ -72,3 +72,31 @@ class Registry:
                 self._breakers[name] = breaker
 
             return breaker
+
+    def close_all(self) -> None:
+        """Release the background resources of every breaker created so far.
+
+        Breakers stay cached — ``get`` keeps returning the same, now torn-down
+        instances rather than silently resurrecting a lane after shutdown.
+
+        Raises:
+            InterlockError: If the registry's storage is asynchronous; use
+                ``aclose_all`` there.
+        """
+        for breaker in self._snapshot():
+            breaker.close()
+
+    async def aclose_all(self) -> None:
+        """Release every breaker's background resources; the async mirror.
+
+        Raises:
+            InterlockError: If the registry's storage is synchronous; use
+                ``close_all`` there.
+        """
+        for breaker in self._snapshot():
+            await breaker.aclose()
+
+    def _snapshot(self) -> tuple[CircuitBreaker, ...]:
+        """The breakers created so far; taken under the lock, closed outside it."""
+        with self._lock:
+            return tuple(self._breakers.values())

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,511 @@
+"""Deterministic teardown: the lane stops, the timer is cancelled, nothing leaks.
+
+A coordinated breaker owns a background lane (daemon thread or asyncio task) and
+an ``auto_transition`` breaker owns a ``threading.Timer``. Both used to end only
+when the object was collected. These tests pin the explicit path added in #98 —
+``close()`` / ``aclose()`` / ``Registry.close_all()`` — and the queue invariant
+on the lane's drop path (#97), which the shutdown API makes reachable.
+
+Real lane threads run here, so ``poll_interval`` is set huge to park the lane in
+``get()``: shutdown must wake it through the sentinel rather than wait it out.
+"""
+
+import asyncio
+import gc
+import threading
+import weakref
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from conftest import FakeClock, RecordingListener
+from inmemory_storage import AsyncInMemoryStorage, InMemoryStorage
+from interlock import CircuitBreaker, Config, Registry, State
+from interlock._coordination import (
+    AsyncCoordinator,
+    SyncCoordinator,
+    _async_lane_tick,
+    _sync_lane_tick,
+)
+from interlock.errors import InterlockError
+from interlock.protocols import AsyncStorage, EventListener, Storage
+from interlock.shared import SharedState
+
+if TYPE_CHECKING:
+    import queue
+    from collections.abc import Callable
+
+NAME = 'svc'
+WAIT = 5.0
+JOIN_TIMEOUT = 5.0
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config(
+        minimum_number_of_calls=2,
+        window_size=10,
+        failure_rate_threshold=0.5,
+        slow_call_duration_threshold=1.0,
+        permitted_calls_in_half_open=2,
+        max_concurrent_probes=2,
+        wait_duration_in_open=WAIT,
+    )
+
+
+@pytest.fixture
+def storage(fake_clock: FakeClock) -> InMemoryStorage:
+    store = InMemoryStorage(clock=fake_clock)
+    store.poll_interval = 3600.0  # park the lane in get(); only the sentinel wakes it
+    return store
+
+
+@pytest.fixture
+def astorage(fake_clock: FakeClock) -> AsyncInMemoryStorage:
+    store = AsyncInMemoryStorage(clock=fake_clock)
+    store.poll_interval = 3600.0
+    return store
+
+
+def _breaker(
+    config: Config, fake_clock: FakeClock, storage: Storage | AsyncStorage | None = None
+) -> CircuitBreaker:
+    return CircuitBreaker(name=NAME, config=config, clock=fake_clock, storage=storage)
+
+
+def _sync_coordinator(breaker: CircuitBreaker) -> SyncCoordinator:
+    coordinator = breaker._engine._sync_coordinator
+    assert coordinator is not None
+    return coordinator
+
+
+def _async_coordinator(breaker: CircuitBreaker) -> AsyncCoordinator:
+    coordinator = breaker._engine._async_coordinator
+    assert coordinator is not None
+    return coordinator
+
+
+def _boom() -> None:
+    msg = 'boom'
+    raise ValueError(msg)
+
+
+def _trip(breaker: CircuitBreaker) -> None:
+    """Drive the breaker to OPEN, which enqueues one shared write."""
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            breaker.call(_boom)
+
+
+def _joined(work: 'queue.Queue[Callable[[], None]]') -> bool:
+    """Whether ``work.join()`` returns — i.e. no dequeued op was left unfinished."""
+    done = threading.Event()
+
+    def wait() -> None:
+        work.join()
+        done.set()
+
+    threading.Thread(target=wait, daemon=True).start()
+    return done.wait(timeout=JOIN_TIMEOUT)
+
+
+# --- the lane's drop path (#97) ----------------------------------------------
+
+
+def test__sync_lane_tick__dead_coordinator_with_op_in_flight__releases_the_op(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    coordinator = SyncCoordinator(
+        name=NAME,
+        config=config,
+        clock=fake_clock,
+        storage=storage,
+        on_view=lambda _view: None,
+        on_degraded=lambda _error: None,
+        on_recovered=lambda: None,
+    )
+    work = coordinator._work
+    work.put(lambda: None)  # dequeued by the tick, then dropped on the dead ref
+    ref = weakref.ref(coordinator)
+    del coordinator
+    gc.collect()
+    assert ref() is None
+
+    assert _sync_lane_tick(ref, work, 0.001) is False
+
+    assert _joined(work)  # task_done ran on the drop path: join() cannot hang
+
+
+@pytest.mark.asyncio
+async def test__async_lane_tick__dead_coordinator_with_op_in_flight__releases_the_op(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    coordinator = AsyncCoordinator(
+        name=NAME,
+        config=config,
+        clock=fake_clock,
+        storage=astorage,
+        on_view=lambda _view: None,
+        on_degraded=lambda _error: None,
+        on_recovered=lambda: None,
+    )
+    work = coordinator._work
+
+    async def op() -> None: ...
+
+    work.put_nowait(op)
+    ref = weakref.ref(coordinator)
+    del coordinator
+    gc.collect()
+    assert ref() is None
+
+    assert await _async_lane_tick(ref, work, 0.001) is False
+
+    await asyncio.wait_for(work.join(), timeout=JOIN_TIMEOUT)
+
+
+# --- sync coordinator shutdown -----------------------------------------------
+
+
+def test__shutdown__stops_the_lane_thread(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    coordinator = _sync_coordinator(breaker)
+    coordinator.ensure_lane()
+    thread = coordinator._thread
+    assert thread is not None
+
+    coordinator.shutdown()
+
+    assert not thread.is_alive()  # shutdown joined it, without waiting out poll_interval
+
+
+def test__shutdown__drains_queued_writes(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+
+    _trip(breaker)  # enqueues the shared trip write
+    breaker.close()
+
+    shared = storage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN  # the queued write ran before the lane exited
+
+
+def test__shutdown__is_idempotent(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    coordinator = _sync_coordinator(breaker)
+    coordinator.ensure_lane()
+
+    coordinator.shutdown()
+    coordinator.shutdown()  # second call must not hang, raise or re-enqueue
+
+    thread = coordinator._thread
+    assert thread is not None
+    assert not thread.is_alive()
+
+
+def test__shutdown__before_the_lane_started__is_a_noop(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    coordinator = _sync_coordinator(breaker)
+
+    coordinator.shutdown()
+
+    assert coordinator._thread is None
+    assert _joined(coordinator._work)  # no sentinel was left behind
+
+
+def test__shutdown__while_degraded__still_stops(config: Config, fake_clock: FakeClock) -> None:
+    class Down(InMemoryStorage):
+        def read(self, name: str) -> SharedState | None:
+            msg = 'storage down'
+            raise ConnectionError(msg)
+
+    down = Down(clock=fake_clock)
+    down.poll_interval = 3600.0
+    breaker = _breaker(config, fake_clock, down)
+    coordinator = _sync_coordinator(breaker)
+    coordinator.poll_once()  # degrade
+    _trip(breaker)  # enqueues a write the degraded gate will drop
+
+    coordinator.shutdown()
+
+    thread = coordinator._thread
+    assert thread is not None
+    assert not thread.is_alive()
+    assert _joined(coordinator._work)  # the dropped write was still marked done
+
+
+def test__close__on_an_adopted_shared_open__falls_back_to_local_state(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    storage.trip_open(name=NAME, ttl=60.0)  # a peer tripped
+    _sync_coordinator(breaker).poll_once()  # adopt it
+    assert breaker.state is State.OPEN
+
+    breaker.close()
+
+    # Nothing polls any more, so a retained view could never refresh: keeping it
+    # would wedge the breaker in a peer's OPEN for good.
+    assert breaker.state is State.CLOSED
+    assert breaker.call(lambda: 'local') == 'local'
+
+
+@pytest.mark.asyncio
+async def test__aclose__on_an_adopted_shared_open__falls_back_to_local_state(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, astorage)
+    await astorage.trip_open(name=NAME, ttl=60.0)
+    await _async_coordinator(breaker).poll_once()
+    assert breaker.state is State.OPEN
+
+    await breaker.aclose()
+
+    assert breaker.state is State.CLOSED
+
+
+def test__close__reports_the_fallback_as_a_state_change(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    listener = RecordingListener()
+    breaker = CircuitBreaker(
+        name=NAME,
+        config=config,
+        clock=fake_clock,
+        storage=storage,
+        listener=cast('EventListener', listener),
+    )
+    storage.trip_open(name=NAME, ttl=60.0)
+    _sync_coordinator(breaker).poll_once()
+
+    breaker.close()
+
+    assert listener.state_changes[-1] == (State.OPEN, State.CLOSED)
+
+
+def test__shutdown__then_a_later_write__is_dropped_and_the_lane_stays_down(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    coordinator = _sync_coordinator(breaker)
+    coordinator.shutdown()
+
+    _trip(breaker)  # would enqueue a shared write and start the lane
+
+    assert coordinator._thread is None  # shutdown is terminal: no restart
+    assert storage.read(NAME) is None  # the write was dropped, as when degraded
+    assert breaker.state is State.OPEN  # local state keeps working
+
+
+# --- async coordinator shutdown ----------------------------------------------
+
+
+async def _boom_async() -> None:
+    msg = 'boom'
+    raise ValueError(msg)
+
+
+async def _trip_async(breaker: CircuitBreaker) -> None:
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            await breaker.call(_boom_async)
+
+
+@pytest.mark.asyncio
+async def test__async_shutdown__stops_the_lane_task(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, astorage)
+    coordinator = _async_coordinator(breaker)
+    coordinator.ensure_lane()
+    task = coordinator._lane_task
+    assert task is not None
+
+    await coordinator.shutdown()
+
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test__async_shutdown__drains_queued_writes(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, astorage)
+
+    await _trip_async(breaker)
+    await breaker.aclose()
+
+    shared = await astorage.read(NAME)
+    assert shared is not None
+    assert shared.state is State.OPEN
+
+
+@pytest.mark.asyncio
+async def test__async_shutdown__is_idempotent(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, astorage)
+    coordinator = _async_coordinator(breaker)
+    coordinator.ensure_lane()
+
+    await coordinator.shutdown()
+    await coordinator.shutdown()
+
+    task = coordinator._lane_task
+    assert task is not None
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test__async_shutdown__before_the_lane_started__is_a_noop(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, astorage)
+    coordinator = _async_coordinator(breaker)
+
+    await coordinator.shutdown()
+
+    assert coordinator._lane_task is None
+    await asyncio.wait_for(coordinator._work.join(), timeout=JOIN_TIMEOUT)
+
+
+@pytest.mark.asyncio
+async def test__async_shutdown__then_a_later_write__is_dropped(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, astorage)
+    coordinator = _async_coordinator(breaker)
+    await coordinator.shutdown()
+
+    await _trip_async(breaker)
+
+    assert coordinator._lane_task is None
+    assert await astorage.read(NAME) is None
+    assert breaker.state is State.OPEN
+
+
+# --- the auto-transition timer -----------------------------------------------
+
+
+def test__close__cancels_the_auto_transition_timer(fake_clock: FakeClock) -> None:
+    config = Config(
+        minimum_number_of_calls=2,
+        failure_rate_threshold=0.5,
+        wait_duration_in_open=3600.0,
+        auto_transition=True,
+    )
+    breaker = _breaker(config, fake_clock)
+    _trip(breaker)
+    assert breaker._engine._timer is not None
+
+    breaker.close()
+
+    assert breaker._engine._timer is None
+
+
+def test__close__then_a_new_trip__does_not_rearm_the_timer(fake_clock: FakeClock) -> None:
+    config = Config(
+        minimum_number_of_calls=2,
+        failure_rate_threshold=0.5,
+        wait_duration_in_open=3600.0,
+        auto_transition=True,
+    )
+    breaker = _breaker(config, fake_clock)
+    breaker.close()
+
+    _trip(breaker)
+
+    assert breaker.state is State.OPEN  # the breaker still works
+    assert breaker._engine._timer is None  # but never arms a timer nobody will cancel
+
+
+def test__close__is_idempotent_without_a_storage(fake_clock: FakeClock, config: Config) -> None:
+    breaker = _breaker(config, fake_clock)
+
+    breaker.close()
+    breaker.close()
+
+
+@pytest.mark.asyncio
+async def test__aclose__without_a_storage__cancels_the_timer(fake_clock: FakeClock) -> None:
+    config = Config(
+        minimum_number_of_calls=2,
+        failure_rate_threshold=0.5,
+        wait_duration_in_open=3600.0,
+        auto_transition=True,
+    )
+    breaker = _breaker(config, fake_clock)
+    _trip(breaker)
+
+    await breaker.aclose()
+
+    assert breaker._engine._timer is None
+
+
+# --- runtime matching --------------------------------------------------------
+
+
+def test__close__on_an_async_coordinated_breaker__raises(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, astorage)
+
+    with pytest.raises(InterlockError, match='async storage'):
+        breaker.close()
+
+
+@pytest.mark.asyncio
+async def test__aclose__on_a_sync_coordinated_breaker__raises(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+
+    with pytest.raises(InterlockError, match='sync storage'):
+        await breaker.aclose()
+
+
+# --- registry ----------------------------------------------------------------
+
+
+def test__close_all__closes_every_breaker(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    registry = Registry(config=config, clock=fake_clock, storage=storage)
+    first = registry.get('a')
+    second = registry.get('b')
+    _sync_coordinator(first).ensure_lane()
+    _sync_coordinator(second).ensure_lane()
+
+    registry.close_all()
+
+    for breaker in (first, second):
+        thread = _sync_coordinator(breaker)._thread
+        assert thread is not None
+        assert not thread.is_alive()
+    assert registry.get('a') is first  # closed breakers stay cached; no silent restart
+
+
+@pytest.mark.asyncio
+async def test__aclose_all__closes_every_breaker(
+    config: Config, fake_clock: FakeClock, astorage: AsyncInMemoryStorage
+) -> None:
+    registry = Registry(config=config, clock=fake_clock, storage=astorage)
+    first = registry.get('a')
+    second = registry.get('b')
+    _async_coordinator(first).ensure_lane()
+    _async_coordinator(second).ensure_lane()
+
+    await registry.aclose_all()
+
+    for breaker in (first, second):
+        task = _async_coordinator(breaker)._lane_task
+        assert task is not None
+        assert task.done()


### PR DESCRIPTION
## Summary

A coordinated breaker owns background work that had no deterministic end. The lane — a daemon thread for a sync `Storage`, an asyncio task for an `AsyncStorage` — exited only once the coordinator was garbage collected and the next tick observed a dead weakref. The `auto_transition` timer was cancelled when the breaker left `OPEN`, never on teardown. So a service dropping a breaker could not flush queued shared writes, could not know when its threads were gone, and an async lane outliving `asyncio.run()` produced *"task was destroyed but it is pending"*.

This adds `CircuitBreaker.close()` / `aclose()` and `Registry.close_all()` / `aclose_all()`, over `SyncCoordinator.shutdown()` / `AsyncCoordinator.shutdown()`.

Shutdown drains queued writes in FIFO order, wakes a parked lane through a sentinel op rather than waiting out `poll_interval`, joins the thread or awaits the task, and cancels the timer without arming another. It is idempotent and safe to call from any thread. The weakref path stays as the safety net for abandoned breakers.

### Decisions the issue left open

- **Flush policy: drain.** Ops already queued run before the lane exits, so a trip recorded just before shutdown still reaches the backend. Writes the degraded gate would drop are still dropped.
- **Shutdown is terminal — the lane does not restart.** Afterwards the breaker keeps protecting calls on local state and drops shared writes, exactly as while the storage is degraded. `Registry.close_all()` keeps the cache, so `get()` returns the same torn-down instance instead of silently starting a fresh lane.
- **`close()` / `aclose()` follow the runtime-matching contract** already enforced on `call()`: calling the wrong one on a coordinated breaker raises `InterlockError` rather than silently leaving the lane running.
- **No context-manager support.** `with breaker:` is already the protected block; `contextlib.closing(breaker)` covers the need.

### One thing found while implementing

Dropping the lane without dropping the cached shared view leaves the breaker wedged: nothing refreshes the cache any more, so a peer's `OPEN` would never expire and every call would be rejected forever. `close()` therefore clears the view *after* the join (so no in-flight write can re-adopt it) and falls back to local state, reported through `on_state_change` like any other transition. Covered by `test__close__on_an_adopted_shared_open__falls_back_to_local_state`.

### Also fixes #97

Both lanes pulled an op off the queue *before* resolving the weak reference, so a lane stopping on a collected coordinator never called `task_done()`: `unfinished_tasks` stayed positive forever and `wait_idle()` could never return. Both drop paths now release the dequeued op. The issue rates this Low because nothing outside a test could reach the hang — the shutdown API is exactly what makes it reachable, which is why the two ship together.

### Tests

New `tests/test_shutdown.py` (24 tests) runs **real** lane threads and tasks with `poll_interval = 3600.0`, so shutdown has to wake the lane through the sentinel rather than wait it out. Covers: lane stopped and joined (sync + async), drain with writes in flight, shutdown while degraded, double shutdown, shutdown before the lane started, terminal semantics, timer cancelled and never re-armed, runtime mismatch, registry close-all, fallback to local state, and the `task_done()` drop-path invariant with `join()` guarded by a timeout.

`542 passed, 2 skipped`, coverage 100.00%.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy` and `uv run pyright` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #98
Closes #97