### PR TITLE
chore: prepare the 2.1.4 release

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -36,7 +36,25 @@ jobs:
       - name: Check public API against the latest release
         id: griffe
         continue-on-error: true
-        run: uv run griffe check interlock --search . -f github
+        run: |
+          # The `-f github` run is what annotates the diff; the gate reads the
+          # `oneline` run so one benign finding can be filtered out of it. Every
+          # release bumps `interlock.VERSION`, and griffe reports the new value
+          # as an attribute change — that is the release mechanism working, not
+          # a public-API breakage, and without this every release PR would need
+          # the `breaking-change` label. The filter is deliberately narrow (that
+          # attribute, in that file, that one check); if griffe ever rewords the
+          # message it stops matching and this job fails, which is the safe
+          # direction to fail in.
+          uv run griffe check interlock --search . -f github || true
+          uv run griffe check interlock --search . -f oneline \
+            > "${RUNNER_TEMP}/griffe.txt" 2>&1 || true
+          grep -vE '^interlock/version\.py:[0-9]+: VERSION: Attribute value was changed:' \
+            "${RUNNER_TEMP}/griffe.txt" > "${RUNNER_TEMP}/breakages.txt" || true
+          if [ -s "${RUNNER_TEMP}/breakages.txt" ]; then
+            cat "${RUNNER_TEMP}/breakages.txt"
+            exit 1
+          fi
 
       - name: Acknowledge intentional breakage
         if: steps.griffe.outcome == 'failure' && contains(github.event.pull_request.labels.*.name, 'breaking-change')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.4] - 2026-08-03
+
 ### Added
 
 - **"Correctness and testing" docs page** (`docs/correctness.md`), linked from
@@ -477,7 +479,8 @@ The major version marks the scope of what is added, not a migration burden.
 - `InterlockDeprecationWarning` (subclasses `UserWarning`, visible by default).
 - `py.typed`; strict mypy and pyright; 100% test coverage.
 
-[Unreleased]: https://github.com/bagowix/interlock/compare/v2.1.3...HEAD
+[Unreleased]: https://github.com/bagowix/interlock/compare/v2.1.4...HEAD
+[2.1.4]: https://github.com/bagowix/interlock/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/bagowix/interlock/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/bagowix/interlock/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/bagowix/interlock/compare/v2.1.0...v2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   though it is not re-exported from `__init__`. A breaking change is not
   automatically wrong — a future major release will make one on purpose — so
   the job is failable but overridable: label the pull request `breaking-change`
