### PR TITLE
test: add mutation testing for the state machine and the engine

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,73 @@
+name: Mutation
+
+# 100% branch coverage proves every line runs; mutation testing asks whether any
+# assertion would notice if it changed. It runs out of band — the signal is a
+# slowly-moving score, not a per-commit gate — so it is never a required check
+# on a pull request.
+on:
+  schedule:
+    - cron: '0 4 * * 1' # Mondays, 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mutmut:
+    name: Mutation score
+    runs-on: ubuntu-latest
+    env:
+      # The floor, as in extras-min: compatibility is the matrix's job in ci.yml,
+      # and a mutation score is about what the tests assert, not about the
+      # interpreter. Pinning one keeps the number reproducible.
+      UV_PYTHON: '3.11'
+      # The survivors left are equivalent mutants, enumerated in CONTRIBUTING.md.
+      # Every new one is a test that would not have noticed the change; raise
+      # this only together with the list.
+      SURVIVOR_BUDGET: '23'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run mutation testing
+        run: uv run mutmut run
+
+      - name: Collect the score
+        if: ${{ !cancelled() }}
+        run: |
+          uv run mutmut export-cicd-stats
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, os, pathlib
+
+          stats = json.loads(pathlib.Path('mutants/mutmut-cicd-stats.json').read_text())
+          killed, survived, total = stats['killed'], stats['survived'], stats['total']
+          budget = int(os.environ['SURVIVOR_BUDGET'])
+          print('## Mutation score\n')
+          print(f'**{killed / total:.1%}** — {killed} killed, {survived} survived of {total}.\n')
+          print(f'Survivor budget: {survived}/{budget}.')
+          with pathlib.Path(os.environ['GITHUB_ENV']).open('a') as env:
+              env.write(f'SURVIVED={survived}\n')
+          PY
+
+      - name: Upload the report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutmut-stats
+          path: mutants/mutmut-cicd-stats.json
+
+      - name: Fail if new mutants survive
+        if: ${{ !cancelled() }}
+        run: |
+          if [ "$SURVIVED" -gt "$SURVIVOR_BUDGET" ]; then
+            echo "::error::$SURVIVED mutants survived, budget is $SURVIVOR_BUDGET."
+            echo 'Run `uv run mutmut results` and `uv run mutmut show <mutant>` locally.'
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage.xml
 junit.xml
 .mypy_cache/
 .pytest_cache/
+mutants/
 .pytype/
 *.pyc
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - **ruff** — formatting and linting.
 - **mypy + pyright + pyrefly** in strict mode — static analysis.
 - **pytest** + `pytest-asyncio`, `pytest-cov`, `pytest-mock`, `pytest-sugar`, `faker`, `hypothesis`.
+- **mutmut** — mutation testing over the state machine and the engine; out of band, never a PR gate.
 - **Zensical** — documentation (plain-Markdown content, portable).
 
 ## Environment and commands
@@ -43,6 +44,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - Lint: `uv run ruff check --fix`
 - Types: `uv run mypy`, `uv run pyright` and `uv run pyrefly check`
 - Tests: `uv run pytest` / with coverage: `uv run pytest --cov`
+- Mutants: `uv run mutmut run` (optional, out of band — see `CONTRIBUTING.md`)
 
 ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = "py311"`), not via
 CLI flags.
@@ -195,6 +197,8 @@ A change is not finished when the tests pass. Before opening a PR:
   clean.
 - **Tests first.** A bug fix starts with a test that reproduces it; a feature starts with the
   behaviour it must exhibit.
+- **Touching `_state_machine.py` or `_engine.py`?** Run `uv run mutmut run` as well. Coverage will
+  stay at 100% whether or not the new tests assert anything; a surviving mutant says they do not.
 
 The PR checklist in `.github/PULL_REQUEST_TEMPLATE.md` mirrors this — it is the last gate, not the
 first reminder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Mutation testing** (`mutmut`) over `interlock/_state_machine.py` and
+  `interlock/_engine.py` — the two modules where a surviving mutant is a real
+  bug. The 100% coverage gate proves every branch executes, not that anything
+  would notice if it changed, and the first run made that concrete: 105 of 549
+  mutants survived a fully covered suite. Killing them added tests for what the
+  suite was taking on trust — that probe accounting frees exactly one slot,
+  that a probe round is judged on rates rather than counts, that an era counter
+  is never reused, that `retry_after` is clamped and measured from the moment
+  the breaker opened, that a coordinated rejection still names its breaker and
+  its last failure, and that the `auto_transition` timer is armed and cancelled
+  exactly at the two moments it should be and by nothing else. The score is now
+  **526 of 549 (95.8%)**; the 23 survivors are equivalent mutants, enumerated by
+  class in `CONTRIBUTING.md`. It runs weekly out of band
+  (`.github/workflows/mutation.yml`), never as a pull-request gate, and against
+  the deterministic suite only — a randomised test that reaches a branch some of
+  the time makes the score irreproducible.
+
 - The test suite now runs on **free-threaded CPython (3.14t)** in CI, alongside
   3.11–3.14. interlock has always documented the breaker as thread-safe, but
   every interpreter in the matrix had a GIL, so nothing could falsify that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,40 @@ free-threading support, so importing it re-enables the GIL — and
 `filterwarnings = "error"` turns that warning into a collection error. Set
 `INTERLOCK_TEST_REDIS_URL` (CI does) and `fakeredis` is never imported.
 
+### Mutation testing
+
+The 100% coverage gate proves every line and branch runs; it does not prove any
+assertion would notice if the behaviour changed. `mutmut` closes that gap for
+the two modules where a surviving mutant is a real bug — `interlock/_state_machine.py`
+(thresholds, transitions, probe admission) and `interlock/_engine.py` (lock scope,
+dispatch, recording order):
+
+```bash
+uv run mutmut run                 # ~1 min; writes mutants/ (gitignored)
+uv run mutmut results             # what survived
+uv run mutmut show <mutant-name>  # the diff that survived
+```
+
+It is deliberately out of band: `.github/workflows/mutation.yml` runs it weekly
+and on demand, never as a pull-request gate. The score is measured against the
+deterministic suite only — the hypothesis suites are excluded, because a test
+that reaches a branch only sometimes makes both mutmut's test-selection mapping
+and the score itself irreproducible.
+
+Baseline: **526 of 549 mutants killed (95.8%)**. Every survivor is an equivalent
+mutant, in one of five classes:
+
+| Class | Why it cannot be killed |
+|---|---|
+| `_generation += 2`, and the initial `_generation = 1` | The era counter is only ever compared with `!=`. Any strictly increasing sequence behaves identically — what matters is that a value is never reused, which `test__generation__never_repeats_across_transitions` does check. |
+| `_opened_at = None` / `= 1.0` in `StateMachine.__init__` | Read only in `OPEN`, and `_open()` always writes it first. |
+| `_closed = None`, `_storage_degraded = None` | Used only as a boolean; `None` is as falsy as `False`. |
+| Dropping `retry_after=None` from `CircuitOpenError(...)` | The keyword repeats the constructor default. |
+| `_emit_transitions(..., after=None)` on paths that never enter `OPEN`, and the `_detach_shared_view` / storage-callback variants | The timer branch only reacts to `OPEN`; on these paths both arguments are equal, or the timer is already shut down. |
+
+If a run turns up a survivor outside those classes, it is a missing test — write
+it rather than raising `SURVIVOR_BUDGET` in the workflow.
+
 ### Benchmarks
 
 `benchmarks/` holds the performance suite, measured by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,44 @@ exclude_lines = [
 ]
 fail_under = 100
 
+[tool.mutmut]
+# 100% branch coverage proves every line runs, not that anything would notice if
+# it changed. Mutation testing is pointed at the two modules where a surviving
+# mutant is a real bug: the threshold arithmetic and transition ordering of the
+# state machine, and the lock scope, dispatch and recording order of the engine.
+# Run it out of band (`.github/workflows/mutation.yml`), never as a PR gate.
+source_paths = ["interlock"]
+only_mutate = ["interlock/_state_machine.py", "interlock/_engine.py"]
+# typing.cast is erased at runtime: mutating its first argument cannot change
+# behaviour, so those mutants are equivalent by construction.
+do_not_mutate_patterns = ["cast\\("]
+# mutmut runs pytest in-process and copies pyproject.toml into `mutants/`, so
+# the `-n auto` default would fork the collector away from it.
+pytest_add_cli_args = ["-n", "0", "-p", "no:cacheprovider"]
+# Excluded from the mutation suite, for three different reasons:
+#   - the wall-clock example runner and the extras integration tests cost
+#     minutes and exercise third-party code, not the two modules under mutation;
+#   - the hypothesis suites are randomised, and mutmut maps tests to functions
+#     from a single stats run — a test that reaches a branch only sometimes
+#     makes both that mapping and the score irreproducible. The score is a
+#     tracked number, so it is measured against the deterministic suite: a
+#     survivor then means a missing example-based test, every time.
+pytest_add_cli_args_test_selection = [
+  "tests",
+  "--ignore=tests/test_examples.py",
+  "--ignore=tests/test_aiohttp.py",
+  "--ignore=tests/test_fastapi.py",
+  "--ignore=tests/test_httpx2.py",
+  "--ignore=tests/test_httpx2_e2e.py",
+  "--ignore=tests/test_litestar.py",
+  "--ignore=tests/test_otel.py",
+  "--ignore=tests/test_redis_storage.py",
+  "--ignore=tests/test_requests.py",
+  "--ignore=tests/test_tenacity.py",
+  "--ignore=tests/test_state_machine_model.py",
+  "--ignore=tests/test_state_machine_properties.py",
+]
+
 [dependency-groups]
 dev = [
     "aiohttp>=3.14.1",
@@ -240,4 +278,5 @@ dev = [
     "pytest-xdist>=3.8.0",
     "pytest-codspeed>=5.0.3",
     "pyrefly>=1.2.0",
+    "mutmut>=3.7.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,24 +52,33 @@ def fake_clock() -> FakeClock:
 
 
 class RecordingListener:
-    """An EventListener that records every event it receives, for assertions."""
+    """An EventListener that records every event it receives, for assertions.
+
+    ``names`` collects the ``name`` every hook was given: it is how an event is
+    attributed to a breaker, so it is worth asserting on its own.
+    """
 
     def __init__(self) -> None:
         self.state_changes: list[tuple[State, State]] = []
         self.calls: list[tuple[Outcome, float]] = []
+        self.names: list[str] = []
         self.rejected = 0
         self.resets = 0
 
     def on_state_change(self, *, name: str, old: State, new: State) -> None:
+        self.names.append(name)
         self.state_changes.append((old, new))
 
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
+        self.names.append(name)
         self.calls.append((outcome, duration))
 
     def on_rejected(self, *, name: str) -> None:
+        self.names.append(name)
         self.rejected += 1
 
     def on_reset(self, *, name: str) -> None:
+        self.names.append(name)
         self.resets += 1
 
 

--- a/tests/test_auto_transition.py
+++ b/tests/test_auto_transition.py
@@ -1,16 +1,26 @@
-"""End-to-end tests for the auto-transition timer.
+"""Tests for the auto-transition timer.
 
-Unlike the deterministic FakeClock tests, these exercise the real
-``threading.Timer``: they use a short real ``wait_duration_in_open`` and wait on
-a thread-safe ``Event`` the listener sets when the breaker reaches ``HALF_OPEN``.
+The first half is end-to-end: unlike the deterministic FakeClock tests, they
+exercise the real ``threading.Timer`` with a short real ``wait_duration_in_open``
+and wait on a thread-safe ``Event`` the listener sets when the breaker reaches
+``HALF_OPEN``.
+
+The second half is about the timer's *lifecycle* rather than its firing — armed
+exactly when the local machine enters ``OPEN``, cancelled exactly when it leaves,
+and untouched by everything else. Those tests inspect ``Engine._timer`` directly
+and use a wait long enough that the real timer can never fire during them.
 """
 
 import asyncio
 import threading
+from collections.abc import Iterator
 
 import pytest
 
-from interlock import CircuitBreaker, Config, State
+from conftest import FakeClock
+from interlock import CircuitBreaker, CircuitOpenError, Config, State
+from interlock._engine import Engine
+from interlock.shared import SharedState
 
 _WAIT = 0.05
 
@@ -116,3 +126,139 @@ def test__auto_transition__force_open_before_timer__no_transition() -> None:
 
     assert not signal.reached_half_open.wait(_WAIT * 4)
     assert breaker.state is State.FORCED_OPEN
+
+
+# The timer is armed exactly when the local machine enters OPEN and cancelled
+# exactly when it leaves; nothing else may arm, cancel or re-arm it. A long real
+# wait keeps it from firing, while the FakeClock drives the machine's own view of
+# time, so every transition below happens on demand.
+
+_LONG_WAIT = 3600.0
+
+
+@pytest.fixture
+def timed_engine(fake_clock: FakeClock) -> Iterator[Engine]:
+    engine = Engine(
+        name='timed',
+        config=Config(
+            minimum_number_of_calls=2,
+            window_size=10,
+            permitted_calls_in_half_open=2,
+            max_concurrent_probes=2,
+            wait_duration_in_open=_LONG_WAIT,
+            auto_transition=True,
+        ),
+        clock=fake_clock,
+    )
+    yield engine
+    engine.close()
+
+
+def _trip_engine(engine: Engine) -> None:
+    def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            engine.call_sync(boom)
+
+
+def _armed(engine: Engine) -> threading.Timer:
+    timer = engine._timer
+    assert timer is not None
+    return timer
+
+
+def test__timer__armed_when_the_machine_opens(timed_engine: Engine) -> None:
+    _trip_engine(timed_engine)
+
+    assert _armed(timed_engine).daemon is True  # never blocks interpreter shutdown
+
+
+def test__timer__cancelled_when_a_probe_moves_the_machine_out_of_open(
+    timed_engine: Engine, fake_clock: FakeClock
+) -> None:
+    _trip_engine(timed_engine)
+    fake_clock.advance(_LONG_WAIT)
+
+    assert timed_engine.call_sync(lambda: 'probe') == 'probe'  # lazy OPEN -> HALF_OPEN
+
+    assert timed_engine._timer is None
+
+
+def test__timer__cancelled_by_reset(timed_engine: Engine) -> None:
+    _trip_engine(timed_engine)
+
+    timed_engine.reset()
+
+    assert timed_engine._timer is None
+
+
+def test__timer__cancelled_by_force_open(timed_engine: Engine) -> None:
+    _trip_engine(timed_engine)
+
+    timed_engine.force_open()
+
+    assert timed_engine._timer is None
+
+
+def test__timer__cleared_after_it_fires(timed_engine: Engine, fake_clock: FakeClock) -> None:
+    _trip_engine(timed_engine)
+    fake_clock.advance(_LONG_WAIT)
+
+    timed_engine._fire_auto_transition()
+
+    assert timed_engine.state is State.HALF_OPEN
+    assert timed_engine._timer is None
+
+
+def test__timer__survives_firing_before_the_wait_elapsed(timed_engine: Engine) -> None:
+    _trip_engine(timed_engine)
+    armed = _armed(timed_engine)
+
+    timed_engine._fire_auto_transition()  # the clock has not advanced yet
+
+    # The lazy path stays authoritative: an early wake-up transitions nothing,
+    # so it must not throw away the timer that is still owed a transition.
+    assert timed_engine.state is State.OPEN
+    assert timed_engine._timer is armed
+
+
+def test__timer__survives_a_rejected_call(timed_engine: Engine) -> None:
+    _trip_engine(timed_engine)
+    armed = _armed(timed_engine)
+
+    with pytest.raises(CircuitOpenError):
+        timed_engine.call_sync(lambda: 1)
+
+    assert timed_engine._timer is armed
+
+
+def test__timer__survives_a_stale_call_settling_after_the_trip(timed_engine: Engine) -> None:
+    start, admission = timed_engine.enter_block()  # admitted while CLOSED
+    _trip_engine(timed_engine)
+    armed = _armed(timed_engine)
+
+    timed_engine.exit_block(start=start, admission=admission, exception=ValueError('late'))
+
+    assert timed_engine._timer is armed
+
+
+def test__timer__survives_a_shared_view_update(timed_engine: Engine) -> None:
+    _trip_engine(timed_engine)
+    armed = _armed(timed_engine)
+
+    timed_engine._on_shared_view(SharedState.closed())
+
+    assert timed_engine._timer is armed
+
+
+def test__timer__survives_storage_degradation_and_recovery(timed_engine: Engine) -> None:
+    _trip_engine(timed_engine)
+    armed = _armed(timed_engine)
+
+    timed_engine._on_storage_degraded(ConnectionError('down'))
+    assert timed_engine._timer is armed
+
+    timed_engine._on_storage_recovered()
+    assert timed_engine._timer is armed

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -9,6 +9,7 @@ ticks run via ``poll_once()``, and fire-and-forget writes are awaited with
 import asyncio
 import gc
 import weakref
+from dataclasses import replace
 from typing import cast
 
 import pytest
@@ -60,9 +61,11 @@ class StorageEventsListener(RecordingListener):
         self.recovered: int = 0
 
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        self.names.append(name)
         self.degraded.append(error)
 
     def on_storage_recovered(self, *, name: str) -> None:
+        self.names.append(name)
         self.recovered += 1
 
 
@@ -1005,3 +1008,134 @@ def test__interrupted_leased_probe__not_returned_to_shared_budget(
     assert shared.state is State.HALF_OPEN
     assert shared.probes_remaining == 1
     assert shared.probes_completed == 0
+
+
+def test__shared_open__rejection__reports_the_breaker_and_its_last_failure(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    listener = RecordingListener()
+    breaker = _breaker(config, fake_clock, storage, listener)
+    _trip(breaker)
+    _coordinator(breaker).wait_idle()
+    _coordinator(breaker).poll_once()  # adopt its own trip as the shared view
+    listener.rejected = 0
+
+    with pytest.raises(CircuitOpenError) as exc_info:
+        breaker.call(lambda: 1)
+
+    # A shared trip carries no local wait to estimate from, but it must still
+    # say which breaker rejected the call and why it was open.
+    assert listener.rejected == 1
+    assert set(listener.names) == {NAME}
+    assert exc_info.value.breaker_name == NAME
+    assert exc_info.value.retry_after is None
+    assert isinstance(exc_info.value.last_failure, ValueError)
+
+
+def test__denied_lease__rejection__reports_the_breaker_and_its_last_failure(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    listener = RecordingListener()
+    a = _breaker(config, fake_clock, storage, listener)
+    b = _breaker(config, fake_clock, storage)
+    _trip(a)
+    _coordinator(a).wait_idle()
+    fake_clock.advance(WAIT)
+    _coordinator(a).poll_once()
+    _coordinator(b).poll_once()
+    assert a.call(lambda: 'probe-a') == 'probe-a'  # lease 1 of 2
+    assert b.call(lambda: 'probe-b') == 'probe-b'  # lease 2 of 2
+    listener.rejected = 0
+
+    with pytest.raises(CircuitOpenError) as exc_info:
+        a.call(lambda: 'probe-c')  # global budget spent
+
+    assert listener.rejected == 1
+    assert set(listener.names) == {NAME}
+    assert exc_info.value.breaker_name == NAME
+    assert exc_info.value.retry_after is None
+    assert isinstance(exc_info.value.last_failure, ValueError)
+
+
+def test__storage_events__are_attributed_to_the_breaker(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, flaky, listener)
+    flaky.fail = True
+    _coordinator(breaker).poll_once()
+
+    flaky.fail = False
+    fake_clock.advance(flaky.retry_backoff)
+    _coordinator(breaker).poll_once()
+
+    assert len(listener.degraded) == 1
+    assert listener.recovered == 1
+    assert set(listener.names) == {NAME}
+
+
+def test__leased_probe__settling_after_a_local_reset__is_dropped(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    _trip(breaker)
+    _coordinator(breaker).wait_idle()
+    fake_clock.advance(WAIT)
+    _coordinator(breaker).poll_once()
+    engine = breaker._engine
+    start, admission = engine.enter_block()  # leased probe, still running
+
+    breaker.reset()  # the operator resets the local machine under it
+    engine.exit_block(start=start, admission=admission, exception=ValueError('late'))
+
+    # The lease was granted in the era the reset ended: the outcome belongs to
+    # nobody and must not land in the fresh window.
+    assert breaker.snapshot().total_calls == 0
+
+
+# --- adopting a shared view ---
+
+
+def test__shared_view__newer_open__does_not_reset_the_local_machine(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    breaker = _breaker(config, fake_clock, flaky, listener=None)
+    _trip(breaker)
+    _coordinator(breaker).wait_idle()
+    _coordinator(breaker).poll_once()
+
+    storage.close(name=NAME, ttl=60.0)  # a peer closes, then trips again: newer OPEN
+    storage.trip_open(name=NAME, ttl=60.0)
+    _coordinator(breaker).poll_once()
+
+    # Only a shared *recovery* may cut a local OPEN short. Degrading afterwards
+    # hands protection back to the local machine, which is where the difference
+    # would show: a machine reset here would admit traffic to a dead dependency.
+    flaky.fail = True
+    _coordinator(breaker).poll_once()
+    assert breaker.state is State.OPEN
+
+
+def test__shared_view__closed_at_the_same_version__does_not_reset_the_local_machine(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    breaker = _breaker(config, fake_clock, storage)
+    _trip(breaker)
+    opened = SharedState(
+        state=State.OPEN,
+        opened_at=0.0,
+        version=7,
+        probes_permitted=0,
+        probes_remaining=0,
+        probes_completed=0,
+        probe_failures=0,
+        probe_slows=0,
+    )
+    breaker._engine._on_shared_view(opened)
+
+    breaker._engine._on_shared_view(replace(opened, state=State.CLOSED))
+
+    # Same version: a duplicate or out-of-order delivery, not a recovery.
+    assert breaker.state is State.OPEN

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -138,6 +138,17 @@ def test__call_sync__open_circuit__error_carries_last_failure(engine: Engine) ->
     assert str(exc_info.value.last_failure) == 'boom'
 
 
+def test__call_sync__forced_open__before_any_failure__error_has_no_last_failure(
+    engine: Engine,
+) -> None:
+    engine.force_open()
+
+    with pytest.raises(CircuitOpenError) as exc_info:
+        engine.call_sync(lambda: 1)
+
+    assert exc_info.value.last_failure is None
+
+
 def test__call_sync__forced_open__error_has_no_retry_after(engine: Engine) -> None:
     engine.force_open()  # operator override has no time-based estimate
 
@@ -313,3 +324,86 @@ def test__call_sync__base_exception_in_closed__records_nothing(engine: Engine) -
         engine.call_sync(interrupted)
 
     assert engine.snapshot().total_calls == 0
+
+
+class _BadPayloadIsFailure:
+    """Classifier that judges the returned value, not only raised exceptions."""
+
+    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+        return exception is not None or result == 'bad'
+
+
+class _NothingIsFailure:
+    """Classifier for which no call ever fails, exception or not."""
+
+    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+        return False
+
+
+def test__call_sync__failure_read_from_the_returned_value__records_failure(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    engine = Engine(name='t', config=config, clock=fake_clock, classifier=_BadPayloadIsFailure())
+
+    assert engine.call_sync(lambda: 'bad') == 'bad'
+
+    assert engine.snapshot().failed_calls == 1
+
+
+@pytest.mark.asyncio
+async def test__call_async__failure_read_from_the_returned_value__records_failure(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    engine = Engine(name='t', config=config, clock=fake_clock, classifier=_BadPayloadIsFailure())
+
+    async def bad() -> str:
+        return 'bad'
+
+    assert await engine.call_async(bad) == 'bad'
+
+    assert engine.snapshot().failed_calls == 1
+
+
+def test__call_sync__exception_the_classifier_forgives__is_not_the_last_failure(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    engine = Engine(name='t', config=config, clock=fake_clock, classifier=_NothingIsFailure())
+
+    def boom() -> None:
+        raise ValueError('boom')
+
+    with pytest.raises(ValueError, match='boom'):
+        engine.call_sync(boom)
+    engine.force_open()
+
+    # The exception reached the caller, but the classifier said it was not a
+    # failure — so it is not what a later rejection should point at.
+    with pytest.raises(CircuitOpenError) as exc_info:
+        engine.call_sync(lambda: 1)
+    assert exc_info.value.last_failure is None
+
+
+def test__call_sync__duration_exactly_at_the_slow_threshold__records_slow(
+    engine: Engine, fake_clock: FakeClock
+) -> None:
+    def borderline() -> None:
+        fake_clock.advance(1.0)  # == slow_call_duration_threshold
+
+    engine.call_sync(borderline)
+
+    assert engine.snapshot().slow_calls == 1
+
+
+def test__call_sync__forwards_positional_and_keyword_arguments(engine: Engine) -> None:
+    def echo(first: int, *, second: int) -> tuple[int, int]:
+        return first, second
+
+    assert engine.call_sync(echo, 1, second=2) == (1, 2)
+
+
+@pytest.mark.asyncio
+async def test__call_async__forwards_positional_and_keyword_arguments(engine: Engine) -> None:
+    async def echo(first: int, *, second: int) -> tuple[int, int]:
+        return first, second
+
+    assert await engine.call_async(echo, 1, second=2) == (1, 2)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -153,6 +153,18 @@ def test__metrics_only__records_but_never_trips(breaker: CircuitBreaker) -> None
     assert breaker.snapshot().total_calls == 5
 
 
+def test__every_event__is_attributed_to_the_breaker(
+    breaker: CircuitBreaker, listener: RecordingListener
+) -> None:
+    _trip(breaker)  # on_call x2 + on_state_change
+    with pytest.raises(Exception, match='open'):
+        breaker.call(lambda: 1)  # on_rejected
+    breaker.reset()  # on_reset + on_state_change
+
+    assert len(listener.names) == 6
+    assert set(listener.names) == {'svc'}
+
+
 def test__no_listener__operations_do_not_raise() -> None:
     breaker = CircuitBreaker(name='quiet')
 

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -462,3 +462,187 @@ def test__release_probe__outside_half_open__ignored(config: Config, fake_clock: 
 
     assert machine.state is State.CLOSED
     assert machine.acquire() is True
+
+
+def test__release_probe__stale_generation_in_a_later_round__ignored(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True
+    first_round = machine.generation
+    assert machine.acquire() is True
+    machine.record(Outcome.FAILURE, generation=first_round)
+    machine.record(Outcome.FAILURE, generation=first_round)  # round one fails -> OPEN
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True  # round two, probe 1 of 2
+
+    machine.release_probe(generation=first_round)  # a probe of round one, interrupted late
+
+    # Being in HALF_OPEN is not enough: the slot belonged to a round that is
+    # already over, and returning it would hand round two a third probe.
+    assert machine.acquire() is True
+    assert machine.acquire() is False
+
+
+def test__release_probe__frees_exactly_one_concurrency_slot(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(
+        config=replace(config, permitted_calls_in_half_open=4, max_concurrent_probes=1),
+        clock=fake_clock,
+    )
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True
+    machine.release_probe(generation=machine.generation)
+
+    assert machine.acquire() is True  # the interrupted probe gave its slot back
+    assert machine.acquire() is False  # and gave back exactly one
+
+
+def test__release_probe__returns_exactly_one_call_to_the_probe_budget(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True
+    machine.release_probe(generation=machine.generation)
+
+    # permitted_calls_in_half_open=2, and the released call spent none of it:
+    # exactly two probes may still run, not three.
+    assert machine.acquire() is True
+    machine.record(Outcome.SUCCESS)
+    assert machine.acquire() is True
+    assert machine.acquire() is False
+
+
+def test__half_open__permitted_cap__counts_settled_probes_too(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True
+    machine.record(Outcome.SUCCESS)  # settles, so the concurrency slot is free again
+
+    assert machine.acquire() is True  # the second and last permitted probe
+    assert machine.acquire() is False  # budget spent even though a slot is free
+
+
+def test__half_open__settled_probe__frees_exactly_one_concurrency_slot(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(
+        config=replace(config, permitted_calls_in_half_open=4, max_concurrent_probes=1),
+        clock=fake_clock,
+    )
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True
+    machine.record(Outcome.SUCCESS)
+
+    assert machine.acquire() is True
+    assert machine.acquire() is False
+
+
+def test__half_open__one_bad_probe_in_three__closes(config: Config, fake_clock: FakeClock) -> None:
+    machine = StateMachine(
+        config=replace(
+            config,
+            permitted_calls_in_half_open=3,
+            max_concurrent_probes=3,
+            slow_call_rate_threshold=0.5,
+        ),
+        clock=fake_clock,
+    )
+    _trip_to_open(machine, 2)
+    fake_clock.advance(5.0)
+    for _ in range(3):
+        assert machine.acquire() is True
+
+    machine.record(Outcome.SLOW_FAILURE)
+    machine.record(Outcome.SUCCESS)
+    machine.record(Outcome.SUCCESS)
+
+    # One of three probes failed and one was slow: both 1/3, under the 0.5
+    # thresholds. The round is judged on rates, not on counts.
+    assert machine.state is State.CLOSED
+
+
+def test__generation__never_repeats_across_transitions(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    seen = {machine.generation}
+
+    def assert_new_era() -> None:
+        # A reused generation would let an outcome admitted in an older era
+        # settle into the current one — the exact confusion the counter exists
+        # to prevent. Any transition must therefore mint a value never used yet.
+        assert machine.generation not in seen
+        seen.add(machine.generation)
+
+    _trip_to_open(machine, 2)
+    assert_new_era()
+    fake_clock.advance(5.0)
+    assert machine.acquire() is True
+    assert_new_era()
+    assert machine.acquire() is True
+    machine.record(Outcome.FAILURE)
+    machine.record(Outcome.FAILURE)
+    assert_new_era()
+    machine.force_open()
+    assert_new_era()
+    machine.disable()
+    assert_new_era()
+    machine.metrics_only()
+    assert_new_era()
+    machine.reset()
+    assert_new_era()
+
+
+def test__open__retry_after__measured_from_the_moment_it_opened(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    fake_clock.advance(10.0)  # the breaker does not open at t=0
+    _trip_to_open(machine, 2)
+    fake_clock.advance(2.0)
+
+    assert machine.retry_after() == 3.0
+
+
+def test__open__retry_after__is_zero_once_the_wait_elapsed(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    machine = StateMachine(config=config, clock=fake_clock)
+    _trip_to_open(machine, 2)
+    fake_clock.advance(config.wait_duration_in_open * 2)
+
+    # A caller that sleeps for retry_after must not be sent away again: the
+    # wait is over and the next call is the probe.
+    assert machine.retry_after() == 0.0
+
+
+def test__close__time_based_window__is_rebuilt_with_the_injected_clock(
+    fake_clock: FakeClock,
+) -> None:
+    config = Config(
+        window_type=WindowType.TIME_BASED,
+        window_size=10,
+        minimum_number_of_calls=2,
+        permitted_calls_in_half_open=2,
+        max_concurrent_probes=2,
+        wait_duration_in_open=5.0,
+    )
+    machine = StateMachine(config=config, clock=fake_clock)
+    machine.record(Outcome.FAILURE)
+    machine.record(Outcome.FAILURE)
+
+    machine.reset()  # the fresh window still needs a clock to bucket by
+    machine.record(Outcome.SUCCESS)
+
+    assert machine.snapshot().total_calls == 1

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,9 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -787,6 +789,7 @@ dev = [
     { name = "httpx2" },
     { name = "hypothesis" },
     { name = "litestar" },
+    { name = "mutmut" },
     { name = "mypy" },
     { name = "opentelemetry-api" },
     { name = "prek" },
@@ -830,6 +833,7 @@ dev = [
     { name = "httpx2", specifier = ">=2.4.0" },
     { name = "hypothesis", specifier = ">=6.155.7" },
     { name = "litestar", specifier = ">=2.24.0" },
+    { name = "mutmut", specifier = ">=3.7.0" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "opentelemetry-api", specifier = ">=1.43.0" },
     { name = "prek", specifier = ">=0.4.5" },
@@ -860,6 +864,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "libcst"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version != '3.13.*'" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/c0/098e5c91ff1537f00c85a6438b6cb1863d17144680cc91f47c87f104a200/libcst-1.9.0.tar.gz", hash = "sha256:087b58a9afe076bb08e2d726478e1f16cb928d67ffa9092817e033c335de522a", size = 914739, upload-time = "2026-07-29T21:28:43.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/36/b45e6950878d9143f95db609432031ac688b311aa14450a8df239c648c45/libcst-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cdbafbc992b38ea005ef37e20243c4177879020c82d414789fbb7fa22d6d3a9", size = 2054911, upload-time = "2026-07-29T19:24:38.542Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d8/1c1ae22e05fbc763dc5a4e4c3cab356166913ef19d2c2da42e6f1be5c98c/libcst-1.9.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3f735e3acb3afc75d50803fde1598b467bf05d12d6854025df4398aebd75a14c", size = 2209147, upload-time = "2026-07-29T19:24:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e1/0d5eaeac4dadd34fcd9ea154d0a6e5ce10c9fec0e02c73f807a16475b8b0/libcst-1.9.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:951f13c193e590fc88c9582a5341a130fe53ecece51043cff4bd54e25a5e022d", size = 2260355, upload-time = "2026-07-29T19:24:41.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b2/45ce33c6bca5c1961a90f2999138741daa0dc8cf6fe8b122c0ca2502632d/libcst-1.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bc6aa3e7f21315dbe9868c0d13ffaac309514e8c816320c5f91230fa5b21df92", size = 2275659, upload-time = "2026-07-29T19:24:42.828Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b1/936d2f17d93fb160579ff56ca671d26154209bbc07ea8645eb11db1f9633/libcst-1.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f101e0bf8638eba80694ecc3c3abb5309eb488f5271427536cb379c5c1e0ba9e", size = 2383467, upload-time = "2026-07-29T19:24:44.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/59/db667f15d62cb22c75b24f6b13c4151292aa1889a64ff9abce92f60d5a97/libcst-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:77d9303572cf0fbd0a2eb71aff167a4246541f43bf58b781b35b9d0bbab80ddc", size = 2109985, upload-time = "2026-07-29T19:24:45.966Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a8/99926865cd3f97c0cffc71cd38152c883b7ae666eb8327d355f01bddb33a/libcst-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:4090105fa4ad114766d0f8b34418d9a3b359bc8645da860a447e19770b5705d1", size = 1988559, upload-time = "2026-07-29T19:24:47.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/bb/d22c37c33dfe18084634f5ef89f8f0749ffe7b6e0ad312722aafd86bbbdb/libcst-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd1a3500c41784075c4946a995d5ad89f68fa0d226b63ff3c4d78f6ea6dd23e5", size = 2043159, upload-time = "2026-07-29T19:24:49.013Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b8/2dedef84d72e7271119217503b69ed6dc5d0b2077685e163caae669d9c70/libcst-1.9.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:611cebd3bbc2014576f4dcc7b845b3c594c96ddc287a3db9b78f22eff156a7d3", size = 2203245, upload-time = "2026-07-29T19:24:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/90/e02ac2dad647423f947bb11f8322bfdba8ccfdd380e6c7b695add2d1acd4/libcst-1.9.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8d731abe1307720ea1a52d447555e8443a6d130e0e520243c0634a58f6edbc9d", size = 2255388, upload-time = "2026-07-29T19:24:52.21Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5f/6089a51518cfd2ff40950eb26bcc36951d7b6d4f4213568aa0290265aff7/libcst-1.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8bc5351d92ca6ac1cc32e097700e1161ad1ceaa4d9b2cca5abadb1e94576b325", size = 2268982, upload-time = "2026-07-29T19:24:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/78/26881ec466fb70cbc129dca26ccb5a52a0061face2c5822e4b61f00f9699/libcst-1.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03165a264653bb77f6a11b412ae09c08bdb0c25864f3b8d42b816ac64b9d4b9e", size = 2378174, upload-time = "2026-07-29T19:24:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/7a/a4dba5f11faf12a12ffba06d18019987851aab33b590242a602ffd4fb1bd/libcst-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:b755ed4a4bc2faee849b54820023137d60d4c199e0a0822f0ff0c1bc49e49b48", size = 2103462, upload-time = "2026-07-29T19:24:56.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/13/57cb129093e0d6744b3c914ba6cbbdf51ed1b2c823882936c553a3a0cf1b/libcst-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e50576bad7d56459d9792cd0b0dfe5469dad13646e9a9c0a8b1ba20b269f332", size = 1979825, upload-time = "2026-07-29T19:24:58.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b1/befc0544283bb3923a928accf79ed685e5a725524bdb3491826670affc07/libcst-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b8b9df30f524317b097dc53065b25dda33d6a4cc3c7c8bf4fc83ca7559c58cc0", size = 2043754, upload-time = "2026-07-29T19:24:59.885Z" },
+    { url = "https://files.pythonhosted.org/packages/45/50/fef7c172a8457c95894edf5fb04805024899cdfea41fa01b0636587b79e1/libcst-1.9.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e465a7bc9c2b9533eb9e06d2391f8819f811b5112919d4064c9fb8565aaafa08", size = 2203548, upload-time = "2026-07-29T19:25:01.323Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ff/764cd2be1fd99d774fc44039c319dc0ed1d9d9afeaa02759a05121cccd4b/libcst-1.9.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8504b422c95676a8c27b517e1ac01413ece91bf356865c587ca9bdcd5708a2f7", size = 2255274, upload-time = "2026-07-29T19:25:02.764Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a7/474748a27a02fa83e3556b260d5f5236ca48164fa7beffecf3b2cad24dca/libcst-1.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bcb9f9d4fcfe2ec7a40d2c26e03a538d5d9dc189c38551eb3f94ab661afee7c0", size = 2269126, upload-time = "2026-07-29T19:25:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b7/655e45363b8cf87b91e41e060b21c89e5316c7ef36eb14a1a498b27bb71e/libcst-1.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8d671c39a431c309476099b8ec811e412503ec0f4465f6fc907cb51c70e8e6b", size = 2378602, upload-time = "2026-07-29T19:25:06.424Z" },
+    { url = "https://files.pythonhosted.org/packages/db/13/6da63f0902ece43bf9d737017251ad7ad06edd9d3c4e1856450403cb4473/libcst-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:4d382fba04077eb556a1ea4295a4482e192aa93639c5a07ba0885841965ea0c0", size = 2103486, upload-time = "2026-07-29T19:25:07.979Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ff/dccb1a55e38b4e47256a97242d61d2bef5366c744faf88fb087d4fa0f995/libcst-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:a621e261990148c1cfbe26c1798bd2375c131cf358a44a7a4659fc41c1a336e1", size = 1979907, upload-time = "2026-07-29T19:25:09.532Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2a/4943c71d90975bc59034a057dea346b365c276f308c1d31f5cf2bd85492d/libcst-1.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eccf4c57d273cdd3fe1c67b72cf9bb1bbd4547aa011824e96ccf5b7136057aa4", size = 2044529, upload-time = "2026-07-29T19:25:11.04Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ed/1168b98c2a0f338be3a44753647baab051feaf6167cc887bf4447f8fd920/libcst-1.9.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32395244edfe6538e0ea2bf82051d60103d3f54861274805c4fb3745efb70a85", size = 2203519, upload-time = "2026-07-29T19:25:12.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7d/2eaa697a80f899bcf2245680bbfcc1e478eb3b3328c21d4b2880bdf00dac/libcst-1.9.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:444e84c76cd035cd2fe136838c1a524d34b08216521f6f5093df8a6f6cfa5799", size = 2255879, upload-time = "2026-07-29T19:25:14.137Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/793b9fd96dd52d202f5f2b88d7e54f05ebed767d1bb3b32395a1817bf6ab/libcst-1.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb5d0946f2b4c6711b5d69fe4f833b364f9e7a1a2b08f88b98619dc18975099a", size = 2269807, upload-time = "2026-07-29T19:25:15.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f4/1bc7aaea03971c45e8a885fed9fc1c73176dbbd00b0296a3cde9529bafd6/libcst-1.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45808c03528b3ad40b14095348a918e08d98c47b4a125d631cb78e817c0a5b16", size = 2378171, upload-time = "2026-07-29T19:25:17.289Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f7/bc49e367d2bc8817213594dd52cf6b2da2dbbda90b5382d60653999274ac/libcst-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:568288cdbfe3b4ca3ae4852cb0a439ff053dd54c841bc4995bf2b71238b5de40", size = 2177847, upload-time = "2026-07-29T19:25:19.35Z" },
+    { url = "https://files.pythonhosted.org/packages/87/80/4d81577a22e6d535d1a3409f3a1c6903e09036f0e17fc47f92169dbc3501/libcst-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:107593af46945593e7825821793393262bc4fa1d3ea24c3ed487b61269bbbdf8", size = 2058134, upload-time = "2026-07-29T19:25:20.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7f/c3f3a0e7a1a2adaa76e815e82a7814d6bfe7d49432276bba652248c68d0b/libcst-1.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f6248cb07444ab9a6733a855737a9febed8b9adca51347019348b09a3ac7dfe9", size = 2036102, upload-time = "2026-07-29T19:25:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/af/2f5543255b2c7d749b966adeccc6bfb1652cf8b425afb913d0f3f025a865/libcst-1.9.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:496c24e0d3240bc7da45dae543aff3f5b6509978c39262d6b84ed2fb999dded2", size = 2194806, upload-time = "2026-07-29T19:25:24.017Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/03f4cddce426d005e208b39ea7b2d456e667cdee0f1891360f0fc8430f20/libcst-1.9.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ea490fa8540503db5f321f0268becab46eb50f710e8cec8041e241fd66f6874f", size = 2246762, upload-time = "2026-07-29T19:25:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/31/9d5fe1e43dc3dbcc74f70f3e0e73fcdd8d84effc1059d8b45974f0d0d2eb/libcst-1.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:50ab94bb2524b419056d4003032b8c67102ac800f8d85b3c4260a01746d94dbb", size = 2259633, upload-time = "2026-07-29T19:25:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/6752b28d88c3a19b3bc0b9e1838443b6760d5c862b4f4b37955402659e24/libcst-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a2faaf92500d0226358125630f5aab4758e8aad3f2d70a10892ec3c700781a54", size = 2368043, upload-time = "2026-07-29T19:25:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/94/775825b2637f8ab05694b6a4b3802ae6783b4e799f9b58d2400c7e2d4369/libcst-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0c7b548512db25af9c2997a95fa731bd6b6928ecbad6c0915d7482d8bb42d34f", size = 2176432, upload-time = "2026-07-29T19:25:29.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/88ad67427c6fd9db929e087912b0a540e5140e5cb77e7ca4170edaac8531/libcst-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:497d5329345f1f5df84e41b0bbd00204b64a2fd30dfe3cfaeaebca633a31e877", size = 2052931, upload-time = "2026-07-29T19:25:31.397Z" },
 ]
 
 [[package]]
@@ -935,6 +986,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/99/6203ce619dee940d6bfbe099ec3fe4be00a68e9d60f70abf906cf124fe66/librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18", size = 104357, upload-time = "2026-07-08T12:26:09.828Z" },
     { url = "https://files.pythonhosted.org/packages/52/dd/843b6314087c41657c7036d7914d8f294bdf9b580aa8513ea0588c8e9a3d/librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259", size = 126998, upload-time = "2026-07-08T12:26:10.975Z" },
     { url = "https://files.pythonhosted.org/packages/5f/5d/3dcec2884ba1b0806d1408612555c38dd5d68e90156b59f75f6e36435c3a/librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99", size = 110771, upload-time = "2026-07-08T12:26:12.303Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
 ]
 
 [[package]]
@@ -1050,6 +1113,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
@@ -1122,6 +1190,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -1308,6 +1388,23 @@ wheels = [
 ]
 
 [[package]]
+name = "mutmut"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coverage" },
+    { name = "libcst" },
+    { name = "pytest" },
+    { name = "setproctitle" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/f9/a63500696f3f35c443ef566528e55630bf7e064436416278927f7bc9c408/mutmut-3.7.0.tar.gz", hash = "sha256:dc93260fabb3a6fd3693aa8d1746825885cb6f9e66c7f9cc1a0f34fc6388e14a", size = 63735, upload-time = "2026-07-31T10:52:58.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/16/93e3e6aa30e5bc4141724463ae9d9bcc283d08b02aa85dbf5a2b665f3108/mutmut-3.7.0-py3-none-any.whl", hash = "sha256:1d2f9a1bfa4a474b2213df6b17223150b492bf4a85af0eda4fb322297337fb32", size = 59070, upload-time = "2026-07-31T10:53:00.005Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1405,6 +1502,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -1906,6 +2012,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-ft"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/5a0d575de784f9a1f94e2b1288c6886f13f34185e13117ed530f32b6f8a8/pyyaml_ft-8.0.0.tar.gz", hash = "sha256:0c947dce03954c7b5d38869ed4878b2e6ff1d44b08a0d84dc83fdad205ae39ab", size = 141057, upload-time = "2025-06-10T15:32:15.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/ba/a067369fe61a2e57fb38732562927d5bae088c73cb9bb5438736a9555b29/pyyaml_ft-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8c1306282bc958bfda31237f900eb52c9bedf9b93a11f82e1aab004c9a5657a6", size = 187027, upload-time = "2025-06-10T15:31:48.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c5/a3d2020ce5ccfc6aede0d45bcb870298652ac0cf199f67714d250e0cdf39/pyyaml_ft-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30c5f1751625786c19de751e3130fc345ebcba6a86f6bddd6e1285342f4bbb69", size = 176146, upload-time = "2025-06-10T15:31:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/23a9739291086ca0d3189eac7cd92b4d00e9fdc77d722ab610c35f9a82ba/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa992481155ddda2e303fcc74c79c05eddcdbc907b888d3d9ce3ff3e2adcfb0", size = 746792, upload-time = "2025-06-10T15:31:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/e8825f4ff725b7e560d62a3609e31d735318068e1079539ebfde397ea03e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec6c92b4207004b62dfad1f0be321c9f04725e0f271c16247d8b39c3bf3ea42", size = 786772, upload-time = "2025-06-10T15:31:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/58a4dcae8854f2fdca9b28d9495298fd5571a50d8430b1c3033ec95d2d0e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b", size = 778723, upload-time = "2025-06-10T15:31:56.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/fed0da92b5d5d7340a082e3802d84c6dc9d5fa142954404c41a544c1cb92/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a7f332bc565817644cdb38ffe4739e44c3e18c55793f75dddb87630f03fc254", size = 758478, upload-time = "2025-06-10T15:31:58.314Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/69/ac02afe286275980ecb2dcdc0156617389b7e0c0a3fcdedf155c67be2b80/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d10175a746be65f6feb86224df5d6bc5c049ebf52b89a88cf1cd78af5a367a8", size = 799159, upload-time = "2025-06-10T15:31:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/c492a9da2e39abdff4c3094ec54acac9747743f36428281fb186a03fab76/pyyaml_ft-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:58e1015098cf8d8aec82f360789c16283b88ca670fe4275ef6c48c5e30b22a96", size = 158779, upload-time = "2025-06-10T15:32:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9b/41998df3298960d7c67653669f37710fa2d568a5fc933ea24a6df60acaf6/pyyaml_ft-8.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb", size = 191331, upload-time = "2025-06-10T15:32:02.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/16/2710c252ee04cbd74d9562ebba709e5a284faeb8ada88fcda548c9191b47/pyyaml_ft-8.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8d445bf6ea16bb93c37b42fdacfb2f94c8e92a79ba9e12768c96ecde867046d1", size = 182879, upload-time = "2025-06-10T15:32:04.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/40/ae8163519d937fa7bfa457b6f78439cc6831a7c2b170e4f612f7eda71815/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c56bb46b4fda34cbb92a9446a841da3982cdde6ea13de3fbd80db7eeeab8b49", size = 811277, upload-time = "2025-06-10T15:32:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/28d82dbff7f87b96f0eeac79b7d972a96b4980c1e445eb6a857ba91eda00/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dab0abb46eb1780da486f022dce034b952c8ae40753627b27a626d803926483b", size = 831650, upload-time = "2025-06-10T15:32:08.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/df/161c4566facac7d75a9e182295c223060373d4116dead9cc53a265de60b9/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd48d639cab5ca50ad957b6dd632c7dd3ac02a1abe0e8196a3c24a52f5db3f7a", size = 815755, upload-time = "2025-06-10T15:32:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
 name = "redis"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1985,6 +2115,77 @@ wheels = [
 ]
 
 [[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/cd/1b7ba5cad635510720ce19d7122154df96a2387d2a74217be552887c93e5/setproctitle-1.3.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0", size = 18085, upload-time = "2025-09-05T12:49:22.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1a/b2da0a620490aae355f9d72072ac13e901a9fec809a6a24fc6493a8f3c35/setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4", size = 13097, upload-time = "2025-09-05T12:49:23.322Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2e/bd03ff02432a181c1787f6fc2a678f53b7dacdd5ded69c318fe1619556e8/setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f", size = 32191, upload-time = "2025-09-05T12:49:24.567Z" },
+    { url = "https://files.pythonhosted.org/packages/28/78/1e62fc0937a8549f2220445ed2175daacee9b6764c7963b16148119b016d/setproctitle-1.3.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9", size = 33203, upload-time = "2025-09-05T12:49:25.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/65edc65db3fa3df400cf13b05e9d41a3c77517b4839ce873aa6b4043184f/setproctitle-1.3.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba", size = 34963, upload-time = "2025-09-05T12:49:27.044Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/89157e3de997973e306e44152522385f428e16f92f3cf113461489e1e2ee/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307", size = 32398, upload-time = "2025-09-05T12:49:28.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/18/77a765a339ddf046844cb4513353d8e9dcd8183da9cdba6e078713e6b0b2/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee", size = 33657, upload-time = "2025-09-05T12:49:30.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/f0b6205c64d74d2a24a58644a38ec77bdbaa6afc13747e75973bf8904932/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1", size = 31836, upload-time = "2025-09-05T12:49:32.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/e1277f9ba302f1a250bbd3eedbbee747a244b3cc682eb58fb9733968f6d8/setproctitle-1.3.7-cp311-cp311-win32.whl", hash = "sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d", size = 12556, upload-time = "2025-09-05T12:49:33.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7b/822a23f17e9003dfdee92cd72758441ca2a3680388da813a371b716fb07f/setproctitle-1.3.7-cp311-cp311-win_amd64.whl", hash = "sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4", size = 13243, upload-time = "2025-09-05T12:49:34.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2f/fcedcade3b307a391b6e17c774c6261a7166aed641aee00ed2aad96c63ce/setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922", size = 18047, upload-time = "2025-09-05T12:49:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/afc141ca9631350d0a80b8f287aac79a76f26b6af28fd8bf92dae70dc2c5/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee", size = 13073, upload-time = "2025-09-05T12:49:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd", size = 33284, upload-time = "2025-09-05T12:49:52.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0", size = 34104, upload-time = "2025-09-05T12:49:54.416Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/6daf66394152756664257180439d37047aa9a1cfaa5e4f5ed35e93d1dc06/setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929", size = 35982, upload-time = "2025-09-05T12:49:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/62/f2c0595403cf915db031f346b0e3b2c0096050e90e0be658a64f44f4278a/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f", size = 33150, upload-time = "2025-09-05T12:49:58.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/29/10dd41cde849fb2f9b626c846b7ea30c99c81a18a5037a45cc4ba33c19a7/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698", size = 34463, upload-time = "2025-09-05T12:49:59.424Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/cedd8eccfaf15fb73a2c20525b68c9477518917c9437737fa0fda91e378f/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c", size = 32848, upload-time = "2025-09-05T12:50:01.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/0a0e27d1c9926fecccfd1f91796c244416c70bf6bca448d988638faea81d/setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd", size = 12544, upload-time = "2025-09-05T12:50:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1b/6bf4cb7acbbd5c846ede1c3f4d6b4ee52744d402e43546826da065ff2ab7/setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f", size = 13235, upload-time = "2025-09-05T12:50:16.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a4/d588d3497d4714750e3eaf269e9e8985449203d82b16b933c39bd3fc52a1/setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9", size = 18058, upload-time = "2025-09-05T12:50:02.501Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/7637f7682322a7244e07c373881c7e982567e2cb1dd2f31bd31481e45500/setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5", size = 13072, upload-time = "2025-09-05T12:50:03.601Z" },
+    { url = "https://files.pythonhosted.org/packages/52/09/f366eca0973cfbac1470068d1313fa3fe3de4a594683385204ec7f1c4101/setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29", size = 34490, upload-time = "2025-09-05T12:50:04.948Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/611fc2ed149fdea17c3677e1d0df30d8186eef9562acc248682b91312706/setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152", size = 35267, upload-time = "2025-09-05T12:50:06.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a4/64e77d0671446bd5a5554387b69e1efd915274686844bea733714c828813/setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c", size = 37376, upload-time = "2025-09-05T12:50:07.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/ad9c664fe524fb4a4b2d3663661a5c63453ce851736171e454fa2cdec35c/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b", size = 33963, upload-time = "2025-09-05T12:50:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a36de7caf2d90c4c28678da1466b47495cbbad43badb4e982d8db8167ed4/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18", size = 35550, upload-time = "2025-09-05T12:50:10.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/68/17e8aea0ed5ebc17fbf03ed2562bfab277c280e3625850c38d92a7b5fcd9/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c", size = 33727, upload-time = "2025-09-05T12:50:12.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/33/90a3bf43fe3a2242b4618aa799c672270250b5780667898f30663fd94993/setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29", size = 12549, upload-time = "2025-09-05T12:50:13.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/50d1f07f3032e1f23d814ad6462bc0a138f369967c72494286b8a5228e40/setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9", size = 13243, upload-time = "2025-09-05T12:50:14.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5b/5e1c117ac84e3cefcf8d7a7f6b2461795a87e20869da065a5c087149060b/setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1", size = 12587, upload-time = "2025-09-05T12:51:21.195Z" },
+    { url = "https://files.pythonhosted.org/packages/73/02/b9eadc226195dcfa90eed37afe56b5dd6fa2f0e5220ab8b7867b8862b926/setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65", size = 14286, upload-time = "2025-09-05T12:51:22.61Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/1be1d2a53c2a91ec48fa2ff4a409b395f836798adf194d99de9c059419ea/setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a", size = 13282, upload-time = "2025-09-05T12:51:24.094Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2031,6 +2232,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [[package]]
@@ -2136,6 +2354,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The 100% branch-coverage gate proves every line and branch executes — not that
any assertion would notice if the behaviour changed. The first `mutmut` run put
a number on that gap: **105 of 549 mutants survived a fully covered suite**.

This adds `mutmut` over the two modules where a surviving mutant is a real bug —
`interlock/_state_machine.py` (thresholds, transitions, probe admission) and
`interlock/_engine.py` (lock scope, dispatch, recording order) — and kills the
survivors that were real gaps. Score after this PR: **526 of 549 (95.8%)**.

**No production code changed.** The diff is config, tests, docs and one workflow.

### What the survivors turned into

Each of these is a test for something the suite was taking on trust:

- probe accounting frees **exactly one** slot, whether the probe settled or was
  released, and the permitted budget counts settled probes too;
- a probe round is judged on **rates, not counts** — one bad probe in three
  closes the breaker (`failures / completed` and `failures * completed` are
  indistinguishable when `completed == 1`, which is all the suite had);
- the era counter **never reuses a value** on any transition — a reused
  generation would let an outcome from an older era settle into the current one;
- `retry_after` is clamped at zero and measured from the moment the breaker
  opened, not from `t=0` (every existing test tripped at `t=0`, where `-` and
  `+` give the same answer);
- a stale probe from an earlier round cannot return a slot to the current one;
- a classifier's verdict on the **returned value** reaches the window, an
  exception it forgives is not recorded as `last_failure`, and a call whose
  duration is exactly the slow threshold is slow;
- every event carries the breaker's name, and a coordinated rejection reports
  its breaker and its last failure;
- the `auto_transition` timer is armed exactly when the local machine enters
  `OPEN` and cancelled exactly when it leaves — a rejection, a stale settle, a
  shared-view update, a storage callback and an early firing all leave it alone.

That last group is new deterministic coverage: the timer lifecycle was only
tested end-to-end before, so 14 mutants lived in the gap between "the timer
eventually fires" and "the timer is managed correctly".

### Configuration decisions worth reviewing

- **Not a PR gate.** `.github/workflows/mutation.yml` runs weekly (Mon 04:00
  UTC) and on demand. `SURVIVOR_BUDGET: 23` is a ratchet, so a new survivor
  fails the scheduled run without blocking anyone's merge.
- **Pinned to Python 3.11**, the floor, as in `extras-min`: compatibility is the
  matrix's job in `ci.yml`, and a mutation score is about what the tests assert.
  Verified identical on 3.11 and 3.12.
- **The hypothesis suites are excluded from the mutation run.** mutmut maps
  tests to functions from a single stats run, and a randomised test that reaches
  a branch only sometimes makes both that mapping and the score irreproducible —
  measured: the mapping differed between two consecutive runs of the same tree.
- **`do_not_mutate_patterns = ["cast\\("]`** — `typing.cast` is erased at
  runtime, so mutating its first argument is equivalent by construction (12
  mutants).

### The 23 remaining survivors

All equivalent mutants, in five classes, documented in `CONTRIBUTING.md`:

| Class | Why it cannot be killed |
|---|---|
| `_generation += 2`, initial `_generation = 1` | The era counter is only compared with `!=`; any strictly increasing sequence is equivalent. What matters — no value is ever reused — is asserted. |
| `_opened_at = None` / `= 1.0` in `__init__` | Read only in `OPEN`, and `_open()` always writes it first. |
| `_closed = None`, `_storage_degraded = None` | Used only as booleans. |
| Dropping `retry_after=None` from `CircuitOpenError(...)` | Repeats the constructor default. |
| `_emit_transitions(..., after=None)` on paths that never enter `OPEN`; the `_detach_shared_view` and storage-callback variants | Both arguments are equal, or the timer is already shut down. |

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — 583 passed, 2
      skipped, 100.00%
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes — n/a, nothing user-facing
      changed; the contributor-facing guide is in `CONTRIBUTING.md`
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

Also ran: `uv run prek run --all-files` (clean) and `uv run mutmut run`
(526/549 on both 3.11 and 3.12). The scheduled workflow runs for the first time
on Monday; it can be triggered manually from the Actions tab to verify sooner.

## Related issues

Closes #103

Out of scope here, but found while doing it and worth its own issue: the
hypothesis model in `tests/test_state_machine_model.py` reaches `HALF_OPEN`
roughly 6 times across a whole 200-example run. Four of its nine rules are
operator overrides and only `reset` leads back to `CLOSED`, so the machine
spends nearly all its time in override states and the probe paths are
effectively unexplored. Folding the three override rules into one would fix the
balance.