### PR TITLE
feat: make the degraded-storage retry policy configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The degraded-storage retry policy is now configurable (#100).** Every
+  release before this one retried a downed `Storage` backend on a single
+  fixed cadence (`retry_backoff`) — with many instances sharing that backend,
+  they all retried in lockstep, so a recovering backend immediately faced a
+  synchronised retry wave. `RedisStorage` / `AsyncRedisStorage` gain three new
+  keyword-only knobs: `retry_backoff_multiplier` grows the delay
+  geometrically with each further *consecutive* failure, `retry_backoff_max`
+  caps it, and `retry_jitter` spreads it with a proportional random draw
+  (deterministic under an injected clock, so it stays reproducible in tests).
+  The attempt counter resets on recovery. Defaults (`multiplier=1.0`,
+  `jitter=0.0`) exactly reproduce the fixed-delay behavior of earlier
+  releases — nothing changes unless you opt in. See the Redis integration
+  guide's Tuning section for the new knobs.
+
 - **CI now catches two release-only failure modes before they ship (#85).** A
   `packaging-smoke` job builds the wheel, runs `twine check` and
   `check-wheel-contents` against it, then installs it with `pip`-equivalent

--- a/docs/integrations/redis.md
+++ b/docs/integrations/redis.md
@@ -114,10 +114,17 @@ for the fleet: the breaker immediately resumes its cached shared `OPEN` or
 
 A storage error never reaches your calls. On the first failure the breaker
 switches to its local state and keeps protecting the process on its own window;
-pending shared writes are dropped, and Redis is left alone for `retry_backoff`
-seconds before the poller tries again. On the first successful operation the
-shared view becomes authoritative again — including adopting a shared OPEN that
-happened while this instance was cut off.
+pending shared writes are dropped, and Redis is left alone before the poller
+tries again. That delay starts at `retry_backoff` seconds and, by default,
+stays there for as long as the outage lasts — the same fixed cadence every
+release before this one used. Set `retry_backoff_multiplier` above `1.0` to
+grow it geometrically with each further consecutive failure (capped at
+`retry_backoff_max`), plus `retry_jitter` to spread out the retries of a fleet
+of instances recovering from the same outage instead of having them all probe
+Redis in the same instant. On the first successful operation the shared view
+becomes authoritative again — including adopting a shared OPEN that happened
+while this instance was cut off — and the failure count resets, so the next
+outage starts back at `retry_backoff`.
 
 Both edges are observable through the listener:
 
@@ -196,6 +203,9 @@ RedisStorage(
     state_ttl=300.0,  # key lifetime (s); refreshed on every write
     poll_interval=1.0,  # cache refresh cadence (s)
     retry_backoff=5.0,  # local-only time after a storage failure (s)
+    retry_backoff_multiplier=1.0,  # growth per consecutive failure; 1.0 = fixed delay
+    retry_backoff_max=None,  # cap on the delay (s), or None for no cap
+    retry_jitter=0.0,  # proportional random spread added to the (capped) delay
 )
 ```
 
@@ -204,7 +214,19 @@ RedisStorage(
   `wait_duration_in_open`.
 - **`poll_interval`** is the propagation latency of a coordinated trip. Each
   breaker costs about one Redis read per interval.
-- **`retry_backoff`** bounds how often a degraded breaker re-tests Redis.
+- **`retry_backoff`** is the delay before the first retry after a storage
+  failure, and the fixed delay for every retry after that while
+  `retry_backoff_multiplier` stays at its default of `1.0`.
+- **`retry_backoff_multiplier`** grows the delay geometrically with each
+  further *consecutive* failure (`retry_backoff * retry_backoff_multiplier **
+  attempts`); a recovery resets the attempt count. Must be `>= 1.0`.
+- **`retry_backoff_max`** caps the grown delay in seconds. `None` (the
+  default) leaves it uncapped.
+- **`retry_jitter`** adds up to this fraction of the (capped) delay as random
+  spread, so instances that degraded at the same moment do not all retry
+  Redis at the same moment too. Deterministic given the same clock reading,
+  attempt number and breaker name — it does not depend on process-global
+  random state.
 
 ## Compatibility
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3226,10 +3226,17 @@ for the fleet: the breaker immediately resumes its cached shared `OPEN` or
 
 A storage error never reaches your calls. On the first failure the breaker
 switches to its local state and keeps protecting the process on its own window;
-pending shared writes are dropped, and Redis is left alone for `retry_backoff`
-seconds before the poller tries again. On the first successful operation the
-shared view becomes authoritative again — including adopting a shared OPEN that
-happened while this instance was cut off.
+pending shared writes are dropped, and Redis is left alone before the poller
+tries again. That delay starts at `retry_backoff` seconds and, by default,
+stays there for as long as the outage lasts — the same fixed cadence every
+release before this one used. Set `retry_backoff_multiplier` above `1.0` to
+grow it geometrically with each further consecutive failure (capped at
+`retry_backoff_max`), plus `retry_jitter` to spread out the retries of a fleet
+of instances recovering from the same outage instead of having them all probe
+Redis in the same instant. On the first successful operation the shared view
+becomes authoritative again — including adopting a shared OPEN that happened
+while this instance was cut off — and the failure count resets, so the next
+outage starts back at `retry_backoff`.
 
 Both edges are observable through the listener:
 
@@ -3308,6 +3315,9 @@ RedisStorage(
     state_ttl=300.0,  # key lifetime (s); refreshed on every write
     poll_interval=1.0,  # cache refresh cadence (s)
     retry_backoff=5.0,  # local-only time after a storage failure (s)
+    retry_backoff_multiplier=1.0,  # growth per consecutive failure; 1.0 = fixed delay
+    retry_backoff_max=None,  # cap on the delay (s), or None for no cap
+    retry_jitter=0.0,  # proportional random spread added to the (capped) delay
 )
 ```
 
@@ -3316,7 +3326,19 @@ RedisStorage(
   `wait_duration_in_open`.
 - **`poll_interval`** is the propagation latency of a coordinated trip. Each
   breaker costs about one Redis read per interval.
-- **`retry_backoff`** bounds how often a degraded breaker re-tests Redis.
+- **`retry_backoff`** is the delay before the first retry after a storage
+  failure, and the fixed delay for every retry after that while
+  `retry_backoff_multiplier` stays at its default of `1.0`.
+- **`retry_backoff_multiplier`** grows the delay geometrically with each
+  further *consecutive* failure (`retry_backoff * retry_backoff_multiplier **
+  attempts`); a recovery resets the attempt count. Must be `>= 1.0`.
+- **`retry_backoff_max`** caps the grown delay in seconds. `None` (the
+  default) leaves it uncapped.
+- **`retry_jitter`** adds up to this fraction of the (capped) delay as random
+  spread, so instances that degraded at the same moment do not all retry
+  Redis at the same moment too. Deterministic given the same clock reading,
+  attempt number and breaker name — it does not depend on process-global
+  random state.
 
 ## Compatibility
 
@@ -3665,7 +3687,7 @@ See the [Litestar integration](integrations/litestar.md).
 
 Extra `interlock-cb[redis]`, module `interlock.integrations.redis`:
 
-- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0)`** —
+- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0, retry_backoff_multiplier=1.0, retry_backoff_max=None, retry_jitter=0.0)`** —
   sync `Storage` over a `redis.Redis` client.
 - **`AsyncRedisStorage(client, *, ...)`** — async mirror over
   `redis.asyncio.Redis`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -239,7 +239,7 @@ See the [Litestar integration](integrations/litestar.md).
 
 Extra `interlock-cb[redis]`, module `interlock.integrations.redis`:
 
-- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0)`** —
+- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0, retry_backoff_multiplier=1.0, retry_backoff_max=None, retry_jitter=0.0)`** —
   sync `Storage` over a `redis.Redis` client.
 - **`AsyncRedisStorage(client, *, ...)`** — async mirror over
   `redis.asyncio.Redis`.

--- a/interlock/_coordination.py
+++ b/interlock/_coordination.py
@@ -14,14 +14,19 @@ is the plumbing between the two, built so the protected path stays fast:
   the poller refreshing the cached view every ``poll_interval``.
 - Storage failures never reach the protected path: any storage error
   flips the coordinator into degraded mode — the breaker runs on local state,
-  writes are dropped, and the lane keeps retrying after ``retry_backoff``
-  seconds. Degradation and recovery surface through the engine's listener
-  callbacks; on recovery the shared view becomes authoritative again.
+  writes are dropped, and the lane keeps retrying after a backoff delay that
+  grows with consecutive failures (``retry_backoff`` *
+  ``retry_backoff_multiplier`` ** attempts, capped at ``retry_backoff_max``,
+  plus proportional ``retry_jitter``) so many instances recovering from the
+  same outage do not retry in lockstep. Degradation and recovery surface
+  through the engine's listener callbacks; on recovery the shared view
+  becomes authoritative again and the attempt counter resets.
 
 Tuning knobs are read from optional attributes on the storage object
-(``state_ttl``, ``poll_interval``, ``retry_backoff``) with conservative
-defaults, so the ``Storage`` protocol itself stays minimal and the core
-``Config`` stays storage-agnostic.
+(``state_ttl``, ``poll_interval``, ``retry_backoff``,
+``retry_backoff_multiplier``, ``retry_backoff_max``, ``retry_jitter``) with
+conservative defaults, so the ``Storage`` protocol itself stays minimal and
+the core ``Config`` stays storage-agnostic.
 
 The probe-round decision is the one piece of threshold policy applied here:
 after the last probe the lane computes the same rate checks as the local state
@@ -32,6 +37,7 @@ clobber a newer shared state.
 
 import asyncio
 import queue
+import random
 import threading
 import weakref
 from collections.abc import Awaitable, Callable
@@ -47,6 +53,9 @@ __all__ = ('AsyncCoordinator', 'SyncCoordinator')
 _DEFAULT_STATE_TTL = 300.0
 _DEFAULT_POLL_INTERVAL = 1.0
 _DEFAULT_RETRY_BACKOFF = 5.0
+_DEFAULT_RETRY_BACKOFF_MULTIPLIER = 1.0
+_DEFAULT_RETRY_BACKOFF_MAX: float | None = None
+_DEFAULT_RETRY_JITTER = 0.0
 
 _SyncOp = Callable[[], None]
 _AsyncOp = Callable[[], Awaitable[None]]
@@ -97,9 +106,16 @@ class _CoordinatorBase:
         self._ttl = float(getattr(storage, 'state_ttl', _DEFAULT_STATE_TTL))
         self._interval = float(getattr(storage, 'poll_interval', _DEFAULT_POLL_INTERVAL))
         self._backoff = float(getattr(storage, 'retry_backoff', _DEFAULT_RETRY_BACKOFF))
+        self._backoff_multiplier = float(
+            getattr(storage, 'retry_backoff_multiplier', _DEFAULT_RETRY_BACKOFF_MULTIPLIER)
+        )
+        backoff_max = getattr(storage, 'retry_backoff_max', _DEFAULT_RETRY_BACKOFF_MAX)
+        self._backoff_max = float(backoff_max) if backoff_max is not None else None
+        self._jitter = float(getattr(storage, 'retry_jitter', _DEFAULT_RETRY_JITTER))
         self._lock = threading.Lock()
         self._degraded = False
         self._retry_at = 0.0
+        self._failures = 0
         self._last_view: SharedState | None = None
         self._stopped = False
 
@@ -120,7 +136,8 @@ class _CoordinatorBase:
         with self._lock:
             first = not self._degraded
             self._degraded = True
-            self._retry_at = self._clock.monotonic() + self._backoff
+            self._retry_at = self._clock.monotonic() + self._next_delay(self._failures)
+            self._failures += 1
 
         if first:
             self._on_degraded(error)
@@ -129,9 +146,31 @@ class _CoordinatorBase:
         with self._lock:
             was_degraded = self._degraded
             self._degraded = False
+            self._failures = 0
 
         if was_degraded:
             self._on_recovered()
+
+    def _next_delay(self, attempt: int) -> float:
+        """Backoff for the ``attempt``-th consecutive failure (0-indexed).
+
+        Grows geometrically from ``retry_backoff``, capped at
+        ``retry_backoff_max``, then widened by up to ``retry_jitter`` (a
+        fraction of the capped delay) so that many instances degrading from
+        the same outage do not all retry at the same instant. The jitter draw
+        is seeded from the clock reading, the attempt number and the breaker
+        name rather than process-global randomness, so it stays reproducible
+        under an injected (fake) clock in tests.
+        """
+        delay = self._backoff * (self._backoff_multiplier**attempt)
+        if self._backoff_max is not None:
+            delay = min(delay, self._backoff_max)
+        if self._jitter <= 0.0:
+            return delay
+
+        seed = f'{self._name}:{self._clock.monotonic()}:{attempt}'.encode()
+        spread = random.Random(seed).random()  # noqa: S311 - jitter, not crypto
+        return delay + delay * self._jitter * spread
 
     def _round_finished(self, view: SharedState) -> bool:
         return (

--- a/interlock/integrations/redis.py
+++ b/interlock/integrations/redis.py
@@ -201,14 +201,32 @@ def _positive(name: str, value: float) -> float:
     return value
 
 
+def _at_least_one(name: str, value: float) -> float:
+    if value < 1.0:
+        msg = f'{name} must be >= 1.0, got {value!r}'
+        raise ValueError(msg)
+    return value
+
+
+def _non_negative(name: str, value: float) -> float:
+    if value < 0:
+        msg = f'{name} must be >= 0, got {value!r}'
+        raise ValueError(msg)
+    return value
+
+
 class RedisStorage:
     """Synchronous ``Storage`` backed by a ``redis.Redis`` client.
 
-    The three keyword floats are the coordination tuning knobs the engine reads
-    off the storage object: how long state keys live without a refresh
+    The keyword floats are the coordination tuning knobs the engine reads off
+    the storage object: how long state keys live without a refresh
     (``state_ttl``), how often the cached shared view is refreshed
-    (``poll_interval``), and how long the breaker runs purely locally after a
-    storage failure before retrying (``retry_backoff``).
+    (``poll_interval``), and the degraded-storage retry policy — how long the
+    breaker runs purely locally after a storage failure before retrying
+    (``retry_backoff``), how that delay grows on further consecutive failures
+    (``retry_backoff_multiplier``, capped at ``retry_backoff_max``), and how
+    much proportional jitter to add so that many instances recovering from
+    the same outage do not retry in lockstep (``retry_jitter``).
 
     Args:
         client: A connected ``redis.Redis`` instance.
@@ -216,6 +234,13 @@ class RedisStorage:
         state_ttl: Key lifetime in seconds; refreshed on every write.
         poll_interval: Seconds between background view refreshes.
         retry_backoff: Seconds to stay degraded after a storage failure.
+        retry_backoff_multiplier: Growth factor applied per consecutive
+            failure; must be >= 1.0. The default, 1.0, reproduces the fixed
+            ``retry_backoff`` delay of earlier releases.
+        retry_backoff_max: Upper bound on the backoff delay in seconds, or
+            ``None`` for no cap.
+        retry_jitter: Fraction (>= 0) of the capped delay added as random
+            spread. The default, 0.0, adds none.
     """
 
     def __init__(
@@ -226,12 +251,22 @@ class RedisStorage:
         state_ttl: float = 300.0,
         poll_interval: float = 1.0,
         retry_backoff: float = 5.0,
+        retry_backoff_multiplier: float = 1.0,
+        retry_backoff_max: float | None = None,
+        retry_jitter: float = 0.0,
     ) -> None:
         self._client = client
         self._prefix = key_prefix
         self.state_ttl = _positive('state_ttl', state_ttl)
         self.poll_interval = _positive('poll_interval', poll_interval)
         self.retry_backoff = _positive('retry_backoff', retry_backoff)
+        self.retry_backoff_multiplier = _at_least_one(
+            'retry_backoff_multiplier', retry_backoff_multiplier
+        )
+        self.retry_backoff_max = (
+            None if retry_backoff_max is None else _positive('retry_backoff_max', retry_backoff_max)
+        )
+        self.retry_jitter = _non_negative('retry_jitter', retry_jitter)
 
     def _key(self, name: str) -> str:
         return f'{self._prefix}{name}'
@@ -300,6 +335,13 @@ class AsyncRedisStorage:
         state_ttl: Key lifetime in seconds; refreshed on every write.
         poll_interval: Seconds between background view refreshes.
         retry_backoff: Seconds to stay degraded after a storage failure.
+        retry_backoff_multiplier: Growth factor applied per consecutive
+            failure; must be >= 1.0. The default, 1.0, reproduces the fixed
+            ``retry_backoff`` delay of earlier releases.
+        retry_backoff_max: Upper bound on the backoff delay in seconds, or
+            ``None`` for no cap.
+        retry_jitter: Fraction (>= 0) of the capped delay added as random
+            spread. The default, 0.0, adds none.
     """
 
     def __init__(
@@ -310,12 +352,22 @@ class AsyncRedisStorage:
         state_ttl: float = 300.0,
         poll_interval: float = 1.0,
         retry_backoff: float = 5.0,
+        retry_backoff_multiplier: float = 1.0,
+        retry_backoff_max: float | None = None,
+        retry_jitter: float = 0.0,
     ) -> None:
         self._client = client
         self._prefix = key_prefix
         self.state_ttl = _positive('state_ttl', state_ttl)
         self.poll_interval = _positive('poll_interval', poll_interval)
         self.retry_backoff = _positive('retry_backoff', retry_backoff)
+        self.retry_backoff_multiplier = _at_least_one(
+            'retry_backoff_multiplier', retry_backoff_multiplier
+        )
+        self.retry_backoff_max = (
+            None if retry_backoff_max is None else _positive('retry_backoff_max', retry_backoff_max)
+        )
+        self.retry_jitter = _non_negative('retry_jitter', retry_jitter)
 
     def _key(self, name: str) -> str:
         return f'{self._prefix}{name}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ ban-relative-imports = "all"
 "interlock/pipeline.py" = [
   "PLR0913", # PipelineBuilder.retry mirrors RetryStrategy's keyword-only collaborators
 ]
+"interlock/integrations/redis.py" = [
+  "PLR0913", # RedisStorage/AsyncRedisStorage take keyword-only coordination tuning knobs
+]
 "benchmarks/**/*.py" = [
   "INP001",  # benchmarks are collected by pytest, not imported
   "S101",    # a sanity assert keeps each benchmark honest about what it measures

--- a/tests/inmemory_storage.py
+++ b/tests/inmemory_storage.py
@@ -122,6 +122,9 @@ class InMemoryStorage:
         self.state_ttl = 300.0
         self.poll_interval = 1.0
         self.retry_backoff = 5.0
+        self.retry_backoff_multiplier = 1.0
+        self.retry_backoff_max: float | None = None
+        self.retry_jitter = 0.0
 
     def read(self, name: str) -> SharedState | None:
         return self._core.read(name)
@@ -157,6 +160,9 @@ class AsyncInMemoryStorage:
         self.state_ttl = 300.0
         self.poll_interval = 1.0
         self.retry_backoff = 5.0
+        self.retry_backoff_multiplier = 1.0
+        self.retry_backoff_max: float | None = None
+        self.retry_jitter = 0.0
 
     async def read(self, name: str) -> SharedState | None:
         return self._core.read(name)

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -75,11 +75,16 @@ class FlakyStorage:
     def __init__(self, inner: InMemoryStorage) -> None:
         self._inner = inner
         self.fail = False
+        self.calls = 0
         self.state_ttl = inner.state_ttl
         self.poll_interval = inner.poll_interval
         self.retry_backoff = inner.retry_backoff
+        self.retry_backoff_multiplier = inner.retry_backoff_multiplier
+        self.retry_backoff_max = inner.retry_backoff_max
+        self.retry_jitter = inner.retry_jitter
 
     def _check(self) -> None:
+        self.calls += 1
         if self.fail:
             raise ConnectionError('storage down')
 
@@ -465,6 +470,189 @@ def test__degradation__old_style_listener_does_not_break(
     assert breaker.call(lambda: 'ok') == 'ok'
 
 
+# --- degraded-storage retry policy: growth, cap, jitter, reset (#100) ---
+
+
+def test__degraded__backoff_grows_geometrically_with_consecutive_failures(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    flaky.retry_backoff = 1.0
+    flaky.retry_backoff_multiplier = 2.0
+    breaker = _breaker(config, fake_clock, flaky)
+    flaky.fail = True
+
+    _coordinator(breaker).poll_once()  # 1st failure: next delay = 1.0 * 2**0 = 1.0
+    assert flaky.calls == 1
+
+    fake_clock.advance(0.999)
+    _coordinator(breaker).poll_once()  # not due yet: gate stays closed
+    assert flaky.calls == 1
+
+    fake_clock.advance(0.002)  # now 1.001, past the 1.0s delay
+    _coordinator(breaker).poll_once()  # 2nd failure: next delay = 1.0 * 2**1 = 2.0
+    assert flaky.calls == 2
+
+    fake_clock.advance(1.999)  # now 3.0, just short of 1.001 + 2.0 = 3.001
+    _coordinator(breaker).poll_once()
+    assert flaky.calls == 2  # still gated: proves the delay actually doubled
+
+    fake_clock.advance(0.002)  # now 3.002, past the due time
+    _coordinator(breaker).poll_once()  # 3rd failure confirms the geometric growth held
+    assert flaky.calls == 3
+
+
+def test__degraded__backoff_capped_at_retry_backoff_max(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    flaky.retry_backoff = 1.0
+    flaky.retry_backoff_multiplier = 10.0
+    flaky.retry_backoff_max = 5.0
+    breaker = _breaker(config, fake_clock, flaky)
+    flaky.fail = True
+
+    _coordinator(breaker).poll_once()  # 1st failure: next delay = 1.0 (uncapped)
+    assert flaky.calls == 1
+
+    fake_clock.advance(1.0)
+    _coordinator(breaker).poll_once()  # 2nd failure: 1.0 * 10**1 = 10, capped to 5.0
+    assert flaky.calls == 2
+
+    fake_clock.advance(4.999)
+    _coordinator(breaker).poll_once()  # not yet past the capped 5.0s delay
+    assert flaky.calls == 2
+
+    fake_clock.advance(0.002)  # now past it: an uncapped 10s delay would still gate this
+    _coordinator(breaker).poll_once()
+    assert flaky.calls == 3
+
+
+def test__degraded__attempt_counter_resets_on_recovery(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky = FlakyStorage(storage)
+    flaky.retry_backoff = 1.0
+    flaky.retry_backoff_multiplier = 2.0
+    breaker = _breaker(config, fake_clock, flaky)
+    flaky.fail = True
+
+    _coordinator(breaker).poll_once()  # attempt 0: next delay 1.0
+    fake_clock.advance(1.0)
+    _coordinator(breaker).poll_once()  # attempt 1: next delay 2.0, still failing
+    assert flaky.calls == 2
+
+    flaky.fail = False
+    fake_clock.advance(2.0)
+    _coordinator(breaker).poll_once()  # recovers: attempt counter resets to 0
+    assert flaky.calls == 3
+
+    flaky.fail = True
+    _coordinator(breaker).poll_once()  # fails again right away: gate was open (not degraded)
+    assert flaky.calls == 4  # this failure re-degrades using attempt 0, not 2
+
+    fake_clock.advance(0.999)
+    _coordinator(breaker).poll_once()
+    assert flaky.calls == 4  # gated at ~1.0s, proving the counter did not keep growing from before
+
+    fake_clock.advance(0.002)
+    _coordinator(breaker).poll_once()
+    assert flaky.calls == 5
+
+
+def test__degraded__jitter_is_bounded_and_reproducible_for_the_same_seed(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    flaky_a = FlakyStorage(storage)
+    flaky_a.retry_backoff = 10.0
+    flaky_a.retry_jitter = 0.5
+    breaker_a = _breaker(config, fake_clock, flaky_a)
+
+    flaky_b = FlakyStorage(storage)
+    flaky_b.retry_backoff = 10.0
+    flaky_b.retry_jitter = 0.5
+    breaker_b = _breaker(config, fake_clock, flaky_b)  # different instance, same name + clock
+
+    delay_a = _coordinator(breaker_a)._next_delay(0)
+    delay_b = _coordinator(breaker_b)._next_delay(0)
+
+    # Same (name, clock reading, attempt) seed -> the same draw, not process-global
+    # randomness, so the delay is reproducible under a fake clock in tests.
+    assert delay_a == delay_b
+    assert 10.0 <= delay_a < 15.0  # base delay plus up to 50% proportional spread
+
+    fake_clock.advance(1.0)
+    delay_later = _coordinator(breaker_a)._next_delay(0)
+    assert delay_later != delay_a  # a different clock reading draws differently
+
+
+@pytest.mark.asyncio
+async def test__async__degraded__backoff_grows_geometrically_with_consecutive_failures(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    inner = AsyncInMemoryStorage(clock=fake_clock)
+    flaky = AsyncFlakyStorage(inner)
+    flaky.retry_backoff = 1.0
+    flaky.retry_backoff_multiplier = 2.0
+    breaker = _breaker(config, fake_clock, flaky)
+    coordinator = _async_coordinator(breaker)
+    flaky.fail = True
+
+    await coordinator.poll_once()  # 1st failure: next delay = 1.0
+    assert flaky.calls == 1
+
+    fake_clock.advance(0.999)
+    await coordinator.poll_once()
+    assert flaky.calls == 1  # not due yet
+
+    fake_clock.advance(0.002)
+    await coordinator.poll_once()  # 2nd failure: next delay = 2.0
+    assert flaky.calls == 2
+
+    fake_clock.advance(1.999)
+    await coordinator.poll_once()
+    assert flaky.calls == 2  # still gated: the delay doubled, not stayed at 1.0
+
+    fake_clock.advance(0.002)
+    await coordinator.poll_once()
+    assert flaky.calls == 3
+
+
+@pytest.mark.asyncio
+async def test__async__degraded__attempt_counter_resets_on_recovery(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    inner = AsyncInMemoryStorage(clock=fake_clock)
+    flaky = AsyncFlakyStorage(inner)
+    flaky.retry_backoff = 1.0
+    flaky.retry_backoff_multiplier = 2.0
+    breaker = _breaker(config, fake_clock, flaky)
+    coordinator = _async_coordinator(breaker)
+    flaky.fail = True
+
+    await coordinator.poll_once()  # attempt 0: next delay 1.0
+    fake_clock.advance(1.0)
+    await coordinator.poll_once()  # attempt 1: next delay 2.0
+    assert flaky.calls == 2
+
+    flaky.fail = False
+    fake_clock.advance(2.0)
+    await coordinator.poll_once()  # recovers: attempt counter resets to 0
+    assert flaky.calls == 3
+
+    flaky.fail = True
+    await coordinator.poll_once()  # fails again immediately (gate was open)
+    assert flaky.calls == 4
+
+    fake_clock.advance(0.999)
+    await coordinator.poll_once()
+    assert flaky.calls == 4  # gated at ~1.0s again, not continuing from 4.0
+
+    fake_clock.advance(0.002)
+    await coordinator.poll_once()
+    assert flaky.calls == 5
+
+
 # --- runtime matching (D8) ---
 
 
@@ -660,11 +848,16 @@ class AsyncFlakyStorage:
     def __init__(self, inner: AsyncInMemoryStorage) -> None:
         self._inner = inner
         self.fail = False
+        self.calls = 0
         self.state_ttl = inner.state_ttl
         self.poll_interval = inner.poll_interval
         self.retry_backoff = inner.retry_backoff
+        self.retry_backoff_multiplier = inner.retry_backoff_multiplier
+        self.retry_backoff_max = inner.retry_backoff_max
+        self.retry_jitter = inner.retry_jitter
 
     def _check(self) -> None:
+        self.calls += 1
         if self.fail:
             raise ConnectionError('storage down')
 

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -386,6 +386,32 @@ def test__constructor__rejects_non_positive_knobs(redis_client: redis_mod.Redis)
         RedisStorage(redis_client, retry_backoff=0.0)
 
 
+def test__constructor__rejects_invalid_retry_policy_knobs(redis_client: redis_mod.Redis) -> None:
+    with pytest.raises(ValueError, match='retry_backoff_multiplier'):
+        RedisStorage(redis_client, retry_backoff_multiplier=0.5)
+    with pytest.raises(ValueError, match='retry_backoff_max'):
+        RedisStorage(redis_client, retry_backoff_max=0.0)
+    with pytest.raises(ValueError, match='retry_jitter'):
+        RedisStorage(redis_client, retry_jitter=-0.1)
+
+
+def test__constructor__accepts_configured_retry_policy_knobs(redis_client: redis_mod.Redis) -> None:
+    storage = RedisStorage(
+        redis_client,
+        retry_backoff_multiplier=2.0,
+        retry_backoff_max=30.0,
+        retry_jitter=0.2,
+    )
+    assert storage.retry_backoff_multiplier == 2.0
+    assert storage.retry_backoff_max == 30.0
+    assert storage.retry_jitter == 0.2
+
+    default = RedisStorage(redis_client)
+    assert default.retry_backoff_multiplier == 1.0
+    assert default.retry_backoff_max is None
+    assert default.retry_jitter == 0.0
+
+
 # --- e2e: coordinated breaker over RedisStorage ---
 
 


### PR DESCRIPTION
## Summary

- Every prior release retried a downed `Storage` backend on a single fixed cadence (`retry_backoff`). With many instances sharing that backend, they all retried in lockstep, so a recovering backend immediately faced a synchronised retry wave.
- `RedisStorage` / `AsyncRedisStorage` gain three keyword-only knobs: `retry_backoff_multiplier` grows the delay geometrically with each further *consecutive* failure, `retry_backoff_max` caps it, and `retry_jitter` adds a proportional random spread so instances degrading from the same outage do not all retry at the same instant.
- The jitter draw is seeded from the clock reading, the attempt number and the breaker name (via a sha512-seeded `random.Random`, not process-global randomness), so it stays deterministic and reproducible under an injected (fake) clock in tests.
- The attempt counter resets on recovery (`_mark_available`).
- Defaults (`multiplier=1.0`, `jitter=0.0`) exactly reproduce the fixed-delay behavior of every earlier release — no behavior change unless a caller opts in.

## Test plan

- [x] `uv run pytest --cov` — 100% coverage, 591 passed / 2 skipped (real-Redis-only tests, as documented)
- [x] New deterministic tests in `tests/test_coordination.py` (sync + async): geometric growth across consecutive failures, cap at `retry_backoff_max`, attempt-counter reset on recovery, jitter bounded and reproducible for the same (name, clock, attempt) seed
- [x] New constructor-validation tests in `tests/test_redis_storage.py` for the three new knobs
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] `uv run griffe check interlock --search .` — no public API breakage
- [x] Docs updated: `docs/integrations/redis.md` (degradation section + Tuning knobs), `docs/reference.md` (constructor signature), `_coordination.py` module docstring; `docs/llms-full.txt` regenerated
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #100