### PR TITLE
ci: detect public-API breakage with griffe check

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -1,0 +1,49 @@
+name: API compatibility
+
+# griffe check diffs the public API of the working tree against the latest
+# release tag: interlock/__init__.py's re-exports plus interlock/integrations/*,
+# which is public without being re-exported from __init__ (#104). A detected
+# breakage is not automatically wrong — it must be deliberate, so the job is
+# failable but overridable: label the pull request `breaking-change` to
+# acknowledge it.
+on:
+  pull_request:
+
+concurrency:
+  group: api-compatibility-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  griffe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # tags must be present locally; griffe resolves the latest one itself
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Check public API against the latest release
+        id: griffe
+        continue-on-error: true
+        run: uv run griffe check interlock --search . -f github
+
+      - name: Acknowledge intentional breakage
+        if: steps.griffe.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'breaking-change')
+        run: echo '::warning::griffe reported a public-API breakage, acknowledged via the "breaking-change" label.'
+
+      - name: Fail on unacknowledged breakage
+        if: steps.griffe.outcome == 'failure' && !contains(github.event.pull_request.labels.*.name, 'breaking-change')
+        run: |
+          echo '::error::griffe detected a public-API breakage. If intentional, label the pull request "breaking-change" and record it in CHANGELOG.md.'
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - **pytest** + `pytest-asyncio`, `pytest-cov`, `pytest-mock`, `pytest-sugar`, `faker`, `hypothesis`.
 - **mutmut** — mutation testing over the state machine and the engine; out of band, never a PR gate.
 - **zizmor** — static audit of the GitHub Actions workflows; a PR gate like ruff and mypy.
+- **griffe** — public-API breakage detection against the latest release tag; a PR gate,
+  overridable with the `breaking-change` label for intentional changes.
 - **Zensical** — documentation (plain-Markdown content, portable).
 
 ## Environment and commands
@@ -46,6 +48,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
 - Types: `uv run mypy`, `uv run pyright` and `uv run pyrefly check`
 - Tests: `uv run pytest` / with coverage: `uv run pytest --cov`
 - Workflows: `uv run zizmor .github/workflows/` (export `GH_TOKEN` for the online audits)
+- Public API: `uv run griffe check interlock --search .` (diffs against the latest release tag)
 - Mutants: `uv run mutmut run` (optional, out of band — see `CONTRIBUTING.md`)
 
 ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = "py311"`), not via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Public-API breakage detection** (`griffe check`) on every pull request.
+  v2.0 shipped without breaking changes and the standalone breaker surface
+  stays untouched by the pipeline layer, but until now nothing mechanically
+  verified either promise — mypy, pyright and pyrefly check that the code is
+  internally consistent, not that its public surface is still compatible with
+  the previous release, and `tests/typing_surface.py` only pins the shapes
+  somebody remembered to write down. `.github/workflows/api-compatibility.yml`
+  diffs the working tree against the latest release tag: removed or renamed
+  objects, changed parameter kinds, order or defaults, narrowed return types.
+  It covers `interlock/integrations/*` too, since that surface is public even
+  though it is not re-exported from `__init__`. A breaking change is not
+  automatically wrong — a future major release will make one on purpose — so
+  the job is failable but overridable: label the pull request `breaking-change`
+  to acknowledge it. `griffe` is a dev/CI-only dependency; the core stays at
+  zero.
+
 - **Mutation testing** (`mutmut`) over `interlock/_state_machine.py` and
   `interlock/_engine.py` — the two modules where a surviving mutant is a real
   bug. The 100% coverage gate proves every branch executes, not that anything

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,23 @@ The pre-commit hooks run the fast subset automatically:
 uv run prek install           # one-time, installs the git hook
 ```
 
+### Public API compatibility
+
+`.github/workflows/api-compatibility.yml` runs [`griffe check`](https://mkdocstrings.github.io/griffe/)
+on every pull request, diffing the public API of the working tree against the
+latest release tag — removed or renamed objects, changed parameter kinds,
+order or defaults, narrowed return types. It covers everything importable from
+`interlock/__init__.py` plus `interlock/integrations/*`, which is public even
+though it is not re-exported from `__init__`. Run it locally with:
+
+```bash
+uv run griffe check interlock --search .
+```
+
+A breaking change is not automatically wrong — it must be deliberate, though,
+and reflected in `CHANGELOG.md`. If it is intentional, label the pull request
+`breaking-change`; the job still reports the diff but no longer fails on it.
+
 ### Redis-backed tests
 
 `tests/test_redis_storage.py` runs against in-process **`fakeredis`** by default —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,4 +280,5 @@ dev = [
     "pyrefly>=1.2.0",
     "mutmut>=3.7.0",
     "zizmor>=1.29.0",
+    "griffe>=2.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -601,6 +601,41 @@ wheels = [
 ]
 
 [[package]]
+name = "griffe"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffecli" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/44/63913c007814cab5ba9d36f25ad40dfc640c2e2931d195bd2d05f774a5d6/griffe-2.1.0.tar.gz", hash = "sha256:c58845df5a364feaabd05ee8c767b97b03e478da8aa18b9923553c812fb0d955", size = 244879, upload-time = "2026-06-19T12:05:41.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/fb/3c65d392feae6c36dc2b55a14dd8270b7b35a3171c93b71a4d2ee4abf241/griffe-2.1.0-py3-none-any.whl", hash = "sha256:2ccdab17fb9cd76f278d7b5611cfc8f68cbe846d8d48df63dff80b62ecfa6f65", size = 5140, upload-time = "2026-06-19T12:05:39.913Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c6/90f85d47af96300d629b38c25b71aad9467a620cac964a39280e822efc8a/griffecli-2.1.0.tar.gz", hash = "sha256:2ff68dbee9395fdb668b10374c51683392d697b226ac60159798f4add1ee716c", size = 56913, upload-time = "2026-06-19T12:05:43.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/2f/513232ec1d5f5da182e4ce45a11427e37dd210844a9e2bca451fc9661fb3/griffecli-2.1.0-py3-none-any.whl", hash = "sha256:6e22b1423d562ddc510997b4be1fe89de59e19dcff78831c0f4bfc3b8134a718", size = 9500, upload-time = "2026-06-19T12:05:37.517Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -785,6 +820,7 @@ dev = [
     { name = "faker" },
     { name = "fakeredis", extra = ["lua"] },
     { name = "fastapi" },
+    { name = "griffe" },
     { name = "httpx" },
     { name = "httpx2" },
     { name = "hypothesis" },
@@ -830,6 +866,7 @@ dev = [
     { name = "faker", specifier = ">=40.23.0" },
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.20.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "griffe", specifier = ">=2.1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx2", specifier = ">=2.4.0" },
     { name = "hypothesis", specifier = ">=6.155.7" },


### PR DESCRIPTION
## Summary

- Add `.github/workflows/api-compatibility.yml`: a pull-request job that runs
  `griffe check interlock --search .`, diffing the working tree's public API
  against the latest release tag (removed/renamed objects, changed parameter
  kinds, order or defaults, narrowed return types).
- Covers `interlock/__init__.py`'s re-exports **and** `interlock/integrations/*`,
  which is public even though it is not re-exported.
- Escape hatch: a detected breakage fails the job unless the PR is labelled
  `breaking-change` (created on the repo), in which case it's reported as a
  warning instead — a future major release should not be blocked by its own
  tooling.
- `griffe` added as a dev-only dependency (`uv add --dev griffe`); the core
  stays at zero dependencies.
- Documented the local command and the escape hatch in `CONTRIBUTING.md`,
  and the tool/command in `AGENTS.md`.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — no production
      code changed; full suite still passes at 100% coverage
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`CONTRIBUTING.md`, `AGENTS.md`) — no user-facing `docs/`
      change needed (non-goal: no griffe/mkdocstrings API docs generation)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits
- [x] `uv run zizmor .github/workflows/` passes (new workflow audited clean)

## Related issues

Closes #104