### PR TITLE
feat: bound the coordinator write queue and document its backpressure policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The coordinator's write queue is now bounded (#99).** The queue feeding a
+  coordinated breaker's background lane had no upper bound: a lane that stopped
+  draining — a storage client blocking without a timeout, an async lane whose
+  event loop is gone — grew it for as long as the process lived. It now holds
+  at most `write_queue_size` writes (a new `RedisStorage` /
+  `AsyncRedisStorage` keyword, default 128, read off the storage object like
+  the other coordination knobs). Over capacity the arriving write is dropped
+  rather than queued: it never blocks and never raises inside the protected
+  path, and it is reported through the new optional
+  `on_storage_write_dropped` listener hook (`LoggingEventListener` logs it at
+  `WARNING`, `OTelEventListener` counts it on `interlock.storage.events`).
+  Coordinated writes were already best-effort — a dropped one is reconciled by
+  the next poll and by `state_ttl` — and healthy lanes never reach the bound,
+  since writes are per transition rather than per call. Shutdown keeps working
+  with a full queue: one slot stays reserved for the stop sentinel.
+
 ## [2.2.0] - 2026-08-03
 
 ### Added

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -13,6 +13,7 @@ class EventListener(Protocol):
     def on_reset(self, *, name: str) -> None: ...
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
     def on_storage_recovered(self, *, name: str) -> None: ...
+    def on_storage_write_dropped(self, *, name: str) -> None: ...
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None: ...
     def on_bulkhead_rejected(self, *, name: str) -> None: ...
     def on_fallback(self, *, name: str, error: BaseException) -> None: ...
@@ -21,7 +22,7 @@ class EventListener(Protocol):
 Listeners are called **outside** the breaker's lock, after the protected call
 returns, so a slow listener never serialises throughput.
 
-The two storage hooks fire only for breakers coordinated through a shared
+The three storage hooks fire only for breakers coordinated through a shared
 [storage](../integrations/redis.md); the three pipeline hooks fire from
 [pipeline strategies](pipeline.md) given a `listener=`. Every hook is
 dispatched only if present — a listener that defines just the ones it cares
@@ -110,7 +111,7 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 | `interlock.call.rejected` | counter | `breaker` |
 | `interlock.state.changes` | counter | `breaker`, `from`, `to` |
 | `interlock.reset` | counter | `breaker` |
-| `interlock.storage.events` | counter | `breaker`, `event` (`degraded`/`recovered`), `error` |
+| `interlock.storage.events` | counter | `breaker`, `event` (`degraded`/`recovered`/`write_dropped`), `error` |
 
 ## Custom listeners
 

--- a/docs/integrations/redis.md
+++ b/docs/integrations/redis.md
@@ -121,8 +121,9 @@ skipping any of them breaks the guarantees the coordinator relies on:
    to `state_ttl`. Size it with this in mind — it is not just an
    abandoned-key cleanup knob.
 3. **`record_probe` tallies only while `HALF_OPEN`.** Every coordinated write
-   is best-effort: dropped while degraded, superseded by a later decision,
-   reconciled by the next poll rather than retried.
+   is best-effort *and* bounded: dropped while degraded, dropped when the
+   write queue is full, superseded by a later decision, reconciled by the next
+   poll rather than retried.
 4. **Teardown is explicit, not automatic.** `close()` / `aclose()` stop the
    lane deterministically — see [Shutdown](#shutdown) below. A coordinated
    breaker left to be garbage-collected can outlive its owning scope instead.
@@ -190,6 +191,35 @@ class StorageWatch:
 written before these hooks existed keep working — the engine calls them only if
 present.
 
+## Backpressure: the write queue is bounded
+
+Coordinated writes are fire-and-forget: a local trip and each probe outcome are
+queued for the background lane instead of being written on the protected path.
+That queue holds at most `write_queue_size` writes (128 by default).
+
+It is not a per-call queue — a healthy lane keeps it near empty, because writes
+happen per *transition*, not per call, and probes are capped by
+`permitted_calls_in_half_open`. The bound only matters when the lane stops
+draining at all: a Redis client blocking without a timeout, or an async lane
+whose event loop is gone. Without it, that lane would grow the queue for as
+long as the process lives.
+
+When the queue is full the *arriving* write is dropped — never blocked, never
+raised into the call that produced it — and reported:
+
+```python
+class StorageWatch:
+    def on_storage_write_dropped(self, *, name: str) -> None: ...  # shared state falling behind
+```
+
+Nothing is retried: the shared state is reconciled by the next successful poll
+and, failing that, by `state_ttl` expiring the key. Locally the breaker keeps
+protecting the process on its own window exactly as it does while degraded.
+
+The hook is the signal that a lane is wedged — treat a non-zero rate as an
+alert, not a tuning hint. `LoggingEventListener` logs it at `WARNING` and
+`OTelEventListener` counts it on `interlock.storage.events`.
+
 ## Shutdown
 
 A coordinated breaker owns a background lane — a daemon thread for a sync
@@ -254,6 +284,7 @@ RedisStorage(
     retry_backoff_multiplier=1.0,  # growth per consecutive failure; 1.0 = fixed delay
     retry_backoff_max=None,  # cap on the delay (s), or None for no cap
     retry_jitter=0.0,  # proportional random spread added to the (capped) delay
+    write_queue_size=128,  # max pending coordinated writes; further ones are dropped
 )
 ```
 
@@ -275,6 +306,10 @@ RedisStorage(
   Redis at the same moment too. Deterministic given the same clock reading,
   attempt number and breaker name — it does not depend on process-global
   random state.
+- **`write_queue_size`** bounds the pending coordinated writes; see
+  [Backpressure](#backpressure-the-write-queue-is-bounded). The default of 128
+  is far above what a draining lane ever holds, so raising it does not buy
+  throughput — it only lets a wedged lane hold more memory before dropping.
 
 ## Compatibility
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1735,6 +1735,7 @@ class EventListener(Protocol):
     def on_reset(self, *, name: str) -> None: ...
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
     def on_storage_recovered(self, *, name: str) -> None: ...
+    def on_storage_write_dropped(self, *, name: str) -> None: ...
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None: ...
     def on_bulkhead_rejected(self, *, name: str) -> None: ...
     def on_fallback(self, *, name: str, error: BaseException) -> None: ...
@@ -1743,7 +1744,7 @@ class EventListener(Protocol):
 Listeners are called **outside** the breaker's lock, after the protected call
 returns, so a slow listener never serialises throughput.
 
-The two storage hooks fire only for breakers coordinated through a shared
+The three storage hooks fire only for breakers coordinated through a shared
 [storage](../integrations/redis.md); the three pipeline hooks fire from
 [pipeline strategies](pipeline.md) given a `listener=`. Every hook is
 dispatched only if present — a listener that defines just the ones it cares
@@ -1832,7 +1833,7 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 | `interlock.call.rejected` | counter | `breaker` |
 | `interlock.state.changes` | counter | `breaker`, `from`, `to` |
 | `interlock.reset` | counter | `breaker` |
-| `interlock.storage.events` | counter | `breaker`, `event` (`degraded`/`recovered`), `error` |
+| `interlock.storage.events` | counter | `breaker`, `event` (`degraded`/`recovered`/`write_dropped`), `error` |
 
 ## Custom listeners
 
@@ -3233,8 +3234,9 @@ skipping any of them breaks the guarantees the coordinator relies on:
    to `state_ttl`. Size it with this in mind — it is not just an
    abandoned-key cleanup knob.
 3. **`record_probe` tallies only while `HALF_OPEN`.** Every coordinated write
-   is best-effort: dropped while degraded, superseded by a later decision,
-   reconciled by the next poll rather than retried.
+   is best-effort *and* bounded: dropped while degraded, dropped when the
+   write queue is full, superseded by a later decision, reconciled by the next
+   poll rather than retried.
 4. **Teardown is explicit, not automatic.** `close()` / `aclose()` stop the
    lane deterministically — see [Shutdown](#shutdown) below. A coordinated
    breaker left to be garbage-collected can outlive its owning scope instead.
@@ -3302,6 +3304,35 @@ class StorageWatch:
 written before these hooks existed keep working — the engine calls them only if
 present.
 
+## Backpressure: the write queue is bounded
+
+Coordinated writes are fire-and-forget: a local trip and each probe outcome are
+queued for the background lane instead of being written on the protected path.
+That queue holds at most `write_queue_size` writes (128 by default).
+
+It is not a per-call queue — a healthy lane keeps it near empty, because writes
+happen per *transition*, not per call, and probes are capped by
+`permitted_calls_in_half_open`. The bound only matters when the lane stops
+draining at all: a Redis client blocking without a timeout, or an async lane
+whose event loop is gone. Without it, that lane would grow the queue for as
+long as the process lives.
+
+When the queue is full the *arriving* write is dropped — never blocked, never
+raised into the call that produced it — and reported:
+
+```python
+class StorageWatch:
+    def on_storage_write_dropped(self, *, name: str) -> None: ...  # shared state falling behind
+```
+
+Nothing is retried: the shared state is reconciled by the next successful poll
+and, failing that, by `state_ttl` expiring the key. Locally the breaker keeps
+protecting the process on its own window exactly as it does while degraded.
+
+The hook is the signal that a lane is wedged — treat a non-zero rate as an
+alert, not a tuning hint. `LoggingEventListener` logs it at `WARNING` and
+`OTelEventListener` counts it on `interlock.storage.events`.
+
 ## Shutdown
 
 A coordinated breaker owns a background lane — a daemon thread for a sync
@@ -3366,6 +3397,7 @@ RedisStorage(
     retry_backoff_multiplier=1.0,  # growth per consecutive failure; 1.0 = fixed delay
     retry_backoff_max=None,  # cap on the delay (s), or None for no cap
     retry_jitter=0.0,  # proportional random spread added to the (capped) delay
+    write_queue_size=128,  # max pending coordinated writes; further ones are dropped
 )
 ```
 
@@ -3387,6 +3419,10 @@ RedisStorage(
   Redis at the same moment too. Deterministic given the same clock reading,
   attempt number and breaker name — it does not depend on process-global
   random state.
+- **`write_queue_size`** bounds the pending coordinated writes; see
+  [Backpressure](#backpressure-the-write-queue-is-bounded). The default of 128
+  is far above what a draining lane ever holds, so raising it does not buy
+  throughput — it only lets a wedged lane hold more memory before dropping.
 
 ## Compatibility
 
@@ -3630,7 +3666,8 @@ Implement any of these to swap a core behaviour:
 - **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`. See
   [Failure classification](guides/failure-classification.md).
 - **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`,
-  plus `on_storage_degraded` / `on_storage_recovered` for coordinated breakers
+  plus `on_storage_degraded` / `on_storage_recovered` /
+  `on_storage_write_dropped` for coordinated breakers
   and `on_retry` / `on_bulkhead_rejected` / `on_fallback` for pipeline
   strategies (all optional hooks are dispatched only if present, so older
   listeners keep working). See [Observability](guides/observability.md).
@@ -3735,7 +3772,7 @@ See the [Litestar integration](integrations/litestar.md).
 
 Extra `interlock-cb[redis]`, module `interlock.integrations.redis`:
 
-- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0, retry_backoff_multiplier=1.0, retry_backoff_max=None, retry_jitter=0.0)`** —
+- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0, retry_backoff_multiplier=1.0, retry_backoff_max=None, retry_jitter=0.0, write_queue_size=128)`** —
   sync `Storage` over a `redis.Redis` client.
 - **`AsyncRedisStorage(client, *, ...)`** — async mirror over
   `redis.asyncio.Redis`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -134,7 +134,8 @@ Implement any of these to swap a core behaviour:
 - **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`. See
   [Failure classification](guides/failure-classification.md).
 - **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`,
-  plus `on_storage_degraded` / `on_storage_recovered` for coordinated breakers
+  plus `on_storage_degraded` / `on_storage_recovered` /
+  `on_storage_write_dropped` for coordinated breakers
   and `on_retry` / `on_bulkhead_rejected` / `on_fallback` for pipeline
   strategies (all optional hooks are dispatched only if present, so older
   listeners keep working). See [Observability](guides/observability.md).
@@ -239,7 +240,7 @@ See the [Litestar integration](integrations/litestar.md).
 
 Extra `interlock-cb[redis]`, module `interlock.integrations.redis`:
 
-- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0, retry_backoff_multiplier=1.0, retry_backoff_max=None, retry_jitter=0.0)`** —
+- **`RedisStorage(client, *, key_prefix='interlock:cb:', state_ttl=300.0, poll_interval=1.0, retry_backoff=5.0, retry_backoff_multiplier=1.0, retry_backoff_max=None, retry_jitter=0.0, write_queue_size=128)`** —
   sync `Storage` over a `redis.Redis` client.
 - **`AsyncRedisStorage(client, *, ...)`** — async mirror over
   `redis.asyncio.Redis`.

--- a/interlock/_coordination.py
+++ b/interlock/_coordination.py
@@ -12,6 +12,12 @@ is the plumbing between the two, built so the protected path stays fast:
   decision) are fire-and-forget: they run on a background *lane* (one daemon
   thread for a sync storage, one asyncio task for an async one) that doubles as
   the poller refreshing the cached view every ``poll_interval``.
+- The queue feeding that lane is bounded (``write_queue_size``, at least 1).
+  Enqueues are O(transitions), not O(traffic), so the bound is only ever
+  reached by a lane that stopped draining; the newest write is then dropped
+  and reported through ``on_storage_write_dropped`` rather than blocking or
+  raising into the protected path. Coordinated writes are best-effort either
+  way — a dropped one is reconciled by the next poll and by ``state_ttl``.
 - Storage failures never reach the protected path: any storage error
   flips the coordinator into degraded mode — the breaker runs on local state,
   writes are dropped, and the lane keeps retrying after a backoff delay that
@@ -24,9 +30,9 @@ is the plumbing between the two, built so the protected path stays fast:
 
 Tuning knobs are read from optional attributes on the storage object
 (``state_ttl``, ``poll_interval``, ``retry_backoff``,
-``retry_backoff_multiplier``, ``retry_backoff_max``, ``retry_jitter``) with
-conservative defaults, so the ``Storage`` protocol itself stays minimal and
-the core ``Config`` stays storage-agnostic.
+``retry_backoff_multiplier``, ``retry_backoff_max``, ``retry_jitter``,
+``write_queue_size``) with conservative defaults, so the ``Storage`` protocol
+itself stays minimal and the core ``Config`` stays storage-agnostic.
 
 The probe-round decision is the one piece of threshold policy applied here:
 after the last probe the lane computes the same rate checks as the local state
@@ -56,6 +62,7 @@ _DEFAULT_RETRY_BACKOFF = 5.0
 _DEFAULT_RETRY_BACKOFF_MULTIPLIER = 1.0
 _DEFAULT_RETRY_BACKOFF_MAX: float | None = None
 _DEFAULT_RETRY_JITTER = 0.0
+_DEFAULT_WRITE_QUEUE_SIZE = 128
 
 _SyncOp = Callable[[], None]
 _AsyncOp = Callable[[], Awaitable[None]]
@@ -73,17 +80,23 @@ class _CoordinatorBase:
     """State and policy shared by the sync and async coordinators.
 
     Everything here is I/O-free; subclasses supply the storage calls and the
-    background lane. ``on_view`` / ``on_degraded`` / ``on_recovered`` are engine
-    callbacks — they must be fast and must not raise. They notify the user's
-    listener, which is why every hook goes through ``_notify.notify``: a raising
-    listener would otherwise kill the lane (``poll_once`` calls back outside its
-    ``try``) or be misreported as a storage failure (inside ``execute_op``).
+    background lane. ``on_view`` / ``on_degraded`` / ``on_recovered`` /
+    ``on_write_dropped`` are engine callbacks — they must be fast and must not
+    raise. They notify the user's listener, which is why every hook goes through
+    ``_notify.notify``: a raising listener would otherwise kill the lane
+    (``poll_once`` calls back outside its ``try``) or be misreported as a
+    storage failure (inside ``execute_op``).
 
     ``shutdown`` is terminal: the lane never restarts, and later writes are
     dropped exactly as they are while the storage is degraded. Everything that
     touches ``_stopped``, the lane handle and ``_work.put`` happens under
     ``_lock``, so a write can never be enqueued onto a lane that will not run
     to consume it — which would leave ``wait_idle`` unable to return.
+
+    The work queue holds ``write_queue_size`` writes plus one slot reserved for
+    the shutdown sentinel: ``_enqueue`` refuses to fill the last slot, so
+    ``shutdown`` can always wake a lane whose queue is full and never blocks
+    under ``_lock``.
     """
 
     def __init__(
@@ -96,6 +109,7 @@ class _CoordinatorBase:
         on_view: Callable[[SharedState], None],
         on_degraded: Callable[[BaseException], None],
         on_recovered: Callable[[], None],
+        on_write_dropped: Callable[[], None],
     ) -> None:
         self._name = name
         self._config = config
@@ -103,6 +117,7 @@ class _CoordinatorBase:
         self._on_view = on_view
         self._on_degraded = on_degraded
         self._on_recovered = on_recovered
+        self._on_write_dropped = on_write_dropped
         self._ttl = float(getattr(storage, 'state_ttl', _DEFAULT_STATE_TTL))
         self._interval = float(getattr(storage, 'poll_interval', _DEFAULT_POLL_INTERVAL))
         self._backoff = float(getattr(storage, 'retry_backoff', _DEFAULT_RETRY_BACKOFF))
@@ -112,6 +127,7 @@ class _CoordinatorBase:
         backoff_max = getattr(storage, 'retry_backoff_max', _DEFAULT_RETRY_BACKOFF_MAX)
         self._backoff_max = float(backoff_max) if backoff_max is not None else None
         self._jitter = float(getattr(storage, 'retry_jitter', _DEFAULT_RETRY_JITTER))
+        self._queue_size = int(getattr(storage, 'write_queue_size', _DEFAULT_WRITE_QUEUE_SIZE))
         self._lock = threading.Lock()
         self._degraded = False
         self._retry_at = 0.0
@@ -202,6 +218,7 @@ class SyncCoordinator(_CoordinatorBase):
         on_view: Callable[[SharedState], None],
         on_degraded: Callable[[BaseException], None],
         on_recovered: Callable[[], None],
+        on_write_dropped: Callable[[], None],
     ) -> None:
         super().__init__(
             name=name,
@@ -211,9 +228,10 @@ class SyncCoordinator(_CoordinatorBase):
             on_view=on_view,
             on_degraded=on_degraded,
             on_recovered=on_recovered,
+            on_write_dropped=on_write_dropped,
         )
         self._storage = storage
-        self._work: queue.Queue[_SyncOp] = queue.Queue()
+        self._work: queue.Queue[_SyncOp] = queue.Queue(maxsize=self._queue_size + 1)
         self._thread: threading.Thread | None = None
 
     def ensure_lane(self) -> None:
@@ -226,14 +244,16 @@ class SyncCoordinator(_CoordinatorBase):
 
         The sentinel wakes a lane parked in ``get`` immediately, so shutdown
         never waits out ``poll_interval``. Writes already queued run first
-        (FIFO); ones the degraded gate would drop are still dropped.
+        (FIFO); ones the degraded gate would drop are still dropped. The
+        sentinel goes into the slot ``_enqueue`` keeps reserved, so a full
+        queue can never make this block while holding ``_lock``.
         """
         with self._lock:
             first = not self._stopped
             self._stopped = True
             thread = self._thread
             if first and thread is not None:
-                self._work.put(_sync_stop)
+                self._work.put_nowait(_sync_stop)
 
         if thread is not None:
             thread.join()  # outside the lock: the lane takes it in poll_once
@@ -320,8 +340,16 @@ class SyncCoordinator(_CoordinatorBase):
         with self._lock:
             if self._stopped:
                 return  # shut down: drop the write, as the degraded gate does
-            self._work.put(op)
+            # Drop the newest, not the oldest: the queued writes are already
+            # accounted for by ``wait_idle``, so evicting one would need a
+            # matching ``task_done``. Dropping the arriving one keeps FIFO.
+            dropped = self._work.qsize() >= self._queue_size
+            if not dropped:
+                self._work.put_nowait(op)
             self._start_lane_locked()
+
+        if dropped:
+            self._on_write_dropped()  # outside the lock: it calls the listener
 
     def _start_lane_locked(self) -> None:
         if self._thread is not None or self._stopped:
@@ -406,6 +434,7 @@ class AsyncCoordinator(_CoordinatorBase):
         on_view: Callable[[SharedState], None],
         on_degraded: Callable[[BaseException], None],
         on_recovered: Callable[[], None],
+        on_write_dropped: Callable[[], None],
     ) -> None:
         super().__init__(
             name=name,
@@ -415,9 +444,10 @@ class AsyncCoordinator(_CoordinatorBase):
             on_view=on_view,
             on_degraded=on_degraded,
             on_recovered=on_recovered,
+            on_write_dropped=on_write_dropped,
         )
         self._storage = storage
-        self._work: asyncio.Queue[_AsyncOp] = asyncio.Queue()
+        self._work: asyncio.Queue[_AsyncOp] = asyncio.Queue(maxsize=self._queue_size + 1)
         self._lane_task: asyncio.Task[None] | None = None
 
     def ensure_lane(self) -> None:
@@ -518,8 +548,16 @@ class AsyncCoordinator(_CoordinatorBase):
         with self._lock:
             if self._stopped:
                 return  # shut down: drop the write, as the degraded gate does
-            self._work.put_nowait(op)
+            # Drop the newest, not the oldest, for the reason the sync lane
+            # does: evicting a queued write would need a matching ``task_done``
+            # to keep ``wait_idle`` accurate.
+            dropped = self._work.qsize() >= self._queue_size
+            if not dropped:
+                self._work.put_nowait(op)
             self._start_lane_locked()
+
+        if dropped:
+            self._on_write_dropped()  # outside the lock: it calls the listener
 
     def _start_lane_locked(self) -> None:
         if self._lane_task is not None or self._stopped:

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -107,6 +107,7 @@ class Engine:
                     on_view=self._on_shared_view,
                     on_degraded=self._on_storage_degraded,
                     on_recovered=self._on_storage_recovered,
+                    on_write_dropped=self._on_storage_write_dropped,
                 )
             else:
                 self._sync_coordinator = SyncCoordinator(
@@ -117,6 +118,7 @@ class Engine:
                     on_view=self._on_shared_view,
                     on_degraded=self._on_storage_degraded,
                     on_recovered=self._on_storage_recovered,
+                    on_write_dropped=self._on_storage_write_dropped,
                 )
 
     @property
@@ -553,6 +555,15 @@ class Engine:
 
         notify(self._listener, 'on_storage_recovered', name=self._name)
         self._emit_transitions(machine_state, machine_state, effective_before, effective_after)
+
+    def _on_storage_write_dropped(self) -> None:
+        """Coordinator callback: a shared write was dropped by a full queue.
+
+        Nothing local changes — the breaker keeps running on the state it
+        already has, and the shared state is reconciled by the next poll and
+        by ``state_ttl``. This only makes the drop observable.
+        """
+        notify(self._listener, 'on_storage_write_dropped', name=self._name)
 
     def _schedule_auto_transition(self) -> None:
         """Arm a timer to fire the proactive OPEN → HALF_OPEN once the wait ends.

--- a/interlock/integrations/otel.py
+++ b/interlock/integrations/otel.py
@@ -48,7 +48,7 @@ class OTelEventListener:
         )
         self._storage_events = meter.create_counter(
             'interlock.storage.events',
-            description='Shared storage degradations and recoveries.',
+            description='Shared storage degradations, recoveries and dropped writes.',
         )
         self._pipeline_events = meter.create_counter(
             'interlock.pipeline.events',
@@ -80,6 +80,10 @@ class OTelEventListener:
     def on_storage_recovered(self, *, name: str) -> None:
         """Count a storage recovery, labelled with the breaker."""
         self._storage_events.add(1, {'breaker': name, 'event': 'recovered'})
+
+    def on_storage_write_dropped(self, *, name: str) -> None:
+        """Count a dropped coordinated write, labelled with the breaker."""
+        self._storage_events.add(1, {'breaker': name, 'event': 'write_dropped'})
 
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None:  # noqa: ARG002
         """Count a retry, labelled with the strategy name (attempt/delay stay off the label)."""

--- a/interlock/integrations/redis.py
+++ b/interlock/integrations/redis.py
@@ -215,6 +215,13 @@ def _non_negative(name: str, value: float) -> float:
     return value
 
 
+def _positive_int(name: str, value: int) -> int:
+    if value < 1:
+        msg = f'{name} must be >= 1, got {value!r}'
+        raise ValueError(msg)
+    return value
+
+
 class RedisStorage:
     """Synchronous ``Storage`` backed by a ``redis.Redis`` client.
 
@@ -226,7 +233,8 @@ class RedisStorage:
     (``retry_backoff``), how that delay grows on further consecutive failures
     (``retry_backoff_multiplier``, capped at ``retry_backoff_max``), and how
     much proportional jitter to add so that many instances recovering from
-    the same outage do not retry in lockstep (``retry_jitter``).
+    the same outage do not retry in lockstep (``retry_jitter``). One more knob,
+    ``write_queue_size``, bounds the coordinator's fire-and-forget write queue.
 
     Args:
         client: A connected ``redis.Redis`` instance.
@@ -241,6 +249,9 @@ class RedisStorage:
             ``None`` for no cap.
         retry_jitter: Fraction (>= 0) of the capped delay added as random
             spread. The default, 0.0, adds none.
+        write_queue_size: Maximum number of pending coordinated writes; must
+            be >= 1. Further writes are dropped and reported through
+            ``on_storage_write_dropped`` instead of growing the queue.
     """
 
     def __init__(
@@ -254,6 +265,7 @@ class RedisStorage:
         retry_backoff_multiplier: float = 1.0,
         retry_backoff_max: float | None = None,
         retry_jitter: float = 0.0,
+        write_queue_size: int = 128,
     ) -> None:
         self._client = client
         self._prefix = key_prefix
@@ -267,6 +279,7 @@ class RedisStorage:
             None if retry_backoff_max is None else _positive('retry_backoff_max', retry_backoff_max)
         )
         self.retry_jitter = _non_negative('retry_jitter', retry_jitter)
+        self.write_queue_size = _positive_int('write_queue_size', write_queue_size)
 
     def _key(self, name: str) -> str:
         return f'{self._prefix}{name}'
@@ -342,6 +355,9 @@ class AsyncRedisStorage:
             ``None`` for no cap.
         retry_jitter: Fraction (>= 0) of the capped delay added as random
             spread. The default, 0.0, adds none.
+        write_queue_size: Maximum number of pending coordinated writes; must
+            be >= 1. Further writes are dropped and reported through
+            ``on_storage_write_dropped`` instead of growing the queue.
     """
 
     def __init__(
@@ -355,6 +371,7 @@ class AsyncRedisStorage:
         retry_backoff_multiplier: float = 1.0,
         retry_backoff_max: float | None = None,
         retry_jitter: float = 0.0,
+        write_queue_size: int = 128,
     ) -> None:
         self._client = client
         self._prefix = key_prefix
@@ -368,6 +385,7 @@ class AsyncRedisStorage:
             None if retry_backoff_max is None else _positive('retry_backoff_max', retry_backoff_max)
         )
         self.retry_jitter = _non_negative('retry_jitter', retry_jitter)
+        self.write_queue_size = _positive_int('write_queue_size', write_queue_size)
 
     def _key(self, name: str) -> str:
         return f'{self._prefix}{name}'

--- a/interlock/listeners.py
+++ b/interlock/listeners.py
@@ -45,6 +45,10 @@ class LoggingEventListener:
         """Log a storage recovery at INFO."""
         self._log.info('circuit %r: shared storage recovered', name)
 
+    def on_storage_write_dropped(self, *, name: str) -> None:
+        """Log a dropped coordinated write at WARNING (shared state is falling behind)."""
+        self._log.warning('circuit %r: shared write dropped, coordination queue full', name)
+
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None:
         """Log an upcoming retry at INFO (bounded by the attempt cap)."""
         self._log.info('retry %r: attempt %d failed, retrying in %.3fs', name, attempt, delay)

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -226,6 +226,16 @@ class EventListener(Protocol):
         """Called when the shared storage backend becomes reachable again."""
         ...
 
+    def on_storage_write_dropped(self, *, name: str) -> None:
+        """Called when a coordinated write is dropped by a full write queue.
+
+        The queue only fills when the background lane stops draining it, so
+        this is the signal that shared writes are being lost while the breaker
+        keeps protecting the process locally. The shared state is reconciled
+        by the next successful poll and by ``state_ttl``.
+        """
+        ...
+
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None:
         """Called by a pipeline retry layer before it sleeps between attempts.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,9 @@ class ExplodingListener:
     def on_storage_recovered(self, *, name: str) -> None:
         self._fire('on_storage_recovered')
 
+    def on_storage_write_dropped(self, *, name: str) -> None:
+        self._fire('on_storage_write_dropped')
+
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None:
         self._fire('on_retry')
 

--- a/tests/inmemory_storage.py
+++ b/tests/inmemory_storage.py
@@ -125,6 +125,7 @@ class InMemoryStorage:
         self.retry_backoff_multiplier = 1.0
         self.retry_backoff_max: float | None = None
         self.retry_jitter = 0.0
+        self.write_queue_size = 128
 
     def read(self, name: str) -> SharedState | None:
         return self._core.read(name)
@@ -163,6 +164,7 @@ class AsyncInMemoryStorage:
         self.retry_backoff_multiplier = 1.0
         self.retry_backoff_max: float | None = None
         self.retry_jitter = 0.0
+        self.write_queue_size = 128
 
     async def read(self, name: str) -> SharedState | None:
         return self._core.read(name)

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -8,13 +8,14 @@ ticks run via ``poll_once()``, and fire-and-forget writes are awaited with
 
 import asyncio
 import gc
+import threading
 import weakref
 from dataclasses import replace
 from typing import cast
 
 import pytest
 
-from conftest import FakeClock, RecordingListener
+from conftest import ExplodingListener, FakeClock, RecordingListener
 from inmemory_storage import AsyncInMemoryStorage, InMemoryStorage
 from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, Registry, State
 from interlock._coordination import (
@@ -25,11 +26,12 @@ from interlock._coordination import (
     _sync_lane_tick,
 )
 from interlock.errors import InterlockError
-from interlock.protocols import AsyncStorage, EventListener, Storage
+from interlock.protocols import AsyncStorage, Clock, EventListener, Storage
 from interlock.shared import ProbeLease, SharedState
 
 NAME = 'svc'
 WAIT = 5.0
+LANE_TIMEOUT = 5.0  # real seconds: a lane that never parks must fail, not hang
 
 
 @pytest.fixture
@@ -53,12 +55,13 @@ def storage(fake_clock: FakeClock) -> InMemoryStorage:
 
 
 class StorageEventsListener(RecordingListener):
-    """RecordingListener extended with the 1.2 storage hooks."""
+    """RecordingListener extended with the storage hooks."""
 
     def __init__(self) -> None:
         super().__init__()
         self.degraded: list[BaseException] = []
         self.recovered: int = 0
+        self.write_dropped: int = 0
 
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
         self.names.append(name)
@@ -67,6 +70,10 @@ class StorageEventsListener(RecordingListener):
     def on_storage_recovered(self, *, name: str) -> None:
         self.names.append(name)
         self.recovered += 1
+
+    def on_storage_write_dropped(self, *, name: str) -> None:
+        self.names.append(name)
+        self.write_dropped += 1
 
 
 class FlakyStorage:
@@ -653,6 +660,152 @@ async def test__async__degraded__attempt_counter_resets_on_recovery(
     assert flaky.calls == 5
 
 
+# --- bounded write queue (#99) ---
+
+
+class BlockingTripStorage(InMemoryStorage):
+    """In-memory storage whose ``trip_open`` parks the lane until released.
+
+    A parked lane is what makes the queue fill up deterministically: it can
+    neither drain a write nor poll while it waits on ``release``.
+    """
+
+    def __init__(self, *, clock: Clock) -> None:
+        super().__init__(clock=clock)
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        self.entered.set()
+        self.release.wait()
+        return super().trip_open(name=name, ttl=ttl, expected_version=expected_version)
+
+
+class AsyncBlockingTripStorage(AsyncInMemoryStorage):
+    """Async mirror of ``BlockingTripStorage``."""
+
+    def __init__(self, *, clock: Clock) -> None:
+        super().__init__(clock=clock)
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def trip_open(
+        self, *, name: str, ttl: float, expected_version: int | None = None
+    ) -> SharedState:
+        self.entered.set()
+        await self.release.wait()
+        return await super().trip_open(name=name, ttl=ttl, expected_version=expected_version)
+
+
+def _blocking_storage(fake_clock: FakeClock) -> BlockingTripStorage:
+    storage = BlockingTripStorage(clock=fake_clock)
+    storage.poll_interval = 3600.0
+    storage.write_queue_size = 1
+    return storage
+
+
+def test__write_queue__at_capacity__drops_the_write_and_reports_it(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    storage = _blocking_storage(fake_clock)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, storage, listener)
+    coordinator = _coordinator(breaker)
+
+    coordinator.notify_local_trip()  # the lane takes this one and parks in trip_open
+    assert storage.entered.wait(timeout=LANE_TIMEOUT)
+    coordinator.notify_local_trip()  # fills the single queue slot
+    coordinator.notify_local_trip()  # over capacity: dropped, never queued
+
+    assert listener.write_dropped == 1
+    assert listener.names == [NAME]
+    assert not coordinator._work.full()  # the slot reserved for the sentinel stays free
+
+    storage.release.set()
+    breaker.close()
+
+
+def test__write_queue__at_capacity__settle_neither_blocks_nor_raises(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    storage = _blocking_storage(fake_clock)
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, storage, listener)
+    coordinator = _coordinator(breaker)
+
+    coordinator.notify_local_trip()
+    assert storage.entered.wait(timeout=LANE_TIMEOUT)
+    coordinator.notify_local_trip()  # queue now full
+
+    _trip(breaker)  # the trip write is dropped inside _settle, not raised there
+
+    assert breaker.state is State.OPEN  # local protection is unaffected
+    assert listener.write_dropped == 1
+
+    storage.release.set()
+    breaker.close()
+
+
+@pytest.mark.asyncio
+async def test__async__write_queue__at_capacity__drops_the_write_and_reports_it(
+    config: Config, fake_clock: FakeClock
+) -> None:
+    storage = AsyncBlockingTripStorage(clock=fake_clock)
+    storage.poll_interval = 3600.0
+    storage.write_queue_size = 1
+    listener = StorageEventsListener()
+    breaker = _breaker(config, fake_clock, storage, listener)
+    coordinator = _async_coordinator(breaker)
+
+    coordinator.notify_local_trip()
+    await asyncio.wait_for(storage.entered.wait(), timeout=LANE_TIMEOUT)
+    coordinator.notify_local_trip()
+    coordinator.notify_local_trip()
+
+    assert listener.write_dropped == 1
+    assert not coordinator._work.full()
+
+    storage.release.set()
+    await breaker.aclose()
+
+
+def test__write_queue__at_capacity__raising_listener_is_isolated_from_the_call(
+    config: Config, fake_clock: FakeClock, exploding: ExplodingListener
+) -> None:
+    storage = _blocking_storage(fake_clock)
+    breaker = CircuitBreaker(
+        name=NAME,
+        config=config,
+        clock=fake_clock,
+        storage=storage,
+        listener=cast('EventListener', exploding),
+    )
+    coordinator = _coordinator(breaker)
+
+    coordinator.notify_local_trip()
+    assert storage.entered.wait(timeout=LANE_TIMEOUT)
+    coordinator.notify_local_trip()  # queue now full
+
+    _trip(breaker)  # the drop hook raises; the calls keep their own exception
+
+    assert 'on_storage_write_dropped' in exploding.events
+    assert breaker.state is State.OPEN
+
+    storage.release.set()
+    breaker.close()
+
+
+def test__write_queue__default_size__is_the_documented_bound(
+    config: Config, fake_clock: FakeClock, storage: InMemoryStorage
+) -> None:
+    del storage.write_queue_size  # a storage that predates the knob
+    breaker = _breaker(config, fake_clock, storage)
+
+    assert _coordinator(breaker)._queue_size == 128
+
+
 # --- runtime matching (D8) ---
 
 
@@ -963,6 +1116,7 @@ def test__sync_lane_tick__dead_coordinator_stops_lane(
         on_view=lambda _view: None,
         on_degraded=lambda _error: None,
         on_recovered=lambda: None,
+        on_write_dropped=lambda: None,
     )
     work = coordinator._work
     ref = weakref.ref(coordinator)
@@ -1069,6 +1223,7 @@ def test__sync_lane__exits_on_dead_coordinator(
         on_view=lambda _view: None,
         on_degraded=lambda _error: None,
         on_recovered=lambda: None,
+        on_write_dropped=lambda: None,
     )
     work = coordinator._work
     ref = weakref.ref(coordinator)

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -70,6 +70,16 @@ def test__on_storage_recovered__logs_info(caplog: pytest.LogCaptureFixture) -> N
     assert 'recovered' in caplog.text
 
 
+def test__on_storage_write_dropped__logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    listener = LoggingEventListener(logging.getLogger('interlock.test'))
+
+    with caplog.at_level(logging.WARNING, logger='interlock.test'):
+        listener.on_storage_write_dropped(name='svc')
+
+    assert 'svc' in caplog.text
+    assert 'queue full' in caplog.text
+
+
 def test__on_retry__logs_info(caplog: pytest.LogCaptureFixture) -> None:
     listener = LoggingEventListener(logging.getLogger('interlock.test'))
 

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -86,6 +86,17 @@ def test__on_storage_recovered__counts_event() -> None:
     )
 
 
+def test__on_storage_write_dropped__counts_event() -> None:
+    meter, instruments = _meter_with_named_instruments()
+    listener = OTelEventListener(meter=meter)
+
+    listener.on_storage_write_dropped(name='svc')
+
+    instruments['interlock.storage.events'].add.assert_called_once_with(
+        1, {'breaker': 'svc', 'event': 'write_dropped'}
+    )
+
+
 def test__on_retry__counts_a_pipeline_event() -> None:
     meter, instruments = _meter_with_named_instruments()
     listener = OTelEventListener(meter=meter)

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -412,6 +412,16 @@ def test__constructor__accepts_configured_retry_policy_knobs(redis_client: redis
     assert default.retry_jitter == 0.0
 
 
+def test__constructor__write_queue_size__validated_and_configurable(
+    redis_client: redis_mod.Redis,
+) -> None:
+    with pytest.raises(ValueError, match='write_queue_size'):
+        RedisStorage(redis_client, write_queue_size=0)
+
+    assert RedisStorage(redis_client, write_queue_size=8).write_queue_size == 8
+    assert RedisStorage(redis_client).write_queue_size == 128
+
+
 # --- e2e: coordinated breaker over RedisStorage ---
 
 

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -123,6 +123,7 @@ def test__sync_lane_tick__dead_coordinator_with_op_in_flight__releases_the_op(
         on_view=lambda _view: None,
         on_degraded=lambda _error: None,
         on_recovered=lambda: None,
+        on_write_dropped=lambda: None,
     )
     work = coordinator._work
     work.put(lambda: None)  # dequeued by the tick, then dropped on the dead ref
@@ -148,6 +149,7 @@ async def test__async_lane_tick__dead_coordinator_with_op_in_flight__releases_th
         on_view=lambda _view: None,
         on_degraded=lambda _error: None,
         on_recovered=lambda: None,
+        on_write_dropped=lambda: None,
     )
     work = coordinator._work
 


### PR DESCRIPTION
## Summary

- `SyncCoordinator._work` / `AsyncCoordinator._work` were unbounded. Enqueues
  are per *transition* (a local CLOSED→OPEN trip, probe outcomes capped by
  `permitted_calls_in_half_open`), never per call, so a healthy lane keeps the
  queue near empty — but a lane that stops draining (a storage client blocking
  without a timeout, an async lane whose event loop is gone, a lane thread
  killed by an exception, #83) grew it for the life of the process.
- Both coordinators now cap the queue at `write_queue_size`, read off the
  storage object like the other coordination knobs, with a conservative default
  of 128. `RedisStorage` / `AsyncRedisStorage` gain the matching keyword-only
  knob (validated `>= 1`).
- Over capacity the *arriving* write is dropped: `_enqueue` never blocks and
  never raises into `Engine._settle`, and the queued writes stay untouched, so
  `wait_idle()` accounting and FIFO order are preserved.
- The drop is observable through a new optional listener hook,
  `on_storage_write_dropped` — `LoggingEventListener` logs it at `WARNING`,
  `OTelEventListener` counts it on `interlock.storage.events` with
  `event=write_dropped`. It deliberately does **not** reuse
  `on_storage_degraded`: the storage is healthy in this case, and degrading
  would wrongly stop treating the shared view as authoritative.
- The queue is allocated with one slot above `write_queue_size`, reserved for
  the shutdown sentinel: `_enqueue` refuses to fill it, so `shutdown()` can
  always wake a lane whose queue is full instead of blocking on `put` while
  holding the coordinator lock (which would stall the protected path too).
- Documented guarantee: coordinated writes are best-effort *and* bounded — a
  dropped write is reconciled by the next poll and by `state_ttl`, and locally
  the breaker keeps protecting the process on its own window.

## Test plan

- [x] `uv run pytest --cov` — 100% coverage, 599 passed / 2 skipped
  (real-Redis-only tests, as documented)
- [x] New deterministic tests in `tests/test_coordination.py` (sync + async): a
  `BlockingTripStorage` parks the lane inside `trip_open` so the queue fills
  without sleeps — overflow drops exactly one write and reports it, the
  reserved sentinel slot stays free, `close()` still stops the lane, a trip
  through the public API settles normally with a full queue, a raising listener
  is isolated from the call, and a storage predating the knob gets the
  documented default of 128
- [x] New tests for the hook in `tests/test_listeners.py` and `tests/test_otel.py`,
  and for the `write_queue_size` validation in `tests/test_redis_storage.py`
- [x] Repeated runs of `tests/test_coordination.py` + `tests/test_shutdown.py`
  (the real-thread/real-task suites) to check the new tests are not flaky
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] `uv run griffe check interlock --search .` — no public API breakage
- [x] `uv run zensical build --strict` (catches broken anchors)

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes — `docs/integrations/redis.md`
  (new "Backpressure: the write queue is bounded" section, Tuning knobs, the
  coordinated-mode contract), `docs/guides/observability.md` (hook list + OTel
  label), `docs/reference.md`; `docs/llms-full.txt` regenerated
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #99
