### PR TITLE
ci: harden the supply chain with zizmor, SHA-pinned actions and Scorecard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,26 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
       - name: Install dependencies
         run: uv sync --frozen
+
+      # The token buys the online audits, which are the ones that make a SHA pin
+      # mean anything: impostor-commit, ref-confusion, known-vulnerable-actions
+      # and stale-action-refs all read the GitHub API. Without one zizmor warns
+      # and degrades to the offline subset — which is what a local run does.
+      - name: Zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uv run zizmor .github/workflows/
 
       - name: Ruff format
         run: uv run ruff format --check
@@ -72,10 +83,12 @@ jobs:
     env:
       UV_PYTHON: '3.11'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -123,10 +136,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -139,7 +154,7 @@ jobs:
           --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -147,7 +162,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -13,19 +13,23 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write # OpenID Connect authentication with CodSpeed
 
 jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OpenID Connect authentication with CodSpeed
     env:
       UV_PYTHON: '3.12'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -35,7 +39,7 @@ jobs:
       # `-n 0` opts out of the xdist default in pyproject.toml: the measurement
       # must happen in a single process.
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v5
+        uses: CodSpeedHQ/action@88472375d0a4572cf70a9f1fe3a4e0ab8da1b924 # v5.0.1
         with:
           mode: simulation
           run: uv run --no-sync pytest benchmarks --codspeed -n 0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches: [main]
 
+# Least-privilege default; only `deploy` gets the Pages and OIDC scopes.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -17,10 +16,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -31,17 +32,20 @@ jobs:
         run: uv run zensical build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -26,10 +26,12 @@ jobs:
       # this only together with the list.
       SURVIVOR_BUDGET: '23'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 
@@ -58,7 +60,7 @@ jobs:
 
       - name: Upload the report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutmut-stats
           path: mutants/mutmut-cicd-stats.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          enable-cache: true
+          persist-credentials: false
+
+      # No cache here, unlike the other workflows: a cache entry written by a
+      # pull-request run would be readable by the job that builds the published
+      # artefacts. One `uv sync` per release is cheaper than that risk.
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --frozen
@@ -29,7 +34,7 @@ jobs:
         run: uv build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -42,13 +47,17 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
+      # `attestations` defaults to true, but PEP 740 provenance is the point of
+      # the OIDC flow — state it so a default flip cannot silently drop it.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          attestations: true
 
   github-release:
     needs: publish
@@ -57,6 +66,6 @@ jobs:
       contents: write
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard
+
+# OpenSSF Scorecard audits the repository itself — pinned dependencies, token
+# permissions, release provenance, branch protection. It is a published signal
+# for adopters (the README badge), not a merge gate: no pull_request trigger,
+# and a dropped check never blocks a PR.
+on:
+  schedule:
+    - cron: '0 5 * * 1' # Mondays, 05:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # Token-Permissions and Pinned-Dependencies read the workflows
+      checks: read # CI-Tests reads the check runs on merged pull requests
+      id-token: write # publishes the result to the public API behind the badge
+      security-events: write # uploads the SARIF to the code-scanning dashboard
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Required for the badge: without it the score stays private and
+          # api.scorecard.dev has nothing to serve.
+          publish_results: true
+
+      - name: Upload the results to code scanning
+        uses: github/codeql-action/upload-sarif@a2983b8bed1923f44751c5c43237f479442827b3 # v3.37.4
+        with:
+          sarif_file: results.sarif

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  # `gh release create --generate-notes` would replace the action, but
+  # softprops/action-gh-release is pinned to a SHA, tracked by Dependabot and
+  # already proven on every release so far. Rewriting the one step that runs
+  # with `contents: write` is a change to the release path, not a hardening of
+  # it — revisit it on its own, not as part of the pinning work (#105).
+  superfluous-actions:
+    ignore:
+      - release.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,13 @@ repos:
         types: [python]
         pass_filenames: false
 
+      - id: zizmor
+        name: zizmor
+        entry: uv run zizmor .github/workflows/
+        language: system
+        files: ^\.github/(workflows/.*\.ya?ml|zizmor\.yml)$
+        pass_filenames: false
+
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: v0.9.38
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - **mypy + pyright + pyrefly** in strict mode — static analysis.
 - **pytest** + `pytest-asyncio`, `pytest-cov`, `pytest-mock`, `pytest-sugar`, `faker`, `hypothesis`.
 - **mutmut** — mutation testing over the state machine and the engine; out of band, never a PR gate.
+- **zizmor** — static audit of the GitHub Actions workflows; a PR gate like ruff and mypy.
 - **Zensical** — documentation (plain-Markdown content, portable).
 
 ## Environment and commands
@@ -44,6 +45,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - Lint: `uv run ruff check --fix`
 - Types: `uv run mypy`, `uv run pyright` and `uv run pyrefly check`
 - Tests: `uv run pytest` / with coverage: `uv run pytest --cov`
+- Workflows: `uv run zizmor .github/workflows/` (export `GH_TOKEN` for the online audits)
 - Mutants: `uv run mutmut run` (optional, out of band — see `CONTRIBUTING.md`)
 
 ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = "py311"`), not via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,42 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   behaviour and still raise: a `FailureClassifier`, a pipeline fallback
   function, a tenacity `before_sleep` hook.
 
+### Security
+
+- **The CI supply chain is now auditable from the outside.** Workflows are the
+  most privileged code in the repository and were the least checked part of it:
+  every `uses:` resolved to a mutable tag, so a compromised action could have
+  changed what a release publishes without a single commit here. Three changes
+  close that, and they only work together — a Scorecard grade over unpinned
+  actions would have been a badge that says less than it looks like it does:
+  - every action is pinned to a full commit SHA with the version in a trailing
+    comment (Dependabot updates both, and `zizmor --fix=all` writes the pin for
+    a newly added action). Pinning surfaced two actions sitting a major behind
+    their upstream, so they were bumped at the same time:
+    `astral-sh/setup-uv` 7 → 9 and `codecov/codecov-action` 5 → 7;
+  - [zizmor](https://docs.zizmor.sh) audits `.github/workflows/` on every pull
+    request and locally through the pre-commit hook. CI hands it the job's own
+    token so the four audits that resolve a pin against its upstream repository
+    — `impostor-commit`, `ref-confusion`, `known-vulnerable-actions`,
+    `stale-action-refs` — actually run; without one they are silently skipped
+    and a SHA is only as trustworthy as the person who typed it. Its findings
+    are fixed
+    rather than muted: `actions/checkout` no longer leaves the job's credentials
+    in `.git/config` (`persist-credentials: false`), `docs.yml` grants
+    `pages: write` and `id-token: write` to the deploy job instead of to the
+    whole workflow, and the release build no longer restores a dependency cache
+    that a pull-request run could have written. The one suppression, with its
+    reason, lives in `.github/zizmor.yml`;
+  - [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/bagowix/interlock)
+    runs weekly and on every push to `main`, publishing a per-check score to the
+    code-scanning dashboard and to a README badge.
+
+  Nothing about the release flow changed: it still builds once and publishes
+  that artefact through PyPI's OIDC trusted publisher. The PEP 740 attestations
+  it already produced are now requested explicitly rather than inherited from
+  the action's default, and `SECURITY.md` documents where to fetch and verify
+  them.
+
 ## [2.1.3] - 2026-07-31
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,20 @@ uv run mypy                   # type checking
 uv run pyright                # type checking (strict)
 uv run pyrefly check          # type checking (strict, third opinion)
 uv run pytest --cov           # tests with coverage
+uv run zizmor .github/workflows/   # GitHub Actions audit
 ```
+
+`zizmor` needs a GitHub token for four of its audits (`impostor-commit`,
+`ref-confusion`, `known-vulnerable-actions`, `stale-action-refs`) — the ones
+that check what a pinned SHA actually points at. CI passes the job's built-in
+token; locally, export `GH_TOKEN=$(gh auth token)` to run the same set. Without
+one zizmor warns and runs the offline subset, which is enough for everything
+except a bad pin.
+
+Every action in `.github/workflows/` is pinned to a commit SHA with the version
+in a trailing comment. Adding one? Write the tag and let zizmor rewrite it —
+`GH_TOKEN=$(gh auth token) uv run zizmor --fix=all .github/workflows/` resolves
+the SHA and the comment for you. Routine bumps come from Dependabot.
 
 The pre-commit hooks run the fast subset automatically:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/bagowix/interlock/actions/workflows/ci.yml/badge.svg)](https://github.com/bagowix/interlock/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/bagowix/interlock/branch/main/graph/badge.svg)](https://codecov.io/gh/bagowix/interlock)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bagowix/interlock/badge)](https://scorecard.dev/viewer/?uri=github.com/bagowix/interlock)
 [![PyPI](https://img.shields.io/pypi/v/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![Downloads](https://img.shields.io/pypi/dm/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![Python versions](https://img.shields.io/pypi/pyversions/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,29 @@ versions, and a reproduction if you have one.
 
 You can expect an acknowledgement within a few days. Once a fix is ready we will
 release it and credit the reporter unless you prefer to stay anonymous.
+
+## Supply chain
+
+The release path is auditable end to end, and the
+[OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/bagowix/interlock)
+badge in the README is the summary of it.
+
+- **Trusted publishing.** `.github/workflows/release.yml` builds and publishes
+  through PyPI's OIDC trusted publisher — there is no long-lived API token that
+  could leak.
+- **Signed provenance.** Every artefact carries a Sigstore-backed
+  [PEP 740](https://peps.python.org/pep-0740/) attestation generated at publish
+  time. PyPI serves it from
+  `https://pypi.org/integrity/interlock-cb/<version>/<filename>/provenance`.
+- **Pinned actions.** Every `uses:` in `.github/workflows/` is pinned to a full
+  commit SHA with the version in a trailing comment; Dependabot bumps both.
+- **Audited workflows.** [zizmor](https://docs.zizmor.sh) runs over
+  `.github/workflows/` on every pull request, with a token so that the audits
+  which resolve a pinned SHA against the upstream repository (`impostor-commit`,
+  `ref-confusion`, `known-vulnerable-actions`, `stale-action-refs`) are included.
+  Suppressions live in `.github/zizmor.yml`, each with a reason.
+- **Static analysis.** CodeQL default setup (`python` and `actions`) plus
+  ruff's `S` ruleset (flake8-bandit), which is part of `select = ["ALL"]`.
+- **Zero-dependency core.** `interlock.*` imports only the standard library;
+  every third-party library sits behind an optional extra, so the default
+  install has no transitive attack surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,4 +279,5 @@ dev = [
     "pytest-codspeed>=5.0.3",
     "pyrefly>=1.2.0",
     "mutmut>=3.7.0",
+    "zizmor>=1.29.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -808,6 +808,7 @@ dev = [
     { name = "tenacity" },
     { name = "types-requests" },
     { name = "zensical" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -852,6 +853,7 @@ dev = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "types-requests", specifier = ">=2.31.0" },
     { name = "zensical", specifier = ">=0.0.46" },
+    { name = "zizmor", specifier = ">=1.29.0" },
 ]
 
 [[package]]
@@ -2501,4 +2503,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/b4/7f1b6c3cf06d9f6ff5216523168a5d6ccc693444d5ceeb911eca97b30d98/zensical-0.0.51-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6fa0ecaf14f56841bfc595fa141396350c72aafbec73a016ebe3c824ed21ac72", size = 13451420, upload-time = "2026-07-17T18:07:52.563Z" },
     { url = "https://files.pythonhosted.org/packages/0a/44/be4bc09ec8f69e7be1b07b875887961c4e0e478b03a10d2cc624ef28fbe6/zensical-0.0.51-cp310-abi3-win32.whl", hash = "sha256:fb7ff4946b72168759c6af0a29cf5de4c38aebe633a83292e8cd4145b5213cc2", size = 12375639, upload-time = "2026-07-17T18:07:56.081Z" },
     { url = "https://files.pythonhosted.org/packages/1f/85/aa827c244ed4f404e99a91c3ecf5e5adb62eca806a9e9c8e3333bbad8660/zensical-0.0.51-cp310-abi3-win_amd64.whl", hash = "sha256:12529d3d3991b63820952111dc1d1edc29b2c9b3a3abb16c243bcb649631ebf2", size = 12628965, upload-time = "2026-07-17T18:07:59.741Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/f8/f4e3fc0b316d5241b6d6968e8fb702e28446bc7d3c1e2b229f4caa6eacf2/zizmor-1.29.0.tar.gz", hash = "sha256:60e34e83c67064e0036989c7c525d13413e897aa4c4f683f1efb2048cdb28a47", size = 571865, upload-time = "2026-08-01T21:09:19.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/97/667ef4db0ca9225ee402c1b947b5b6f17fd234d72c15a71db150b7695c62/zizmor-1.29.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ea72f84d610643d57f96430c655a3780d0b874e477d32e14eae8e910f6cce1fd", size = 9037504, upload-time = "2026-08-01T21:08:56.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d4/9fc7deaf75778e7516fa1d6c836377c3cb5d203dedc28899946b6f11ecdb/zizmor-1.29.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5aafe617d7b1e0c0c15d58fdf20495f360f74a791dfa136f76630b4cc06c2a34", size = 8654426, upload-time = "2026-08-01T21:08:59.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/6db714fb0aa08aeec62eb9d6ad6a443a1f4ed50d4c0b789944ae55fb83e4/zizmor-1.29.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:67644ae8d6d0394204b9a488f7d86f0dd66fe562f4ba85fc53e6105a6bfc7b6a", size = 8918927, upload-time = "2026-08-01T21:09:01.46Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/a12edc0c0c0a0101c54dbb9099ff08f8de2fcb35c36cb706db3deb2c2728/zizmor-1.29.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:81e4093fed5c8a41d6ae7bb773085a9d2e6c0b0a0b560d46a9c76d69be0a07ed", size = 8500655, upload-time = "2026-08-01T21:09:03.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20", size = 9351035, upload-time = "2026-08-01T21:09:06.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1b/93cdd5a06984b394d90001f9778008a21689052904109080a09952626c99/zizmor-1.29.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:061600f23c46f2e400bcdef666c236de7e5c0b07dd6ca046daa001eb1514b909", size = 8941717, upload-time = "2026-08-01T21:09:08.861Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f4/8d9e54405b477bc8e4b56c1a60123fca26c109ea6a762eea104fab32555e/zizmor-1.29.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:332546480be38aca95c149f835e0dcb7679ab5d74618a90c6ccb3fa6b8c7b99d", size = 8468289, upload-time = "2026-08-01T21:09:11.096Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/06d57ca830cc4653369c5aca22cccbf04c8c36ee84a67f351214e556bad8/zizmor-1.29.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a7462b9ab45d72a20ad5ab8193b430df8184c59e2bf46954ddd09496f2f00b45", size = 9446505, upload-time = "2026-08-01T21:09:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/253d9a3538e0ea6f96a3bcd69839c0c5a816a00299620b58a10b5bd1df59/zizmor-1.29.0-py3-none-win32.whl", hash = "sha256:8c759e68cd866375030ca39e19e2de47a056b7be7288c1620e2d5b4c274f631f", size = 7655723, upload-time = "2026-08-01T21:09:15.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2d/7919bc23475273ed8038a031fc24bc3f2005c78e608ce8df96746ef0fb98/zizmor-1.29.0-py3-none-win_amd64.whl", hash = "sha256:0fb85948ba5ffc7a8116eee36fe9cfc10167225c97bd2810e3378e66a9fd27c4", size = 8785519, upload-time = "2026-08-01T21:09:17.513Z" },
 ]


### PR DESCRIPTION
## Summary

Workflows are the most privileged code in the repository and were the least
checked part of it: every `uses:` resolved to a mutable tag, so a compromised
action could have changed what a release publishes without a commit landing
here. Closes #105.

The three parts only work together — a Scorecard grade computed over unpinned
actions would be a badge that says less than it looks like it does.

**1. Every action is pinned to a full commit SHA** with the version in a
trailing comment. Dependabot rewrites both; for a newly added action,
`GH_TOKEN=$(gh auth token) uv run zizmor --fix=all .github/workflows/` writes
the pin in exactly this format. Pinning surfaced two actions sitting a major
behind upstream, bumped in the same pass: `astral-sh/setup-uv` 7 → 9 (v8
dropped a deprecated version-manifest format we never used; v9 flips
`prune-cache` to `false`) and `codecov/codecov-action` 5 → 7 (node24; the
`token`/`files`/`fail_ci_if_error` inputs are unchanged).

**2. `zizmor` audits `.github/workflows/`** in the `quality` job and through a
`prek` hook. CI passes the job's own `github.token`: four audits —
`impostor-commit`, `ref-confusion`, `known-vulnerable-actions`,
`stale-action-refs` — only run online, and they are precisely the ones that
check what a SHA *points at*. Offline they are silently skipped and a pin is
only as good as the person who typed it.

Its findings are fixed rather than muted:

- `actions/checkout` no longer leaves the job token in `.git/config`
  (`persist-credentials: false`, 8 checkouts — nothing here pushes);
- `docs.yml` grants `pages: write` / `id-token: write` to the `deploy` job
  instead of the whole workflow; `codspeed.yml` does the same for `id-token`;
- the release build no longer restores a `setup-uv` cache that a pull-request
  run could have written.

The single suppression (`superfluous-actions` on `softprops/action-gh-release`)
lives in `.github/zizmor.yml` with its reason: rewriting the one step that runs
with `contents: write` is a change to the release path, not a hardening of it.

**3. `scorecard.yml`** runs weekly and on pushes to `main` — never on a PR,
like `mutation.yml`: a check that drops for reasons outside the diff must not
block someone else's work. Results go to the code-scanning dashboard and, via
`publish_results: true`, to the README badge.

### Release path

Unchanged: still builds once and publishes that artefact through PyPI's OIDC
trusted publisher. `attestations: true` is now stated explicitly rather than
inherited from the action's default — the PEP 740 attestations were verified as
already present on 2.1.3 (`https://pypi.org/integrity/interlock-cb/2.1.3/interlock_cb-2.1.3-py3-none-any.whl/provenance`).
`SECURITY.md` gains a "Supply chain" section pointing adopters at all of it.

Scorecard's `SAST` check is satisfied by the existing CodeQL default setup
(`python` + `actions`, configured in repository settings) — no CodeQL workflow
is added. `Branch-Protection` needs a PAT and `Fuzzing` does not apply; both are
#105 non-goals.

## Test plan

- [x] `uv run zizmor .github/workflows/` clean, offline **and** online with a
      token (the online run is what validates the 13 new pins).
- [x] `uv run prek run --all-files` green, including the new `zizmor` hook.
- [x] `uv run pytest --cov` — 583 passed, 2 skipped, coverage unchanged.
- [x] Every pinned SHA resolved from the GitHub tags API and checked against
      `releases/latest`; 13 of 13 now on the newest release.
- [ ] `scorecard.yml` first runs on merge to `main` — the badge stays blank
      until then, and the `Pinned-Dependencies` / `Token-Permissions` scores are
      the thing to check on that first run.
- [ ] `release.yml` is only exercised on the next `v*` tag. The diff there is
      three lines (SHA pins, `enable-cache: false`, `attestations: true`).

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — CI-only change,
      no test surface
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes — `SECURITY.md`,
      `CONTRIBUTING.md`, `README.md` badge; `docs/` has no CI page
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #105