### PR TITLE
docs: document the coordinated-mode contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The Redis integration guide now documents the coordinated-mode contract
+  (#101).** Fencing (`expected_version`), the `state_ttl`-bounded probe-lease
+  leak on an interrupted probe, the "tallies only while `HALF_OPEN`" rule for
+  `record_probe`, and the need for explicit teardown were previously only
+  implicit in the code and internal notes. `docs/integrations/redis.md` gains
+  a "Coordinated mode contract" section plus a checklist for anyone
+  implementing `Storage` / `AsyncStorage` against a backend other than Redis,
+  and the `Storage` / `AsyncStorage` protocol docstrings point at it.
+
 - **The degraded-storage retry policy is now configurable (#100).** Every
   release before this one retried a downed `Storage` backend on a single
   fixed cadence (`retry_backoff`) — with many instances sharing that backend,

--- a/docs/integrations/redis.md
+++ b/docs/integrations/redis.md
@@ -101,6 +101,54 @@ of a round, the deciding instance applies the same thresholds as the local
 state machine and writes the transition guarded by a version check, so a
 delayed decision can never overwrite a newer state.
 
+## Coordinated mode contract
+
+`RedisStorage` implements `Storage` / `AsyncStorage`; a third-party backend can
+too. Four behaviours are part of that contract, not implementation detail —
+skipping any of them breaks the guarantees the coordinator relies on:
+
+1. **Fencing is mandatory.** `trip_open` and `close` accept `expected_version`
+   and must apply the write only when the backend's current version matches
+   it, otherwise no-op and return the current state. The coordinator relies on
+   this for the probe-round decision: a delayed instance computing "probes
+   passed" off a stale view must lose to a state another instance already
+   wrote, never overwrite it.
+2. **A leaked probe slot is bounded only by `state_ttl`.** `lease_probe`
+   decrements a shared budget and has no corresponding un-lease operation. A
+   `BaseException` — cancellation, process kill — between `lease_probe` and
+   `record_probe` never returns that slot; only the key's TTL expiry does.
+   With several instances interrupted mid-probe, `HALF_OPEN` can stall for up
+   to `state_ttl`. Size it with this in mind — it is not just an
+   abandoned-key cleanup knob.
+3. **`record_probe` tallies only while `HALF_OPEN`.** Every coordinated write
+   is best-effort: dropped while degraded, superseded by a later decision,
+   reconciled by the next poll rather than retried.
+4. **Teardown is explicit, not automatic.** `close()` / `aclose()` stop the
+   lane deterministically — see [Shutdown](#shutdown) below. A coordinated
+   breaker left to be garbage-collected can outlive its owning scope instead.
+
+Also: a breaker's `name` becomes a storage key (`interlock:cb:<name>` for
+`RedisStorage`). Never build one from untrusted input — an attacker-controlled
+name can collide with, and corrupt, unrelated breaker state.
+
+### Checklist for a custom `Storage` implementation
+
+- [ ] `trip_open` / `close` honor `expected_version`: apply only on a match,
+      otherwise no-op and return the current state.
+- [ ] Every operation is atomic against concurrent callers (a Lua script, a
+      locked transaction, ...) — no read-modify-write races.
+- [ ] `ttl` is refreshed on every write so an abandoned key self-expires.
+- [ ] `lease_probe` grants only while `HALF_OPEN` and budget remains.
+- [ ] `record_probe` tallies only while `HALF_OPEN`; a late or out-of-round
+      outcome is dropped, not applied.
+- [ ] No method raises into the protected path — the engine treats any
+      exception as a signal to degrade to local state, so a backend that
+      raises for a routine outcome (e.g. a fencing miss) breaks the contract;
+      that case must return the current state instead.
+- [ ] Time comparisons (has `wait_duration_in_open` elapsed?) use the
+      backend's own clock, not the caller's — instance clocks are not
+      comparable across a fleet.
+
 ## Manual controls
 
 Manual controls are local to one process and take precedence over Redis while

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3213,6 +3213,54 @@ of a round, the deciding instance applies the same thresholds as the local
 state machine and writes the transition guarded by a version check, so a
 delayed decision can never overwrite a newer state.
 
+## Coordinated mode contract
+
+`RedisStorage` implements `Storage` / `AsyncStorage`; a third-party backend can
+too. Four behaviours are part of that contract, not implementation detail —
+skipping any of them breaks the guarantees the coordinator relies on:
+
+1. **Fencing is mandatory.** `trip_open` and `close` accept `expected_version`
+   and must apply the write only when the backend's current version matches
+   it, otherwise no-op and return the current state. The coordinator relies on
+   this for the probe-round decision: a delayed instance computing "probes
+   passed" off a stale view must lose to a state another instance already
+   wrote, never overwrite it.
+2. **A leaked probe slot is bounded only by `state_ttl`.** `lease_probe`
+   decrements a shared budget and has no corresponding un-lease operation. A
+   `BaseException` — cancellation, process kill — between `lease_probe` and
+   `record_probe` never returns that slot; only the key's TTL expiry does.
+   With several instances interrupted mid-probe, `HALF_OPEN` can stall for up
+   to `state_ttl`. Size it with this in mind — it is not just an
+   abandoned-key cleanup knob.
+3. **`record_probe` tallies only while `HALF_OPEN`.** Every coordinated write
+   is best-effort: dropped while degraded, superseded by a later decision,
+   reconciled by the next poll rather than retried.
+4. **Teardown is explicit, not automatic.** `close()` / `aclose()` stop the
+   lane deterministically — see [Shutdown](#shutdown) below. A coordinated
+   breaker left to be garbage-collected can outlive its owning scope instead.
+
+Also: a breaker's `name` becomes a storage key (`interlock:cb:<name>` for
+`RedisStorage`). Never build one from untrusted input — an attacker-controlled
+name can collide with, and corrupt, unrelated breaker state.
+
+### Checklist for a custom `Storage` implementation
+
+- [ ] `trip_open` / `close` honor `expected_version`: apply only on a match,
+      otherwise no-op and return the current state.
+- [ ] Every operation is atomic against concurrent callers (a Lua script, a
+      locked transaction, ...) — no read-modify-write races.
+- [ ] `ttl` is refreshed on every write so an abandoned key self-expires.
+- [ ] `lease_probe` grants only while `HALF_OPEN` and budget remains.
+- [ ] `record_probe` tallies only while `HALF_OPEN`; a late or out-of-round
+      outcome is dropped, not applied.
+- [ ] No method raises into the protected path — the engine treats any
+      exception as a signal to degrade to local state, so a backend that
+      raises for a routine outcome (e.g. a fencing miss) breaks the contract;
+      that case must return the current state instead.
+- [ ] Time comparisons (has `wait_duration_in_open` elapsed?) use the
+      backend's own clock, not the caller's — instance clocks are not
+      comparable across a fleet.
+
 ## Manual controls
 
 Manual controls are local to one process and take precedence over Redis while

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -65,6 +65,10 @@ class Storage(Protocol):
     This is the synchronous contract; ``AsyncStorage`` mirrors it for async
     breakers. No method may raise into the protected path — the engine degrades
     to local state on backend failure.
+
+    A custom implementation must uphold the fencing, probe-lease TTL and
+    teardown guarantees described in the "Coordinated mode contract" section
+    of ``docs/integrations/redis.md``, including its implementation checklist.
     """
 
     def read(self, name: str) -> SharedState | None:
@@ -128,8 +132,9 @@ class Storage(Protocol):
 class AsyncStorage(Protocol):
     """Async mirror of ``Storage`` for async breakers.
 
-    See ``Storage`` for the full contract; every method is the awaitable
-    counterpart.
+    See ``Storage`` for the full contract, including the coordinated-mode
+    contract a custom implementation must uphold; every method here is the
+    awaitable counterpart.
     """
 
     async def read(self, name: str) -> SharedState | None:


### PR DESCRIPTION
## Summary

Coordinated mode has four behaviours a `Storage` implementer or an operator must know, previously only recorded in internal notes and docstrings:

- Fencing (`expected_version`) is mandatory for `trip_open` / `close`, not optional.
- A leaked probe slot (interrupted between `lease_probe` and `record_probe`) is bounded only by `state_ttl`.
- `record_probe` tallies only while `HALF_OPEN`; every coordinated write is best-effort.
- Teardown (`close()` / `aclose()`) is explicit, never automatic.

Adds a "Coordinated mode contract" section plus an implementation checklist to `docs/integrations/redis.md`, and points the `Storage` / `AsyncStorage` protocol docstrings at it. Also notes that breaker `name` values become storage keys, so callers should not build them from untrusted input.

## Test plan

- [x] `uv run ruff format --check` / `uv run ruff check` on changed files
- [x] `uv run mypy` / `uv run pyright` on `interlock/protocols.py`
- [x] `uv run zensical build --strict` (catches broken anchors)
- [x] `uv run pytest tests/test_redis_storage.py tests/test_coordination.py` (88 passed, 2 skipped)
- [x] `uv run python scripts/build_llms_full.py` regenerated and committed

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — docs-only change, no code paths added
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #101