### PR TITLE
test: model the state machine as a hypothesis RuleBasedStateMachine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   window counts add up under concurrent recording, `snapshot()` never returns a
   torn view, the HALF_OPEN caps (`max_concurrent_probes`,
   `permitted_calls_in_half_open`) are never exceeded, and a `Registry` hands out
-  exactly one breaker per name. No races were found; free-threaded builds are
-  not a distribution target (no wheels, no classifiers) — this verifies an
-  existing claim rather than making a new one.
+  exactly one breaker per name. No races were found; this verifies an existing
+  claim rather than making a new one. The package is pure Python, so one wheel
+  already serves both build flavours and the only distribution-level signal
+  left is metadata: it now declares
+  `Programming Language :: Python :: Free Threading :: 3 - Stable`.
+
+- The state machine is now also tested as a **model**
+  (`tests/test_state_machine_model.py`): a hypothesis `RuleBasedStateMachine`
+  generates the *sequence* of steps — interleaved outcomes, clock advances,
+  admissions, probe releases and operator overrides — rather than replaying a
+  hand-written one, and checks the machine against an independently predicted
+  state, generation, window aggregates and probe budget after every step.
+  The existing properties in `tests/test_state_machine_properties.py` target
+  documented boundaries directly and stay; this one looks for the transition
+  orders nobody thought to write down (an override during a probe round, a
+  probe settling an era late). No counterexample was found against the current
+  implementation.
 
 - `CircuitBreaker.close()` / `aclose()` and `Registry.close_all()` /
   `aclose_all()` — a deterministic way to release a breaker's background work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
     "Typing :: Typed",
 ]
 dependencies = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,32 @@ from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
+from hypothesis import strategies as st
 
+from interlock.config import Config
 from interlock.outcome import Outcome
 from interlock.state import State
+
+_LARGE_WINDOW = 500
+
+
+@st.composite
+def configs(draw: st.DrawFn) -> Config:
+    """Build a valid ``Config`` honouring the ``max_concurrent_probes`` bound.
+
+    Shared by the hypothesis suites over the state machine: the property tests
+    and the model-based one.
+    """
+    permitted = draw(st.integers(min_value=1, max_value=10))
+    return Config(
+        failure_rate_threshold=draw(st.floats(min_value=0.01, max_value=1.0)),
+        minimum_number_of_calls=draw(st.integers(min_value=1, max_value=20)),
+        slow_call_rate_threshold=draw(st.floats(min_value=0.01, max_value=1.0)),
+        permitted_calls_in_half_open=permitted,
+        max_concurrent_probes=draw(st.integers(min_value=1, max_value=permitted)),
+        wait_duration_in_open=draw(st.floats(min_value=1.0, max_value=100.0)),
+        window_size=_LARGE_WINDOW,
+    )
 
 
 class FakeClock:

--- a/tests/test_state_machine_model.py
+++ b/tests/test_state_machine_model.py
@@ -1,0 +1,279 @@
+"""Model-based test of the state machine (hypothesis ``RuleBasedStateMachine``).
+
+``test_state_machine_properties.py`` generates a config and then drives a
+*fixed*, hand-written sequence of calls, which finds arithmetic errors at the
+boundaries it is pointed at. This model generates the sequence itself —
+arbitrary interleavings of outcomes, clock advances, admissions and operator
+overrides — and shrinks any failure to a minimal reproducer. Order-dependent
+corruption (an override during a probe round, a probe settling after the state
+already moved) lives in exactly those interleavings.
+
+The model carries its own prediction of the state, the generation, the window
+aggregates and the probe budget, derived from the documented contract rather
+than read back from the machine, and asserts it after every step. Admissions
+flow through a bundle: an admitted call yields a ticket (the generation the
+call layer captures), and settling one consumes it — so probes can settle out
+of order, or long after their era ended.
+
+All time comes from ``FakeClock``; nothing here reads real time.
+"""
+
+from dataclasses import replace
+
+from hypothesis import settings
+from hypothesis import strategies as st
+from hypothesis.stateful import (
+    Bundle,
+    MultipleResults,
+    RuleBasedStateMachine,
+    consumes,
+    initialize,
+    invariant,
+    multiple,
+    rule,
+)
+
+from conftest import FakeClock, configs
+from interlock import Config, Outcome, State
+from interlock._state_machine import StateMachine
+
+_PERMIT_ALL = (State.CLOSED, State.DISABLED, State.METRICS_ONLY)
+
+# Every recorded outcome costs two steps (admit, then settle), so a large
+# `minimum_number_of_calls` would spend a whole run inside CLOSED and never
+# reach the probe round. Narrow that one field; the rest is `configs()`.
+_MODEL_CONFIGS = st.builds(
+    lambda config, minimum: replace(config, minimum_number_of_calls=minimum),
+    config=configs(),
+    minimum=st.integers(min_value=1, max_value=4),
+)
+
+
+class StateMachineModel(RuleBasedStateMachine):
+    """Drives a ``StateMachine`` against an independently predicted model of it."""
+
+    tickets = Bundle('tickets')
+
+    @initialize(config=_MODEL_CONFIGS)
+    def build(self, config: Config) -> None:
+        self.config = config
+        self.clock = FakeClock()
+        self.machine = StateMachine(config=config, clock=self.clock)
+        self.expected = State.CLOSED
+        self.override: State | None = None
+        self.era = self.machine.generation
+        self.opened_at = 0.0
+        self.total = 0
+        self.failed = 0
+        self.slow = 0
+        self._forget_probes()
+
+    @rule(fraction=st.floats(min_value=0.0, max_value=2.0))
+    def advance(self, fraction: float) -> None:
+        # Fractions of the open wait, so 1.0 lands exactly on the boundary.
+        self.clock.advance(self.config.wait_duration_in_open * fraction)
+
+    @rule(target=tickets)
+    def admit(self) -> int | MultipleResults[int]:
+        admits = self._admits()
+        begins_probing = self.expected is State.OPEN and admits
+
+        assert self.machine.acquire() is admits
+
+        if begins_probing:
+            self._to_half_open()
+        if not admits:
+            return multiple()
+        if self.expected is State.HALF_OPEN:
+            self.probes_in_flight += 1
+            self.probes_admitted += 1
+
+        return self.machine.generation
+
+    @rule(ticket=consumes(tickets), outcome=st.sampled_from(list(Outcome)))
+    def settle(self, ticket: int, outcome: Outcome) -> None:
+        self._predict_settle(ticket, outcome)
+        self.machine.record(outcome, generation=ticket)
+
+    @rule(ticket=consumes(tickets))
+    def release(self, ticket: int) -> None:
+        # What the call layer does when a BaseException interrupts a call: the
+        # outcome must not count, but the probe slot has to come back.
+        if ticket == self.era and self.expected is State.HALF_OPEN:
+            self.probes_in_flight -= 1
+            self.probes_admitted -= 1
+
+        self.machine.release_probe(generation=ticket)
+
+    @rule()
+    def auto_transition(self) -> None:
+        elapsed = self.expected is State.OPEN and self._wait_elapsed()
+
+        assert self.machine.attempt_auto_transition() is elapsed
+
+        if elapsed:
+            self._to_half_open()
+
+    @rule()
+    def force_open(self) -> None:
+        self.machine.force_open()
+        self._to_override(State.FORCED_OPEN)
+
+    @rule()
+    def disable(self) -> None:
+        self.machine.disable()
+        self._to_override(State.DISABLED)
+
+    @rule()
+    def metrics_only(self) -> None:
+        self.machine.metrics_only()
+        self._to_override(State.METRICS_ONLY)
+
+    @rule()
+    def reset(self) -> None:
+        self.machine.reset()
+        self.override = None
+        self._to_closed()
+
+    @invariant()
+    def state_is_predicted(self) -> None:
+        assert self.machine.state is self.expected
+
+    @invariant()
+    def generation_is_predicted(self) -> None:
+        # Every transition bumps it exactly once: the fence that stops an
+        # outcome from a previous era settling into the current one.
+        assert self.machine.generation == self.era
+
+    @invariant()
+    def override_is_authoritative(self) -> None:
+        # #79: only another override or a reset may clear an operator override.
+        if self.override is not None:
+            assert self.machine.state is self.override
+
+    @invariant()
+    def probe_budget_holds(self) -> None:
+        # Cross-checking the machine's own accounting surfaces a leaked or
+        # double-returned slot on the step it happens, rather than later as a
+        # rejected admission.
+        assert self.machine._probes_in_flight == self.probes_in_flight
+        assert self.machine._probes_admitted == self.probes_admitted
+        assert self.probes_in_flight <= self.config.max_concurrent_probes
+        assert self.probes_admitted <= self.config.permitted_calls_in_half_open
+
+    @invariant()
+    def window_matches_history(self) -> None:
+        snapshot = self.machine.snapshot()
+        assert snapshot.total_calls == self.total
+        assert snapshot.failed_calls == self.failed
+        assert snapshot.slow_calls == self.slow
+
+    @invariant()
+    def retry_after_is_the_remaining_wait(self) -> None:
+        if self.expected is not State.OPEN:
+            assert self.machine.retry_after() is None
+        else:
+            elapsed = self.clock.monotonic() - self.opened_at
+            assert self.machine.retry_after() == max(
+                0.0, self.config.wait_duration_in_open - elapsed
+            )
+
+    def _admits(self) -> bool:
+        if self.expected in _PERMIT_ALL:
+            return True
+        if self.expected is State.OPEN:
+            # The transition admits the triggering call as the first probe,
+            # and a fresh probe round always has room for one.
+            return self._wait_elapsed()
+        if self.expected is State.HALF_OPEN:
+            return (
+                self.probes_in_flight < self.config.max_concurrent_probes
+                and self.probes_admitted < self.config.permitted_calls_in_half_open
+            )
+        return False  # FORCED_OPEN
+
+    def _predict_settle(self, ticket: int, outcome: Outcome) -> None:
+        if ticket != self.era:
+            return  # A previous era's outcome is dropped: nothing moves.
+
+        if self.expected is State.CLOSED:
+            self._record_in_window(outcome)
+            if self.total >= self.config.minimum_number_of_calls and self._exceeds(
+                failure_rate=self.failed / self.total,
+                slow_call_rate=self.slow / self.total,
+            ):
+                self._to_open()
+        elif self.expected is State.METRICS_ONLY:
+            self._record_in_window(outcome)
+        elif self.expected is State.HALF_OPEN:
+            self._settle_probe(outcome)
+
+    def _settle_probe(self, outcome: Outcome) -> None:
+        self.probes_in_flight -= 1
+        self.probes_completed += 1
+        self.probe_failures += outcome.is_failure
+        self.probe_slows += outcome.is_slow
+
+        if self.probes_completed < self.config.permitted_calls_in_half_open:
+            return
+
+        if self._exceeds(
+            failure_rate=self.probe_failures / self.probes_completed,
+            slow_call_rate=self.probe_slows / self.probes_completed,
+        ):
+            self._to_open()
+        else:
+            self._to_closed()
+
+    def _record_in_window(self, outcome: Outcome) -> None:
+        self.total += 1
+        self.failed += outcome.is_failure
+        self.slow += outcome.is_slow
+
+    def _exceeds(self, *, failure_rate: float, slow_call_rate: float) -> bool:
+        return (
+            failure_rate >= self.config.failure_rate_threshold
+            or slow_call_rate >= self.config.slow_call_rate_threshold
+        )
+
+    def _wait_elapsed(self) -> bool:
+        elapsed = self.clock.monotonic() - self.opened_at
+        return elapsed >= self.config.wait_duration_in_open
+
+    def _to_open(self) -> None:
+        self.expected = State.OPEN
+        self.opened_at = self.clock.monotonic()
+        self._transition()
+
+    def _to_half_open(self) -> None:
+        self.expected = State.HALF_OPEN
+        self._transition()
+
+    def _to_closed(self) -> None:
+        self.expected = State.CLOSED
+        self.total = self.failed = self.slow = 0  # Closing rebuilds the window.
+        self._transition()
+
+    def _to_override(self, state: State) -> None:
+        self.expected = state
+        self.override = state
+        self._transition()
+
+    def _transition(self) -> None:
+        self.era += 1
+        self._forget_probes()
+
+    def _forget_probes(self) -> None:
+        self.probes_admitted = 0
+        self.probes_in_flight = 0
+        self.probes_completed = 0
+        self.probe_failures = 0
+        self.probe_slows = 0
+
+
+StateMachineModel.TestCase.settings = settings(
+    max_examples=200,
+    stateful_step_count=50,
+    deadline=None,
+)
+TestStateMachineModel = StateMachineModel.TestCase

