### PR TITLE
docs: state the definition of done and the sanctioned _notify exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,10 +181,31 @@ self._state = State.OPEN
 # rushes in as probes and knocks over the barely recovered dependency.
 ```
 
+## Definition of done
+
+A change is not finished when the tests pass. Before opening a PR:
+
+- **`CHANGELOG.md`** — add an entry under `[Unreleased]` (`Added` / `Fixed` / `Changed`). Describe
+  what was broken and why it mattered to a user, not just which symbol moved. Only the release
+  step dates the section and updates the link refs.
+- **`docs/`** — update the affected pages for any user-facing change, then regenerate the LLM
+  mirror: `uv run python scripts/build_llms_full.py`. A new page also goes into `docs/llms.txt`
+  under `## Docs` first. Commit the Markdown and `llms-full.txt` together.
+- **Coverage stays at 100%**; `ruff format`, `ruff check`, `mypy` and `pyright` all clean.
+- **Tests first.** A bug fix starts with a test that reproduces it; a feature starts with the
+  behaviour it must exhibit.
+
+The PR checklist in `.github/PULL_REQUEST_TEMPLATE.md` mirrors this — it is the last gate, not the
+first reminder.
+
 ## Hard rules (violation = bug)
 
 - **No fallback values**: never invent defaults to paper over missing data.
 - **No silent exceptions**: catch only what is expected, log with context, re-raise.
+  The one sanctioned exception is `interlock/_notify.py`: an `EventListener` hook is observability,
+  never policy, so a raising hook is logged with its traceback and swallowed rather than allowed to
+  fail the protected call or kill a coordinator lane. It is not silent, and `BaseException` still
+  propagates. Do not "fix" it, and do not generalise it — every other `except` obeys the rule.
 - **No default chains in business logic**: `a or b or c` is for UI labels only, never for
   required config or data.
 - **No hidden retries**: retries are acceptable only when explicitly requested, idempotent,


### PR DESCRIPTION
## Summary

Two gaps in `AGENTS.md` that have each cost rework already.

**1. The CHANGELOG and docs obligations lived only in the PR checklist.** They surface at review time rather than while the work happens, so a change could arrive at a PR complete in every respect except the two things a user actually reads. `#108` shipped its `CHANGELOG` entry only because the template got opened at the end.

Adds a **Definition of done** section naming them explicitly, together with the `llms-full.txt` regeneration step (previously documented only in `docs/CLAUDE.md`, which an agent working in `interlock/` never reads) and the tests-first expectation. The PR template is called out as the last gate, not the first reminder.

**2. The "no silent exceptions" hard rule now has a deliberate, shipped counter-example.** `interlock/_notify.py` logs a raising `EventListener` hook with its traceback and swallows it, so observability cannot replace a protected result, mask a dependency's exception, or kill a coordinator lane (#83). Without that written down, the next reader — human or agent — sees a blind `except Exception` in a codebase whose style guide forbids exactly that, and "fixes" it.

The note records the exception, states why it is not actually silent (`BaseException` still propagates, the traceback is logged), and bounds it so it is not read as licence to swallow anywhere else.

## Checklist

- [ ] Tests added or updated (suite stays at 100% coverage) — n/a, documentation only
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy` and `uv run pyright` pass
- [x] Docs updated (`docs/`) for user-facing changes — n/a, `AGENTS.md` is contributor-facing
- [ ] `CHANGELOG.md` `[Unreleased]` updated — n/a, no user-visible behaviour change
- [x] Commits follow Conventional Commits

## Related issues

None — follow-up housekeeping after #108 and #109.