-  to acknowledge it. `griffe` is a dev/CI-only dependency; the core stays at
-  zero.
+  to acknowledge it. The one finding it ignores is the release bump of
+  `interlock.VERSION`, which griffe reports as a changed attribute value —
+  that is the release mechanism working, and every release would otherwise
+  have to be labelled a breaking change. `griffe` is a dev/CI-only dependency;
+  the core stays at zero.
 
 - **Mutation testing** (`mutmut`) over `interlock/_state_machine.py` and
   `interlock/_engine.py` — the two modules where a surviving mutant is a real

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,7 +35,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of July 2026) | 2.1.3 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of July 2026) | 2.1.4 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -750,7 +750,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of July 2026) | 2.1.3 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of July 2026) | 2.1.4 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0
@@ -889,7 +889,7 @@ breaker = CircuitBreaker(
 | `fail_max` | `minimum_number_of_calls` + `failure_rate_threshold` | Streak → rate; see [above](#the-one-conceptual-change). |
 | `reset_timeout` | `Config.wait_duration_in_open` | Direct, in seconds. |
 | `success_threshold` | `Config.permitted_calls_in_half_open` | Probes admitted before the breaker re-decides. interlock decides on the probe *rate*, not a fixed success count. |
-| `exclude=[...]` | a `FailureClassifier` | See [below](#exclude--failureclassifier). |
+| `exclude=[...]` | a `FailureClassifier` | See [below](#exclude-failureclassifier). |
 | `name=` | `name=` | Same. |
 | `state_storage=CircuitRedisStorage(...)` | `storage=RedisStorage(...)` | See [below](#redis-shared-state). |
 | `listeners=[...]` | `listener=` | See [below](#listeners). |
@@ -1061,8 +1061,8 @@ def external_call(): ...
 |---|---|---|
 | `failure_threshold` | `minimum_number_of_calls` + `failure_rate_threshold` | Streak → rate. |
 | `recovery_timeout` | `Config.wait_duration_in_open` | Direct, in seconds. |
-| `expected_exception` | a `FailureClassifier` | Only these count as failures; see [below](#expected_exception--failureclassifier). |
-| `fallback_function` | `FallbackStrategy` in a pipeline | See [below](#fallback_function--fallbackstrategy). |
+| `expected_exception` | a `FailureClassifier` | Only these count as failures; see [below](#expected_exception-failureclassifier). |
+| `fallback_function` | `FallbackStrategy` in a pipeline | See [below](#fallback_function-fallbackstrategy). |
 | `name=` | `name=` | interlock requires a name explicitly. |
 
 interlock separates the breaker object from the decorator: build one

--- a/interlock/version.py
+++ b/interlock/version.py
@@ -7,7 +7,7 @@ and read at build time by hatchling (see ``[tool.hatch.version]`` in
 
 __all__ = ('VERSION',)
 
-VERSION = '2.1.3'
+VERSION = '2.1.4'
 """The installed version of interlock.
 
 Guaranteed to comply with PEP 440 version specifiers.


### PR DESCRIPTION
## Summary

Prepare the `2.1.4` patch release.

- bump the package version from `2.1.3` to `2.1.4`
- move the current changelog entries from `[Unreleased]` into `2.1.4`
- update changelog comparison links
- update the release version in the comparison page
- regenerate `docs/llms-full.txt`

Everything in `[Unreleased]` is infrastructure, documentation and bug fixes —
the correctness docs page, the OpenSSF badge, `griffe check`, mutation testing,
pyrefly, the Codecov move, the supply-chain hardening, plus the coordinator
lane `task_done()` fix and `EventListener` failure isolation. No public symbol
was added or changed, so this is a patch, not a minor.

### Why now

The `v2.1.4` tag was pushed while `interlock/version.py` still read `2.1.3`, so
the release workflow built `2.1.3` artifacts and PyPI rejected the upload —
that filename already exists and PyPI never allows reuse. The tag has been
deleted locally and on the remote; it needs to be re-created on the merge
commit of this PR so the build picks up the bumped version.

### Note on `docs/llms-full.txt`

The regenerated file carries one change that is not from the version bump:
#87 changed the migration-guide anchors in `docs/migration.md` but did not
regenerate `llms-full.txt`, so the committed copy had drifted. Running
`scripts/build_llms_full.py` brings it back in sync.

`docs/comparison.md` keeps its "as of July 2026" label: that date records when
the *other* libraries' versions were checked, and only interlock's own cell
moves — the same way the 2.1.3 release handled it.

### The griffe gate had to be fixed first

`griffe check` failed this PR on `Attribute value was changed: '2.1.3' -> '2.1.4'`.
The job landed in #118 and this is the first release since, so it had never run
against a version bump — it would have failed every release from now on, or
forced a misleading `breaking-change` label onto each one.

The `-f github` run still annotates the diff; the gate now reads a `oneline`
run with that single finding filtered out. The filter matches only that
attribute, in that file, for that one check, so it fails closed: if griffe
rewords the message it stops matching and the job fails. Verified both ways
locally — the bump alone passes, and a removed public export
(`sync_timeout`) still fails it.

## Checklist

- [x] Test suite passes with 100% coverage (583 passed, 2 skipped)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Documentation updated (`docs/`)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Release artifacts build successfully (`interlock_cb-2.1.4`, sdist + wheel)
- [x] Commits follow Conventional Commits

## Related issues

- Includes changes from #83, #97, #102, #103, #104, #105, #107, #113, #87