--- a/tests/test_state_machine_properties.py
+++ b/tests/test_state_machine_properties.py
@@ -15,26 +15,9 @@ All time is driven through ``FakeClock`` so the runs stay deterministic.
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from conftest import FakeClock
+from conftest import FakeClock, configs
 from interlock import Config, Outcome, State
 from interlock._state_machine import StateMachine
-
-_LARGE_WINDOW = 500
-
-
-@st.composite
-def _configs(draw: st.DrawFn) -> Config:
-    """Build a valid ``Config`` honouring the ``max_concurrent_probes`` bound."""
-    permitted = draw(st.integers(min_value=1, max_value=10))
-    return Config(
-        failure_rate_threshold=draw(st.floats(min_value=0.01, max_value=1.0)),
-        minimum_number_of_calls=draw(st.integers(min_value=1, max_value=20)),
-        slow_call_rate_threshold=draw(st.floats(min_value=0.01, max_value=1.0)),
-        permitted_calls_in_half_open=permitted,
-        max_concurrent_probes=draw(st.integers(min_value=1, max_value=permitted)),
-        wait_duration_in_open=draw(st.floats(min_value=1.0, max_value=100.0)),
-        window_size=_LARGE_WINDOW,
-    )
 
 
 def _open(config: Config, clock: FakeClock) -> StateMachine:
@@ -45,7 +28,7 @@ def _open(config: Config, clock: FakeClock) -> StateMachine:
     return machine
 
 
