### PR TITLE
ci: add pyrefly and move coverage reporting to Codecov

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 - [ ] Tests added or updated (suite stays at 100% coverage)
 - [ ] `uv run ruff format --check` and `uv run ruff check` pass
-- [ ] `uv run mypy` and `uv run pyright` pass
+- [ ] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
 - [ ] Docs updated (`docs/`) for user-facing changes
 - [ ] `CHANGELOG.md` `[Unreleased]` updated
 - [ ] Commits follow Conventional Commits

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,16 @@
+# The 100% gate is enforced by pytest itself (`fail_under` in pyproject.toml).
+# These statuses mirror it inside the PR so the gap is visible per-file before
+# the job turns red.
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 0%
+    patch:
+      default:
+        target: 100%
+
+comment:
+  layout: condensed_header, diff, files
+  require_changes: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,4 +13,7 @@ coverage:
 
 comment:
   layout: condensed_header, diff, files
-  require_changes: true
+  # The suite sits at 100%, so a PR that keeps it there produces no coverage
+  # *change* — with the default `require_changes`, Codecov would stay silent on
+  # exactly the PRs that are supposed to be boring. Always comment.
+  require_changes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-# Least-privilege default for every job; the coverage job overrides it with
-# the write scopes py-cov-action needs.
+# Least-privilege default for every job; nothing here writes to the repository —
+# the coverage comment and badge come from Codecov, not from a job.
 permissions:
   contents: read
 
@@ -60,6 +60,9 @@ jobs:
       - name: Pyright
         run: uv run pyright
 
+      - name: Pyrefly
+        run: uv run pyrefly check
+
       - name: Tests
         run: uv run pytest --cov
 
@@ -107,9 +110,6 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     env:
       INTERLOCK_TEST_REDIS_URL: redis://localhost:6379/0
     services:
@@ -134,9 +134,21 @@ jobs:
         run: uv sync --frozen
 
       - name: Run tests with coverage
-        run: uv run pytest --cov
+        run: >-
+          uv run pytest --cov --cov-report=xml
+          --junitxml=junit.xml -o junit_family=legacy
 
-      - name: Coverage badge and PR comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          GITHUB_TOKEN: ${{ github.token }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ wheels/
 .venv/
 venv/
 .coverage
+coverage.xml
+junit.xml
 .mypy_cache/
 .pytest_cache/
 .pytype/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,13 @@ repos:
         types: [python]
         pass_filenames: false
 
+      - id: pyrefly
+        name: pyrefly
+        entry: uv run pyrefly check
+        language: system
+        types: [python]
+        pass_filenames: false
+
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: v0.9.38
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - **hatchling** — build backend. The version is **static** in `interlock/version.py`
   (`[tool.hatch.version] path`), bumped manually on release and exposed as `interlock.__version__`.
 - **ruff** — formatting and linting.
-- **mypy + pyright** in strict mode — static analysis.
+- **mypy + pyright + pyrefly** in strict mode — static analysis.
 - **pytest** + `pytest-asyncio`, `pytest-cov`, `pytest-mock`, `pytest-sugar`, `faker`, `hypothesis`.
 - **Zensical** — documentation (plain-Markdown content, portable).
 
@@ -41,7 +41,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - Dependencies: `uv add <package>` / dev: `uv add --dev <package>`
 - Format: `uv run ruff format`
 - Lint: `uv run ruff check --fix`
-- Types: `uv run mypy` and `uv run pyright`
+- Types: `uv run mypy`, `uv run pyright` and `uv run pyrefly check`
 - Tests: `uv run pytest` / with coverage: `uv run pytest --cov`
 
 ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = "py311"`), not via
@@ -191,7 +191,8 @@ A change is not finished when the tests pass. Before opening a PR:
 - **`docs/`** — update the affected pages for any user-facing change, then regenerate the LLM
   mirror: `uv run python scripts/build_llms_full.py`. A new page also goes into `docs/llms.txt`
   under `## Docs` first. Commit the Markdown and `llms-full.txt` together.
-- **Coverage stays at 100%**; `ruff format`, `ruff check`, `mypy` and `pyright` all clean.
+- **Coverage stays at 100%**; `ruff format`, `ruff check`, `mypy`, `pyright` and `pyrefly` all
+  clean.
 - **Tests first.** A bug fix starts with a test that reproduces it; a feature starts with the
   behaviour it must exhibit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`reset()` does). The weakref-based collection path stays as the safety net
   for abandoned breakers.
 
+- **pyrefly** joins mypy and pyright as a third strict type checker in CI and in
+  the pre-commit hooks. Three independent implementations of the same type
+  system disagree in the corners, and the corners are exactly where a
+  signature-preserving decorator lives; a check the other two miss should fail
+  before a release, not in a user's editor. The whole package is clean under its
+  `strict` preset. `missing-override-decorator` is the one error kind turned off:
+  `typing.override` is 3.12+ and the core carries no `typing_extensions`
+  dependency to backport it.
+
+### Changed
+
+- Coverage reporting moved to **Codecov**. `pytest --cov` writes
+  `coverage.xml` plus a JUnit report and CI uploads both, so a PR now shows the
+  per-file coverage diff and the failing tests themselves rather than a single
+  total. The 100% gate is unchanged and still enforced by pytest
+  (`fail_under` in `pyproject.toml`); the Codecov statuses mirror it. This
+  replaces `py-cov-action/python-coverage-comment-action` and the badge branch
+  it maintained — the CI job no longer needs `contents: write` or
+  `pull-requests: write`.
+
 ### Fixed
 
 - A coordinator lane that exited while an op was in flight left the work queue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ uv run ruff format --check    # formatting
 uv run ruff check             # linting
 uv run mypy                   # type checking
 uv run pyright                # type checking (strict)
+uv run pyrefly check          # type checking (strict, third opinion)
 uv run pytest --cov           # tests with coverage
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # interlock
 
 [![CI](https://github.com/bagowix/interlock/actions/workflows/ci.yml/badge.svg)](https://github.com/bagowix/interlock/actions/workflows/ci.yml)
-[![Coverage](https://raw.githubusercontent.com/bagowix/interlock/python-coverage-comment-action-data/badge.svg)](https://github.com/bagowix/interlock/tree/python-coverage-comment-action-data)
+[![Coverage](https://codecov.io/gh/bagowix/interlock/branch/main/graph/badge.svg)](https://codecov.io/gh/bagowix/interlock)
 [![PyPI](https://img.shields.io/pypi/v/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![Downloads](https://img.shields.io/pypi/dm/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![Python versions](https://img.shields.io/pypi/pyversions/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
@@ -24,8 +24,8 @@ integrations at the transport level.
 - **Slow-call detection.** Treat calls slower than a threshold as failures —
   not available in any other Python circuit breaker.
 - **Type-safe.** `ParamSpec` + `TypeVar` decorators preserve the wrapped
-  signature *and* its sync/async nature; ships `py.typed`, passes mypy and
-  pyright in strict mode.
+  signature *and* its sync/async nature; ships `py.typed`, passes mypy,
+  pyright and pyrefly in strict mode.
 - **Zero-dependency core.** Standard library only; everything external lives in
   optional extras (`httpx2`, `aiohttp`, `requests`, `tenacity`, `fastapi`,
   `litestar`, `redis`, `otel`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,17 @@ include = ["interlock", "tests/typing_surface.py"]
 pythonVersion = "3.11"
 typeCheckingMode = "strict"
 
+[tool.pyrefly]
+project-includes = ["interlock", "tests/typing_surface.py"]
+python-version = "3.11"
+preset = "strict"
+
+[tool.pyrefly.errors]
+# typing.override is 3.12+, and the core carries no typing_extensions
+# dependency to backport it — the integrations' transport overrides cannot be
+# decorated while 3.11 is supported.
+missing-override-decorator = false
+
 [tool.pymarkdown]
 plugins.MD013.enabled = false   # line-length limit disabled
 plugins.MD029.style = "ordered" # consistent ordered list numbering
@@ -229,4 +240,5 @@ dev = [
     "httpx>=0.28.1",
     "pytest-xdist>=3.8.0",
     "pytest-codspeed>=5.0.3",
+    "pyrefly>=1.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,6 @@ dev = [
     "ruff>=0.15.18",
     "tenacity>=9.0.0",
     "types-requests>=2.31.0",
-    "ty>=0.0.55",
     "zensical>=0.0.46",
     "litestar>=2.24.0",
     "httpx>=0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -790,6 +790,7 @@ dev = [
     { name = "mypy" },
     { name = "opentelemetry-api" },
     { name = "prek" },
+    { name = "pyrefly" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -833,6 +834,7 @@ dev = [
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "opentelemetry-api", specifier = ">=1.43.0" },
     { name = "prek", specifier = ">=0.4.5" },
+    { name = "pyrefly", specifier = ">=1.2.0" },
     { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -1701,6 +1703,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/01/a86e9f24722b095c3f88e3616132b75a21b0df53804bdc6a45314dd4d93c/pyrefly-1.2.0.tar.gz", hash = "sha256:5485f960fc2481617068c918335c39ab1507ef90b6b5bd35bf57726e60e73185", size = 6243654, upload-time = "2026-08-01T02:56:27.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9d/3c0ef1d4843987b22f996ed381ec9cf5a3b1273e29804db276252e4c95eb/pyrefly-1.2.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7f46d983ac49ddd2b043694960a01dc6a19a5cfd8eec609d6bd9c42866f91b4e", size = 14026305, upload-time = "2026-08-01T02:56:02.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/06/03bbb78fbea54cdc65b626619f3597d5611aca4fdef11e72a4e8360e7e63/pyrefly-1.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:756f669b5555090f5c1a4fef30db1785fabe657764f7e4e6dc88994dfb8ca82d", size = 13463880, upload-time = "2026-08-01T02:56:04.93Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/7d8bc00a38e93bbc9c3e7bd14d305f7948717e667c9bcddeab9dd42fd255/pyrefly-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3465812ce5ef4781fb592edbf2724547296f0a3124be115d73c7e8b2401862d", size = 13907329, upload-time = "2026-08-01T02:56:07.104Z" },
+    { url = "https://files.pythonhosted.org/packages/be/94/9e08b4bf799d0b8f36b55a2783c7ba5f51730cf0632a85a67b5b5ed876cd/pyrefly-1.2.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5de7b2ad2bba5c8055181681a84b74143eac2234a48ba5d1b7ed7e7a722b02bd", size = 15039020, upload-time = "2026-08-01T02:56:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bd/bca5fd0c80f4daf8ee6903a29df9f3de1feb05ff0946b8f35ec8c5096b13/pyrefly-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25822ea9505f589ea8a725e4268b475132fb89e038fbf092e446510443ac142a", size = 14986199, upload-time = "2026-08-01T02:56:11.924Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/f07087f3d185ad2eced0c56cef89ca5474dfb4ff25f146cd50a861c97553/pyrefly-1.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90efe75e17491ef5d636e10469e9278d7d0256b3b4c5e1f4750069bf3ae0f5d1", size = 14393715, upload-time = "2026-08-01T02:56:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/70/0d142c320e284b9e3ce35e9b1e58b8ce2ee1f578f2a7234bc30e5022b94f/pyrefly-1.2.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:368aaf7eee4f511ddc0f8e564cf14e01ab2f10b0db9105c6d5b153bf498d07bf", size = 13933008, upload-time = "2026-08-01T02:56:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e8/e84f11b6e1f63fd453ad3654213b9a0f6f4de8cef6b58038eef2d0d5955d/pyrefly-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52d5da7bc65fb7675fbaa80eda879d4f8787c494f04cac21603330d3abbdbbe", size = 14431827, upload-time = "2026-08-01T02:56:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/810d31380f66c75e1c0779a408d3b16117b1b368b57894f6aa66bef21686/pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa", size = 13229447, upload-time = "2026-08-01T02:56:20.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/98/4dafa3c7a1caed2dc8cc708dde09ba27963c7736508f55b626fff3024113/pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170", size = 14087387, upload-time = "2026-08-01T02:56:23.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1c/df3cb0a2e5591660ded7a1836cd2f29dc48c91adb1c0a3a700a96f6d09e1/pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e", size = 13430873, upload-time = "2026-08-01T02:56:25.425Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -803,7 +803,6 @@ dev = [
     { name = "requests" },
     { name = "ruff" },
     { name = "tenacity" },
-    { name = "ty" },
     { name = "types-requests" },
     { name = "zensical" },
 ]
@@ -847,7 +846,6 @@ dev = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.15.18" },
     { name = "tenacity", specifier = ">=9.0.0" },
-    { name = "ty", specifier = ">=0.0.55" },
     { name = "types-requests", specifier = ">=2.31.0" },
     { name = "zensical", specifier = ">=0.0.46" },
 ]
@@ -2096,31 +2094,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
-]
-
-[[package]]
-name = "ty"
-version = "0.0.58"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/4c/26c90732658903aeb1d289208f7b7b492fa21029e0c4d6c51bdd6f8f5e51/ty-0.0.58.tar.gz", hash = "sha256:8f22484174e65c630660a454bf81b80cae7a3a7e70479f19c170d6cd87949258", size = 6133665, upload-time = "2026-07-10T03:09:30.542Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e1/5d1aa2a75829459834689f080e4be7a9d8828ce14b939ebed69161a35811/ty-0.0.58-py3-none-linux_armv6l.whl", hash = "sha256:47412850b6fbef61c42f244f6a51aa2f2c9e91f08cfbafd2d1e3730d2419d317", size = 11706915, upload-time = "2026-07-10T03:08:51.028Z" },
-    { url = "https://files.pythonhosted.org/packages/96/e1/929eda9cc72a9afe39a03c76f946a503508d37343cc8ff2e64226afda105/ty-0.0.58-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79deb7bb4e5b3a1eee6ab9abc724d6ce3559d4977982707f310a139ee11fc703", size = 11532079, upload-time = "2026-07-10T03:08:53.771Z" },
-    { url = "https://files.pythonhosted.org/packages/07/43/ebc58b3fc7d86a7abba2829f1674f7d4ae3a08f9794c1f31b707950c871f/ty-0.0.58-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a28af3187e661708a386d44a4fc32896a5f589fb07b734a11ab2f516e7572b7", size = 11092983, upload-time = "2026-07-10T03:08:56.025Z" },
-    { url = "https://files.pythonhosted.org/packages/92/6e/9547dbb8e51e47749cfb721a02b4fc862f9a932fa0f66a34a4d6dc429bb1/ty-0.0.58-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21a6977e34bc362fb378add46e59d5d56331c1c36727e6904767217ca8479718", size = 11490492, upload-time = "2026-07-10T03:08:58.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/76/9f83b51b5e7795d6c8d76b4bb1bb7cebf4c10d609e846c02ab138e404556/ty-0.0.58-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ac23e6bf6105ceca46632debf1b10b98125aaf60202aeae02f6abfeea242b3d", size = 11503696, upload-time = "2026-07-10T03:09:00.741Z" },
-    { url = "https://files.pythonhosted.org/packages/47/9d/9fd48a0696c680f74e50f31cd54e524eeb58c97ea9bb1c3b8e04230ba215/ty-0.0.58-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb6df6a8c6a21894807a49851370ec7fc64aa910296c78ada31db0ef19359112", size = 12158653, upload-time = "2026-07-10T03:09:02.998Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/ea/b5de845d2d8edae04d901c7585af7f04a057e18b26311f7fa4ca62b2da30/ty-0.0.58-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9df5847eebc026cde088b44420a03f7c6c169a7db747176bdf0a656eb1144713", size = 12723019, upload-time = "2026-07-10T03:09:05.291Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1c/54083b23eeff1e101f50b6df6a2c7f1e14b31abe0577c91bcae9e2c9395d/ty-0.0.58-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53a331a7f1f85872c810676a0f16096ef98c1b95c8c9a573fe7fde64d0a93e7c", size = 12275715, upload-time = "2026-07-10T03:09:07.564Z" },
-    { url = "https://files.pythonhosted.org/packages/22/88/16925434b06faa49d36aa7e7508a6821ec6feacb429ca2fd80a3d52716b4/ty-0.0.58-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb0b05cd479fdcedc2e6781d376ee1a33569f37ae7f58357004635f615c4374c", size = 12033075, upload-time = "2026-07-10T03:09:10.222Z" },
-    { url = "https://files.pythonhosted.org/packages/58/2b/b55708dd483982ae03d14da3667e3f0346cd384e11cca3dd3674a8b598c1/ty-0.0.58-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a0012786077e5becbb6add9fe51eda1d4d36d249afd3ae6cd141d554af15ae3", size = 12367729, upload-time = "2026-07-10T03:09:12.338Z" },
-    { url = "https://files.pythonhosted.org/packages/91/a3/99ad66652956408f7e9ac3db6b4a416199d773b6c073cf95b0eea126d340/ty-0.0.58-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4ede96d7f6d149156da254e784b062b817736b68d4c6d660555a3d02d96966fb", size = 11439798, upload-time = "2026-07-10T03:09:14.518Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/23/344ceed4fe02ed498711e1f4a47b6e311fb1e9c4fecc19d31894be7a3472/ty-0.0.58-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:47608e58f73901b989402e6f283249cda4c2314282ec368aa74ab61761c62bd5", size = 11512695, upload-time = "2026-07-10T03:09:16.852Z" },
-    { url = "https://files.pythonhosted.org/packages/55/cf/3801831812c468f3fd0b3043a80f557a9aa90e6c27375763d7c3121e03f2/ty-0.0.58-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9757de17cc17e4c6bc26e18d4e26dea52ffee53d41a10d9087c6465e6ab12e2b", size = 11812253, upload-time = "2026-07-10T03:09:19.151Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/80/bce4f245787b77d1ec9feec7d9161eade5e01a77dbc132e016b24df83b0d/ty-0.0.58-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f3776d54c1d935fcb8f814bd58efba402c86c555f93e1144c59d087e7aa8b906", size = 12123918, upload-time = "2026-07-10T03:09:21.636Z" },
-    { url = "https://files.pythonhosted.org/packages/46/00/bab3d6268e7e88c792bf7cdde81bd11b31aa587eaba75196502b729747c8/ty-0.0.58-py3-none-win32.whl", hash = "sha256:8f50ec0ac3b42baa4c75895dc367071dc86b00ab440d29fdc72c633286a94815", size = 11230897, upload-time = "2026-07-10T03:09:23.871Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/68/d9504c895864aaa84a840dce6ac7f8e681f6938be1882c8d4f60832dbe57/ty-0.0.58-py3-none-win_amd64.whl", hash = "sha256:de8847b3a65475ae4773bddd3126bfcf29f017e88967c4dcc9c75d743a4d3e5c", size = 12299376, upload-time = "2026-07-10T03:09:26.292Z" },
-    { url = "https://files.pythonhosted.org/packages/26/04/c9847cb680b5fe8e1f7d7b483edd5cedcc29394496e7b8ed40d96be796ba/ty-0.0.58-py3-none-win_arm64.whl", hash = "sha256:7334bb38789878f60677f2eb9c1de4bfdf4583e2443790989c77da9b10fe0989", size = 11710495, upload-time = "2026-07-10T03:09:28.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two CI changes, both about making an existing guarantee visible instead of asserted.

**pyrefly joins mypy and pyright** as a third strict type checker — in the
`quality` matrix and in the pre-commit hooks. Three independent implementations
of the same type system disagree in the corners, and the corners are exactly
where a signature-preserving `ParamSpec` decorator lives; a check the other two
miss should fail before a release, not in a user's editor.

The package is clean under pyrefly's `strict` preset as it stands — no source
changes were needed. `missing-override-decorator` is the one error kind turned
off (`[tool.pyrefly.errors]`): `typing.override` is 3.12+ and the core carries no
`typing_extensions` dependency to backport it, so the transport overrides in
`integrations/httpx2.py` and `integrations/requests.py` cannot be decorated while
3.11 is supported. The 4 existing `# type: ignore` comments are honoured as
suppressions, not re-reported.

**Coverage reporting moves to Codecov.** The `coverage` job now writes
`coverage.xml` plus a JUnit report and uploads both, so a PR shows the per-file
coverage diff and the failing tests themselves rather than one total. The 100%
gate is unchanged and still enforced by pytest (`fail_under` in
`pyproject.toml`); the statuses in `.github/codecov.yml` mirror it (project and
patch at 100%). This replaces `py-cov-action/python-coverage-comment-action` and
the badge branch it maintained — the job no longer needs `contents: write` or
`pull-requests: write`, so every job in `ci.yml` now runs on `contents: read`.

`secrets.CODECOV_TOKEN` is configured in the repository.

## Test plan

- [x] `uv run pyrefly check` — 0 errors (4 suppressed)
- [x] `uv run prek run --all-files` — all hooks pass, including the new `pyrefly` hook
- [x] `uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy`
      — 548 passed, 100.00% coverage, both reports well-formed XML
- [x] `ruff format --check`, `ruff check`, `mypy`, `pyright` unchanged and green
- [ ] CI on this PR: the `Pyrefly` step passes on 3.11–3.14 and 3.14t, and both
      Codecov uploads succeed (`fail_ci_if_error: true`, so a silent failure turns the job red)

## Follow-ups (not in this PR)

- The `python-coverage-comment-action-data` branch is now unused and can be deleted.
- `ty` has been an unused dev dependency since before this change; left alone here.

## Related issues

None — CI maintenance.