### PR TITLE
test: scope the model's probe-budget invariant to HALF_OPEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   documented boundaries directly and stay; this one looks for the transition
   orders nobody thought to write down (an override during a probe round, a
   probe settling an era late). No counterexample was found against the current
-  implementation.
+  implementation. The one sequence it did shrink pointed at the model instead:
+  a failed probe returns to `OPEN` without clearing the probe counters, which
+  is stale bookkeeping rather than a leak — nothing reads them outside
+  `HALF_OPEN`, and entering it starts the round over. The budget invariant is
+  now scoped to `HALF_OPEN`, where the contract defines it, and the sequence is
+  pinned as a regression test.
 
 - `CircuitBreaker.close()` / `aclose()` and `Registry.close_all()` /
   `aclose_all()` — a deterministic way to release a breaker's background work.

--- a/tests/test_state_machine_model.py
+++ b/tests/test_state_machine_model.py
@@ -155,9 +155,12 @@ class StateMachineModel(RuleBasedStateMachine):
     def probe_budget_holds(self) -> None:
         # Cross-checking the machine's own accounting surfaces a leaked or
         # double-returned slot on the step it happens, rather than later as a
-        # rejected admission.
-        assert self.machine._probes_in_flight == self.probes_in_flight
-        assert self.machine._probes_admitted == self.probes_admitted
+        # rejected admission. Only HALF_OPEN spends the budget, and every entry
+        # into it starts the counters over, so that is where they are part of
+        # the contract; elsewhere they are stale bookkeeping nobody reads.
+        if self.expected is State.HALF_OPEN:
+            assert self.machine._probes_in_flight == self.probes_in_flight
+            assert self.machine._probes_admitted == self.probes_admitted
         assert self.probes_in_flight <= self.config.max_concurrent_probes
         assert self.probes_admitted <= self.config.permitted_calls_in_half_open
 
@@ -277,3 +280,33 @@ StateMachineModel.TestCase.settings = settings(
     deadline=None,
 )
 TestStateMachineModel = StateMachineModel.TestCase
+
+
+def test__probe_budget__failed_probe_reopens__next_round_starts_full() -> None:
+    # The shrunk sequence that scoped `probe_budget_holds` to HALF_OPEN: a
+    # failed probe returns to OPEN without clearing the probe counters. They
+    # are stale there, not wrong — nothing reads them outside HALF_OPEN, and
+    # entering it starts the round over. This pins the part that is promised.
+    config = Config(
+        failure_rate_threshold=1.0,
+        minimum_number_of_calls=1,
+        permitted_calls_in_half_open=1,
+        max_concurrent_probes=1,
+        wait_duration_in_open=1.0,
+    )
+    clock = FakeClock()
+    machine = StateMachine(config=config, clock=clock)
+
+    assert machine.acquire()
+    machine.record(Outcome.FAILURE, generation=machine.generation)
+    assert machine.state is State.OPEN
+
+    clock.advance(config.wait_duration_in_open)
+    assert machine.acquire()
+    assert machine.state is State.HALF_OPEN
+    machine.record(Outcome.FAILURE, generation=machine.generation)
+    assert machine.state is State.OPEN
+
+    clock.advance(config.wait_duration_in_open)
+    assert machine.acquire()
+    assert machine.state is State.HALF_OPEN


### PR DESCRIPTION
## Summary

The `RuleBasedStateMachine` from #106 (#112) shrank a counterexample on `main`.
It reproduces locally but not in CI — hypothesis found it on a seed CI has not
drawn yet, so today it is a latent flake rather than a red build:

```
config: minimum_number_of_calls=1, failure_rate_threshold=1.0,
        permitted_calls_in_half_open=1, max_concurrent_probes=1
admit → settle(FAILURE)        # CLOSED → OPEN
advance(1.0)                   # the open wait elapses
admit → settle(FAILURE)        # HALF_OPEN probe fails → OPEN
```

At the last step the machine still holds `_probes_admitted == 1` while the model
predicted `0`: the model forgets the probe round on *every* transition, and the
machine clears it on entry to `HALF_OPEN` (`_to_half_open`) and `CLOSED`
(`_close`), not on `_open()`.

**The machine is right.** The counters are read only by `_admits_probe`, which
is reachable only in `HALF_OPEN`, and `HALF_OPEN` is only ever entered through
`_to_half_open()` — which resets them. Adding a reset to `_open()` would be
defensive code written for a test, not for a caller. What the model asserted
there was an internal detail the contract does not promise.

So `probe_budget_holds` now compares the machine's counters against the model
only in `HALF_OPEN`, where the budget is spent and the contract defines it; the
cap assertions (`max_concurrent_probes`, `permitted_calls_in_half_open`) stay
unconditional. No production code changes.

## Test plan

- [x] `uv run pytest tests/test_state_machine_model.py` passes, plus 6 explicit
      `--hypothesis-seed` runs
- [x] **Mutation check — the invariant still bites.** With the
      `self._probes_in_flight -= 1` line deleted from
      `StateMachine._record_probe` (a leaked probe slot), the scoped invariant
      fails within one run at the same assertion. Scoping removed the false
      alarm, not the sensitivity.
- [x] The shrunk sequence is pinned as
      `test__probe_budget__failed_probe_reopens__next_round_starts_full`, as
      `tests/CLAUDE.md` requires — it asserts what *is* promised: the next probe
      round starts from a full budget.
- [x] `uv run pytest --cov` — 549 passed, 100.00%
- [x] `uv run prek run --all-files` clean

## Related issues

Follow-up to #106 / #112. Independent of #113.