-@given(config=_configs(), extra=st.integers(min_value=0, max_value=50))
+@given(config=configs(), extra=st.integers(min_value=0, max_value=50))
 def test__closed__saturated_failure_window__always_opens(config: Config, extra: int) -> None:
     machine = StateMachine(config=config, clock=FakeClock())
 
@@ -56,7 +39,7 @@ def test__closed__saturated_failure_window__always_opens(config: Config, extra: 
     assert machine.state is State.OPEN
 
 
-@given(config=_configs(), outcomes=st.lists(st.sampled_from(list(Outcome)), max_size=60))
+@given(config=configs(), outcomes=st.lists(st.sampled_from(list(Outcome)), max_size=60))
 def test__closed__below_minimum_calls__never_opens(config: Config, outcomes: list[Outcome]) -> None:
     machine = StateMachine(config=config, clock=FakeClock())
 
@@ -66,7 +49,7 @@ def test__closed__below_minimum_calls__never_opens(config: Config, outcomes: lis
     assert machine.state is State.CLOSED
 
 
-@given(config=_configs(), fraction=st.floats(min_value=0.0, max_value=0.999))
+@given(config=configs(), fraction=st.floats(min_value=0.0, max_value=0.999))
 def test__open__before_wait_elapsed__always_rejects(config: Config, fraction: float) -> None:
     clock = FakeClock()
     machine = _open(config, clock)
@@ -78,7 +61,7 @@ def test__open__before_wait_elapsed__always_rejects(config: Config, fraction: fl
 
 
 @settings(max_examples=200)
-@given(config=_configs(), attempts=st.integers(min_value=0, max_value=40))
+@given(config=configs(), attempts=st.integers(min_value=0, max_value=40))
 def test__half_open__probe_admission__never_exceeds_caps(config: Config, attempts: int) -> None:
     clock = FakeClock()
     machine = _open(config, clock)


### PR DESCRIPTION
## Summary

`tests/test_state_machine_properties.py` generates a config and then drives a
*fixed*, hand-written sequence — good at the boundaries it is pointed at, blind
to order-dependent corruption. This adds `tests/test_state_machine_model.py`: a
hypothesis `RuleBasedStateMachine` that generates the sequence as well, so an
override during a probe round or a probe settling an era late has somewhere to
show up.

- **Rules:** `advance` (fractions of the open wait, so `1.0` lands exactly on
  the boundary), `admit`, `settle`, `release`, `auto_transition`, `force_open`,
  `disable`, `metrics_only`, `reset`.
- **Bundle:** an admitted call yields a ticket — the generation the call layer
  captures — and `settle` / `release` consume one, so probes settle out of
  order, or an era late.
- **Invariants**, after every step, against the model's own prediction rather
  than values read back from the machine: state, generation (the stale-outcome
  fence), the #79 contract that no automatic transition undoes an operator
  override, the probe budget cross-checked against the machine's own
  accounting, window aggregates vs. the recorded history, and `retry_after()`
  as the remaining wait in OPEN.
- I/O-free: all time comes from `FakeClock`.

The `Config` strategy moves to `conftest.py` as `configs()`, now shared by both
hypothesis suites. The model narrows `minimum_number_of_calls` on top of it —
every recorded outcome costs two steps, so an unnarrowed run spends all 50
steps inside CLOSED and never reaches a probe round. The existing four
properties stay unchanged (bar the import).

No counterexample against the current implementation, so there is no regression
test to pin yet. Verified the model actually bites, by mutation:

| Mutation | Result |
|---|---|
| `_admit_probe`: `>=` → `>` on the concurrency cap | fails (`admit` predicted a rejection) |
| `record()`: drop the generation fence | fails (`window_matches_history`) |
| `release_probe()`: drop the generation/state guard | fails (`probe_budget_holds`, `-1 == 0`) |

Also here, since it is the same free-threading thread: `pyproject.toml` now
declares `Programming Language :: Python :: Free Threading :: 3 - Stable`.
There is no `3.14t` version classifier — free-threading is a separate trove
axis. CI has run the whole suite on 3.14t since #111 and
`tests/test_concurrency.py` backs the claim, but the metadata said nothing
about it. The #111 changelog entry asserted the opposite ("no wheels, no
classifiers"), so it is corrected in the same commit: the wheel half still
holds (pure Python — one wheel serves both flavours), the classifier half no
longer does. Verified with `twine check` on the built sdist and wheel.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — 548 passed,
      coverage 100%; the model file runs in ~1.0s (`max_examples=200`,
      `stateful_step_count=50`)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy` and `uv run pyright` pass
- [ ] Docs updated (`docs/`) for user-facing changes — n/a: no public API
      surface changed (the test-suite side is documented in `tests/CLAUDE.md`)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #106.
