### PR TITLE
chore: prepare the 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-03
+
 ### Added
 
 - **The Redis integration guide now documents the coordinated-mode contract
@@ -553,7 +555,8 @@ The major version marks the scope of what is added, not a migration burden.
 - `InterlockDeprecationWarning` (subclasses `UserWarning`, visible by default).
 - `py.typed`; strict mypy and pyright; 100% test coverage.
 
-[Unreleased]: https://github.com/bagowix/interlock/compare/v2.1.4...HEAD
+[Unreleased]: https://github.com/bagowix/interlock/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/bagowix/interlock/compare/v2.1.4...v2.2.0
 [2.1.4]: https://github.com/bagowix/interlock/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/bagowix/interlock/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/bagowix/interlock/compare/v2.1.1...v2.1.2

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,7 +35,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of July 2026) | 2.1.4 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of July 2026) | 2.2.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -750,7 +750,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of July 2026) | 2.1.4 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of July 2026) | 2.2.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/interlock/version.py
+++ b/interlock/version.py
@@ -7,7 +7,7 @@ and read at build time by hatchling (see ``[tool.hatch.version]`` in
 
 __all__ = ('VERSION',)
 
-VERSION = '2.1.4'
+VERSION = '2.2.0'
 """The installed version of interlock.
 
 Guaranteed to comply with PEP 440 version specifiers.


### PR DESCRIPTION
## Summary

Prepare the `2.2.0` minor release.

- Bump the package version from `2.1.4` to `2.2.0`.
- Move the current changelog entries from `[Unreleased]` into `2.2.0`.
- Update changelog comparison links.
- Update the release version in the comparison page.
- Regenerate `docs/llms-full.txt`.

Minor, not patch: #100 added three new keyword-only knobs to `RedisStorage` / `AsyncRedisStorage` (`retry_backoff_multiplier`, `retry_backoff_max`, `retry_jitter`) — a public surface addition, backward compatible by default (`multiplier=1.0`, `jitter=0.0` reproduce prior behavior). The rest of `[Unreleased]` (#101, #85, the model-based test rebalance) is documentation, CI and test infra.

## Test plan

- [x] `uv run pytest --cov` — 591 passed, 2 skipped, 100% coverage
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] `uv run zensical build --strict` — docs build clean
- [x] `uv build` — `interlock_cb-2.2.0` sdist + wheel build successfully
- [x] `uv run griffe check interlock --search . -f oneline` — only the expected `VERSION` attribute change, already filtered by the CI gate (#121)

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Includes changes from #100, #101, #85