### PR TITLE
docs: add the earned OpenSSF Best Practices badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   config, workflow or test file, plus a "known limits" section stating what is
   not covered.
 
+- **OpenSSF Best Practices badge**, earned at the passing level
+  (<https://www.bestpractices.dev/projects/13932>) and added to `README.md`,
+  closing out #107.
+
 - **Public-API breakage detection** (`griffe check`) on every pull request.
   v2.0 shipped without breaking changes and the standalone breaker surface
   stays untouched by the pipeline layer, but until now nothing mechanically

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/bagowix/interlock/actions/workflows/ci.yml/badge.svg)](https://github.com/bagowix/interlock/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/bagowix/interlock/branch/main/graph/badge.svg)](https://codecov.io/gh/bagowix/interlock)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bagowix/interlock/badge)](https://scorecard.dev/viewer/?uri=github.com/bagowix/interlock)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13932/badge)](https://www.bestpractices.dev/projects/13932)
 [![PyPI](https://img.shields.io/pypi/v/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![Downloads](https://img.shields.io/pypi/dm/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)
 [![Python versions](https://img.shields.io/pypi/pyversions/interlock-cb.svg)](https://pypi.org/project/interlock-cb/)

--- a/docs/correctness.md
+++ b/docs/correctness.md
@@ -202,7 +202,11 @@ SHA and audited by [zizmor](https://docs.zizmor.sh) on every pull request, and
 CodeQL default setup over both Python and the workflows themselves. The
 [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/bagowix/interlock)
 badge in the README is the standing summary of this section, refreshed weekly
-and on every push to `main`.
+and on every push to `main`. The project also holds the
+[OpenSSF Best Practices](https://www.bestpractices.dev/projects/13932) badge —
+the self-certified checklist covering release process, vulnerability
+reporting, static/dynamic analysis and secure-development practices, most of
+it satisfied by the mechanisms this page already documents.
 
 ## Known limits
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1418,7 +1418,11 @@ SHA and audited by [zizmor](https://docs.zizmor.sh) on every pull request, and
 CodeQL default setup over both Python and the workflows themselves. The
 [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/bagowix/interlock)
 badge in the README is the standing summary of this section, refreshed weekly
-and on every push to `main`.
+and on every push to `main`. The project also holds the
+[OpenSSF Best Practices](https://www.bestpractices.dev/projects/13932) badge —
+the self-certified checklist covering release process, vulnerability
+reporting, static/dynamic analysis and secure-development practices, most of
+it satisfied by the mechanisms this page already documents.
 
 ## Known limits
 


### PR DESCRIPTION
## Summary

- Adds the earned [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13932) (passing) badge to `README.md`, next to the OpenSSF Scorecard badge.
- Points `docs/correctness.md`'s supply-chain section at it — most of the checklist is satisfied by the mechanisms that page already documents (SECURITY.md, CI, static/dynamic analysis, release process).
- Regenerated `docs/llms-full.txt` via `scripts/build_llms_full.py`.

This completes the last outstanding acceptance criterion of #107 — the docs page itself was already merged in #119.

## Checklist

- [ ] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #107