### PR TITLE
test: rebalance the model rule mix toward probe rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The model-based state-machine test now reaches probe rounds.** The
+  `RuleBasedStateMachine` from #106 exists for the order-dependent half of the
+  machine — the probe budget, generation fencing, out-of-order settles — and it
+  was not exercising any of it: measured over 20 seeds, 18 finished a whole run
+  without entering `HALF_OPEN` once, and the best seed managed 7 entries. The
+  rule mix was the cause. Four of nine rules were operator controls, three of
+  them leading into an absorbing override state that only `reset` leaves — and
+  `reset` wipes the window on the way out — while tripping a window took an
+  uninterrupted run of `2 x minimum_number_of_calls` steps, since every call
+  cost one step to admit and another to settle. The walk spent its examples
+  bouncing between the overrides and CLOSED. Three changes fix it: a `call`
+  rule that admits and settles in one step, the way `Engine.call_*` actually
+  works; the four operator controls collapsed into one sampled rule; and a
+  `teardown` that reports trips and probe rounds through `target()` so
+  hypothesis's search steers toward them. `advance` also draws from a strategy
+  that reaches the end of the open wait, which plain `st.floats` — biased
+  toward `0.0` — almost never did. 17 of 20 seeds now reach `HALF_OPEN` on
+  roughly half of their examples, and every override state is still entered, so
+  the #79 invariant keeps its coverage. `max_examples` drops from 200 to 120:
+  the walk no longer needs the extra examples to stumble into a probe round,
+  which keeps the file's runtime in the same range as before.
+
+- The `Clock` protocol now documents that `monotonic()` must be non-negative.
+  `TimeBasedSlidingWindow` reserves a negative second as its "never written"
+  bucket sentinel, so a custom clock returning negative values would report a
+  permanently empty window and the breaker would never trip. Every stdlib
+  monotonic clock already satisfies this; the contract simply said
+  "monotonically increasing" and left the rest implied.
+
 ## [2.1.4] - 2026-08-03
 
 ### Added

--- a/docs/correctness.md
+++ b/docs/correctness.md
@@ -64,7 +64,11 @@ never real time:
   checked against an independently predicted state, generation, window and
   probe budget after every step. This is the suite that catches
   order-dependent bugs — an override landing mid-probe-round, a probe settling
-  a generation late — that a fixed sequence cannot reach.
+  a generation late — that a fixed sequence cannot reach. Reaching those
+  interleavings is not left to chance: the rule mix and a `target()` objective
+  steer the search into `HALF_OPEN`, and the share of examples that get there
+  is measured whenever a rule changes, because a generated sequence that never
+  reaches the interesting state proves nothing.
 
 When the model finds a counterexample, the shrunk sequence gets pinned as a
 named regression test next to the model, so the reproducer survives the model

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1280,7 +1280,11 @@ never real time:
   checked against an independently predicted state, generation, window and
   probe budget after every step. This is the suite that catches
   order-dependent bugs — an override landing mid-probe-round, a probe settling
-  a generation late — that a fixed sequence cannot reach.
+  a generation late — that a fixed sequence cannot reach. Reaching those
+  interleavings is not left to chance: the rule mix and a `target()` objective
+  steer the search into `HALF_OPEN`, and the share of examples that get there
+  is measured whenever a rule changes, because a generated sequence that never
+  reaches the interesting state proves nothing.
 
 When the model finds a counterexample, the shrunk sequence gets pinned as a
 named regression test next to the model, so the reproducer survives the model

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -27,7 +27,14 @@ class Clock(Protocol):
     """Source of time for the core. Injected so tests stay deterministic."""
 
     def monotonic(self) -> float:
-        """Return a monotonically increasing time in fractional seconds."""
+        """Return a monotonically increasing, non-negative time in seconds.
+
+        The reference point is arbitrary — only differences are ever used — but
+        the values must not be negative: ``TimeBasedSlidingWindow`` buckets by
+        whole seconds and reserves a negative second as its "never written"
+        sentinel, so a clock that went below zero would report a permanently
+        empty window and the breaker would never trip.
+        """
         ...
 
 

--- a/tests/test_state_machine_model.py
+++ b/tests/test_state_machine_model.py
@@ -10,17 +10,21 @@ already moved) lives in exactly those interleavings.
 
 The model carries its own prediction of the state, the generation, the window
 aggregates and the probe budget, derived from the documented contract rather
-than read back from the machine, and asserts it after every step. Admissions
-flow through a bundle: an admitted call yields a ticket (the generation the
-call layer captures), and settling one consumes it — so probes can settle out
-of order, or long after their era ended.
+than read back from the machine, and asserts it after every step.
+
+There are two ways to drive a call, because the interesting sequences need
+both. ``call`` admits and settles in one step, the way ``Engine.call_*`` does,
+which is what gets a window tripped and a probe round entered at all (#116).
+``admit`` and ``settle`` split the two across a bundle: an admission yields a
+ticket (the generation the call layer captures) and settling one consumes it,
+so an outcome can land out of order, or an era after it was admitted.
 
 All time comes from ``FakeClock``; nothing here reads real time.
 """
 
 from dataclasses import replace
 
-from hypothesis import settings
+from hypothesis import settings, target
 from hypothesis import strategies as st
 from hypothesis.stateful import (
     Bundle,
@@ -39,9 +43,32 @@ from interlock._state_machine import StateMachine
 
 _PERMIT_ALL = (State.CLOSED, State.DISABLED, State.METRICS_ONLY)
 
-# Every recorded outcome costs two steps (admit, then settle), so a large
-# `minimum_number_of_calls` would spend a whole run inside CLOSED and never
-# reach the probe round. Narrow that one field; the rest is `configs()`.
+_OVERRIDE_MOVES = {
+    State.FORCED_OPEN: StateMachine.force_open,
+    State.DISABLED: StateMachine.disable,
+    State.METRICS_ONLY: StateMachine.metrics_only,
+}
+
+# Every operator control behind one rule, `None` being `reset`. As four rules of
+# nine they fired on ~44% of steps, and since an override is an absorbing state
+# that only `reset` leaves — wiping the window on the way out — the walk spent
+# its examples bouncing between the overrides and CLOSED, never completing the
+# run of admissions and settles that trips a window (#116). Sampling one rule
+# keeps every move reachable at a quarter of the step budget.
+_OPERATOR_MOVES = (*_OVERRIDE_MOVES, None)
+
+# Fractions of the open wait for `advance`. Plain `st.floats` is biased toward
+# 0.0, which starved the one branch that leaves OPEN: instrumenting the run
+# showed `admit` firing in OPEN 191 times without the wait ever having elapsed
+# (#116). Half the draws now land on or past the boundary; 1.0 hits it exactly.
+_WAIT_FRACTIONS = st.one_of(
+    st.floats(min_value=0.0, max_value=2.0),
+    st.sampled_from((1.0, 2.0)),
+)
+
+# A window trips on `minimum_number_of_calls` outcomes, so a large minimum would
+# spend a whole run inside CLOSED and never reach the probe round. Narrow that
+# one field; the rest is `configs()`.
 _MODEL_CONFIGS = st.builds(
     lambda config, minimum: replace(config, minimum_number_of_calls=minimum),
     config=configs(),
@@ -66,29 +93,43 @@ class StateMachineModel(RuleBasedStateMachine):
         self.total = 0
         self.failed = 0
         self.slow = 0
+        self.open_rounds = 0
+        self.half_open_rounds = 0
         self._forget_probes()
 
-    @rule(fraction=st.floats(min_value=0.0, max_value=2.0))
+    def teardown(self) -> None:
+        # Steering, not an assertion: hypothesis keeps the highest-scoring
+        # examples and mutates from there. Probe rounds alone are a flat
+        # objective — most examples reach none, so there is nothing to climb —
+        # so the trip that has to happen first is scored as its own goal (#116).
+        target(float(self.open_rounds), label='trips to OPEN')
+        target(float(self.half_open_rounds), label='probe rounds entered')
+
+    @rule(fraction=_WAIT_FRACTIONS)
     def advance(self, fraction: float) -> None:
-        # Fractions of the open wait, so 1.0 lands exactly on the boundary.
         self.clock.advance(self.config.wait_duration_in_open * fraction)
+
+    @rule(count=st.integers(min_value=1, max_value=4), outcome=st.sampled_from(list(Outcome)))
+    def call(self, count: int, outcome: Outcome) -> None:
+        # What `Engine.call_*` does: admit and settle as one operation. Splitting
+        # every call across two rules meant tripping a window took a run of
+        # 2 x `minimum_number_of_calls` steps with no operator move in between —
+        # a conjunction the walk almost never completed, which is why the model
+        # never reached a probe round (#116). Settling a run under one outcome
+        # is also what trips a window: a rate crosses its threshold on a run of
+        # like outcomes, not on a mixture. `admit`/`settle` stay for the
+        # interleavings this cannot express — an outcome that lands late.
+        for _ in range(count):
+            ticket = self._admit_one()
+            if ticket is None:
+                continue
+            self._predict_settle(ticket, outcome)
+            self.machine.record(outcome, generation=ticket)
 
     @rule(target=tickets)
     def admit(self) -> int | MultipleResults[int]:
-        admits = self._admits()
-        begins_probing = self.expected is State.OPEN and admits
-
-        assert self.machine.acquire() is admits
-
-        if begins_probing:
-            self._to_half_open()
-        if not admits:
-            return multiple()
-        if self.expected is State.HALF_OPEN:
-            self.probes_in_flight += 1
-            self.probes_admitted += 1
-
-        return self.machine.generation
+        ticket = self._admit_one()
+        return multiple() if ticket is None else ticket
 
     @rule(ticket=consumes(tickets), outcome=st.sampled_from(list(Outcome)))
     def settle(self, ticket: int, outcome: Outcome) -> None:
@@ -114,26 +155,16 @@ class StateMachineModel(RuleBasedStateMachine):
         if elapsed:
             self._to_half_open()
 
-    @rule()
-    def force_open(self) -> None:
-        self.machine.force_open()
-        self._to_override(State.FORCED_OPEN)
+    @rule(move=st.sampled_from(_OPERATOR_MOVES))
+    def operator(self, move: State | None) -> None:
+        if move is None:
+            self.machine.reset()
+            self.override = None
+            self._to_closed()
+            return
 
-    @rule()
-    def disable(self) -> None:
-        self.machine.disable()
-        self._to_override(State.DISABLED)
-
-    @rule()
-    def metrics_only(self) -> None:
-        self.machine.metrics_only()
-        self._to_override(State.METRICS_ONLY)
-
-    @rule()
-    def reset(self) -> None:
-        self.machine.reset()
-        self.override = None
-        self._to_closed()
+        _OVERRIDE_MOVES[move](self.machine)
+        self._to_override(move)
 
     @invariant()
     def state_is_predicted(self) -> None:
@@ -180,6 +211,23 @@ class StateMachineModel(RuleBasedStateMachine):
             assert self.machine.retry_after() == max(
                 0.0, self.config.wait_duration_in_open - elapsed
             )
+
+    def _admit_one(self) -> int | None:
+        """Admit one call, predicting it first; the ticket, or ``None`` if rejected."""
+        admits = self._admits()
+        begins_probing = self.expected is State.OPEN and admits
+
+        assert self.machine.acquire() is admits
+
+        if begins_probing:
+            self._to_half_open()
+        if not admits:
+            return None
+        if self.expected is State.HALF_OPEN:
+            self.probes_in_flight += 1
+            self.probes_admitted += 1
+
+        return self.machine.generation
 
     def _admits(self) -> bool:
         if self.expected in _PERMIT_ALL:
@@ -245,11 +293,13 @@ class StateMachineModel(RuleBasedStateMachine):
 
     def _to_open(self) -> None:
         self.expected = State.OPEN
+        self.open_rounds += 1
         self.opened_at = self.clock.monotonic()
         self._transition()
 
     def _to_half_open(self) -> None:
         self.expected = State.HALF_OPEN
+        self.half_open_rounds += 1
         self._transition()
 
     def _to_closed(self) -> None:
@@ -275,7 +325,12 @@ class StateMachineModel(RuleBasedStateMachine):
 
 
 StateMachineModel.TestCase.settings = settings(
-    max_examples=200,
+    # 120 rather than 200: with the rule mix of #116 an example now reaches a
+    # probe round on its own, so the extra examples bought reliability the walk
+    # already has (7 of 8 seeds reach HALF_OPEN either way) at twice the
+    # runtime. Below 100 it does start to matter — half the seeds explore no
+    # probe round at all.
+    max_examples=120,
     stateful_step_count=50,
     deadline=None,
 )


### PR DESCRIPTION
## Summary

The `RuleBasedStateMachine` from #106 almost never reached `HALF_OPEN`, so the
probe round — the part of the machine with the most order-dependent state
(probe budget, generation fencing, out-of-order settles) — was effectively
unexplored. Instrumenting `_transition` over 20 seeds run the way the suite
runs it: 18 of 20 seeds finished a whole run without entering `HALF_OPEN`
once, and the best seed managed 7 entries.

The rule mix was the cause: four of nine rules were operator controls, three
leading into an absorbing override that only `reset` leaves (wiping the
window on the way out), and tripping a window took an uninterrupted run of
`2 x minimum_number_of_calls` steps since every call cost one step to admit
and another to settle.

Three changes, each measured:

- a `call` rule that admits and settles in one step, the way `Engine.call_*`
  actually works — the missing "ordinary" sequence, and the one that trips a
  window;
- the four operator controls (`force_open`, `disable`, `metrics_only`,
  `reset`) collapsed into one sampled `override` rule, taking their share of
  the step budget from ~44% to ~14% without losing a reachable transition;
- a `teardown` that scores trips and probe-round entries via
  `hypothesis.target()`, so the search has a gradient to climb toward instead
  of a flat objective.

`advance` also now draws from a strategy that reaches the end of the open
wait — plain `st.floats` is biased toward 0.0, and the instrumented run
showed `admit` firing in `OPEN` 191 times without the wait ever elapsing.

Measured the same way afterwards: 17 of 20 seeds reach `HALF_OPEN` on roughly
half their examples (49–67%). All three override states are still entered,
so the #79 override-authoritative invariant keeps its coverage.
`max_examples` drops 200 → 120: the walk no longer needs the extra examples
to stumble into a probe round, holding the file's runtime near where it was.

Also documents that `Clock.monotonic()` must be non-negative:
`TimeBasedSlidingWindow` reserves a negative second as its "never written"
bucket sentinel, so a clock going below zero would report a permanently empty
window and the breaker would never trip — every stdlib monotonic clock
already satisfies this, but the contract previously only said "monotonically
increasing".

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #116