### PR TITLE
feat: support safe initial breaker states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Breakers can now start in a safe operator state before serving traffic.**
+  `CircuitBreaker` and `Registry` accept `initial_state`; `CLOSED`, `FORCED_OPEN`,
+  `DISABLED` and `METRICS_ONLY` are valid, while transitional `OPEN` / `HALF_OPEN`
+  fail fast. Lazy registry creation applies the state before publishing a breaker,
+  so per-host HTTP integrations can deploy in shadow mode without a first-call race.
+  The httpx2 transport, aiohttp middleware and requests adapter expose their registry
+  for diagnostics and accept the same option.
+
+### Fixed
+
+- **Closing an HTTP integration now also releases its per-host breakers.** The httpx2
+  transports and requests adapter close both their native connection resources and
+  the registry; the aiohttp middleware exposes `aclose()` for application shutdown.
+
 ## [2.3.0] - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -157,6 +157,33 @@ Want to watch a breaker trip and recover? Run the
 [examples](examples/) — deterministic output, no network, every transition
 narrated ([walkthrough](docs/demo.md)).
 
+## Safe production rollout
+
+Start a new integration in `METRICS_ONLY` to observe real failure and slow-call
+rates without rejecting traffic. The initial state is applied before a lazy
+per-host breaker can admit its first request:
+
+```python
+import httpx2
+
+from interlock import Config, State
+from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
+
+transport = AsyncCircuitBreakerTransport(
+    httpx2.AsyncHTTPTransport(),
+    initial_state=State.METRICS_ONLY,
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    listener=metrics_listener,
+)
+```
+
+Use an `EventListener` for production metrics. For local diagnostics,
+`transport.registry.get_existing(host)` returns an already-created breaker
+without creating one, so its `state` and `snapshot()` can be inspected safely.
+After tuning thresholds, deploy a new transport with the default
+`initial_state=State.CLOSED`; the enforcing instance starts with a fresh window.
+See [States and manual control](docs/guides/states.md#safe-rollout).
+
 ## Resilience pipeline
 
 When one concern is not enough, compose strategies around a call in an

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,12 @@ calls, stay open for 60s, then admit up to 10 probe calls (one at a time) and
 decide from their outcomes. See [Configuration](guides/configuration.md) for
 every option.
 
+For an existing production dependency, start with
+`initial_state=State.METRICS_ONLY`: calls are always admitted while their
+outcomes populate the window. Tune thresholds from real traffic, then deploy a
+new breaker in the default `CLOSED` state. See
+[Safe production rollout](guides/states.md#safe-rollout).
+
 ## Three ways to protect work
 
 All three run over the same `call()` primitive.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -64,9 +64,12 @@ until you tune it down — safe to leave on while you observe.
 ## Sharing config with a Registry
 
 ```python
-from interlock import Config, Registry
+from interlock import Config, Registry, State
 
-registry = Registry(config=Config(minimum_number_of_calls=20))
+registry = Registry(
+    config=Config(minimum_number_of_calls=20),
+    initial_state=State.METRICS_ONLY,
+)
 
 payments = registry.get('payments')  # shared default
 search = registry.get('search', config=Config(window_size=500))  # per-name override
@@ -74,4 +77,7 @@ search = registry.get('search', config=Config(window_size=500))  # per-name over
 
 The override applies only when the breaker is first created; later `get` calls
 with the same name return the existing instance and ignore the `config`
-argument.
+argument. `initial_state` is also assigned once, inside the registry lock,
+before a newly created breaker can serve traffic. See
+[Safe rollout](states.md#safe-rollout) for using
+`METRICS_ONLY` in production.

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -74,12 +74,46 @@ breaker.metrics_only()  # observe in production without enforcing
 breaker.reset()  # start enforcing with a clean window
 ```
 
-### `METRICS_ONLY` — safe rollout
+### Safe rollout
 
 Shadow mode is the key to introducing a breaker without risk: it records the
 exact failure and slow-call rates real traffic produces, so you can tune
 thresholds against live data before letting the breaker reject anything. It
 costs almost nothing to leave on.
+
+Set the mode at construction when no call may be admitted first:
+
+```python
+from interlock import CircuitBreaker, Registry, State
+
+breaker = CircuitBreaker(name='payments', initial_state=State.METRICS_ONLY)
+registry = Registry(initial_state=State.METRICS_ONLY)
+```
+
+`Registry` applies the state while holding its creation lock and publishes the
+breaker only afterwards. Every name created later therefore starts in shadow
+mode too. Construction is not a state transition, so it does not emit a
+synthetic `CLOSED → METRICS_ONLY` listener event.
+
+Only stable states are valid at construction: `CLOSED`, `FORCED_OPEN`,
+`DISABLED` and `METRICS_ONLY`. `OPEN` and `HALF_OPEN` require timing, probe and
+failure history, so passing either as `initial_state` raises `ValueError`.
+
+For a production rollout:
+
+1. Deploy with `initial_state=State.METRICS_ONLY` and an `EventListener` that
+   exports call outcomes.
+2. Observe failure and slow-call rates, then tune `Config` against real traffic.
+3. Deploy a new breaker, registry or transport with `initial_state=State.CLOSED`
+   (the default). The enforcing instance starts with a fresh window.
+
+Prefer a new deployment for step 3. Calling `reset()` enforces immediately for
+an existing breaker, but a registry configured with `METRICS_ONLY` would still
+apply that original initial state to hosts first seen later.
+
+For local diagnosis, `registry.get_existing(name)` returns a cached breaker or
+`None` without creating one. Inspect its `state` and `snapshot()`; use listeners
+rather than polling snapshots for production metrics.
 
 ## Coordinated state (optional)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ integrations at the transport level.
   ships `py.typed` and passes mypy in strict mode.
 - **Zero-dependency core.** Standard library only; everything external lives in
   optional extras.
+- **Safe production rollout.** Start in `METRICS_ONLY` to observe real traffic
+  without rejecting it, then enable enforcement with tuned thresholds.
 - **Thread-safe, and checked.** One `threading.Lock` guards the critical
   sections; your callable runs outside it. CI drives a single breaker from many
   threads at once — on free-threaded CPython (3.14t) as well as the GIL builds —

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -34,7 +34,13 @@ middleware = CircuitBreakerMiddleware()
 async with aiohttp.ClientSession(middlewares=(middleware,)) as session:
     async with session.get('https://api.example.com/orders') as response:
         orders = await response.json()
+
+await middleware.aclose()
 ```
+
+`ClientSession` does not own middleware resources. Call `middleware.aclose()`
+during application shutdown; it releases every per-host breaker and is
+idempotent.
 
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
@@ -44,6 +50,26 @@ made.
 The breaker observes the time to *response headers*; reading the body happens
 outside the guarded call — the same semantics as the
 [httpx2 transport](httpx2.md).
+
+## Safe production rollout
+
+Pass `initial_state=State.METRICS_ONLY` to record real outcomes without
+rejecting requests. The state is applied to every lazily created host before
+its first request:
+
+```python
+from interlock import State
+
+middleware = CircuitBreakerMiddleware(
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+The public `middleware.registry` supports local diagnosis with
+`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+production metrics, then deploy a new middleware with the default `CLOSED`
+state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 
@@ -68,7 +94,8 @@ Any custom `FailureClassifier` works too — see
 ## Tuning and observability
 
 The middleware accepts the same collaborators as `CircuitBreaker` — `config`,
-`clock`, `classifier`, `listener`. One middleware instance holds one registry
+`clock`, `initial_state`, `classifier`, `listener`. One middleware instance
+holds one registry
 of per-host breakers; reuse the instance across sessions to share breaker
 state, or create separate instances to isolate them. For application-level
 retries combine with the [tenacity integration](tenacity.md) and read

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -46,6 +46,37 @@ client = httpx2.AsyncClient(transport=transport)
 response = await client.get('https://api.example.com/v1/users')
 ```
 
+Closing the client closes both the wrapped connection pool and every breaker
+created by the transport.
+
+## Safe production rollout
+
+Start in shadow mode when introducing the integration to existing traffic:
+
+```python
+import httpx2
+
+from interlock import State
+from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
+
+transport = AsyncCircuitBreakerTransport(
+    httpx2.AsyncHTTPTransport(),
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+Every host created later starts in `METRICS_ONLY` before its first request: it
+records outcomes but never raises `CircuitOpenError`. Use the listener for
+production metrics. For local diagnosis,
+`transport.registry.get_existing(host)` returns an existing breaker without
+creating one; inspect its `state` and `snapshot()`.
+
+After tuning thresholds, deploy a new transport with the default
+`initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
+transport configured for shadow mode would still create future hosts in
+`METRICS_ONLY`. See the complete [safe-rollout guide](../guides/states.md#safe-rollout).
+
 ## Per-host isolation
 
 Each host gets its own breaker, created lazily and cached. A failing

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -29,6 +29,10 @@ Every integration follows the same rules, so learning one means knowing all:
 - **One breaker per host.** HTTP integrations key breakers by request host:
   a failing `api.a` never trips `api.b`. Breakers are created lazily in a
   shared [`Registry`](../reference.md).
+- **Safe rollout before enforcement.** Pass
+  `initial_state=State.METRICS_ONLY` to record real traffic without rejecting
+  it. The state is applied before each lazy breaker serves its first request;
+  deploy a new integration with `CLOSED` after tuning thresholds.
 - **One classification model.** Responses are classified by an
   `HttpStatusClassifier` — by default the canonical retryable set
   (`429, 500, 502, 503, 504`) plus any transport exception counts as a
@@ -42,6 +46,10 @@ Every integration follows the same rules, so learning one means knowing all:
 - **Zero-dependency core.** Integrations live in `interlock.integrations.*`
   as optional extras; `import interlock` itself never pulls anything beyond
   the standard library.
+- **Explicit ownership and teardown.** Transports and adapters close their
+  native connection resources together with their breaker registry. The
+  aiohttp middleware exposes `aclose()` because `ClientSession` does not own
+  middleware resources.
 
 ## Support tiers
 

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -40,10 +40,33 @@ session.mount('http://', adapter)
 response = session.get('https://api.example.com/orders')
 ```
 
+Closing the session closes the adapter's connection pools and every breaker it
+created.
+
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
 request raises [`CircuitOpenError`](../reference.md) *before* a connection is
 made.
+
+## Safe production rollout
+
+Pass `initial_state=State.METRICS_ONLY` to record real outcomes without
+rejecting requests. The state is applied to every lazily created host before
+its first request:
+
+```python
+from interlock import State
+
+adapter = CircuitBreakerAdapter(
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+The public `adapter.registry` supports local diagnosis with
+`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+production metrics, then deploy a new adapter with the default `CLOSED` state
+to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 
@@ -68,7 +91,8 @@ Any custom `FailureClassifier` works too — see
 ## Tuning and observability
 
 The adapter accepts the same collaborators as `CircuitBreaker` — `config`,
-`clock`, `classifier`, `listener` — and forwards everything else
+`clock`, `initial_state`, `classifier`, `listener` — and forwards everything
+else
 (`pool_connections`, `max_retries`, ...) to `HTTPAdapter`. Note that
 `max_retries` is urllib3's connection-level retry; for application-level
 retries combine with the [tenacity integration](tenacity.md) and read

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -69,6 +69,12 @@ calls, stay open for 60s, then admit up to 10 probe calls (one at a time) and
 decide from their outcomes. See [Configuration](guides/configuration.md) for
 every option.
 
+For an existing production dependency, start with
+`initial_state=State.METRICS_ONLY`: calls are always admitted while their
+outcomes populate the window. Tune thresholds from real traffic, then deploy a
+new breaker in the default `CLOSED` state. See
+[Safe production rollout](guides/states.md#safe-rollout).
+
 ## Three ways to protect work
 
 All three run over the same `call()` primitive.
@@ -848,7 +854,7 @@ Translate the trip condition like this:
 
 There is no exact arithmetic conversion, because the two models answer
 different questions. A safe way to pick numbers is to run in
-[shadow mode](guides/states.md#metrics_only-safe-rollout) first (see
+[shadow mode](guides/states.md#safe-rollout) first (see
 [Roll out incrementally](#roll-out-incrementally) below) and read the real
 rates off `breaker.snapshot()` before enforcing.
 
@@ -1192,7 +1198,7 @@ After migrating, expect these behavioural differences — all intended:
 ## Roll out incrementally
 
 You do not have to trust new threshold numbers on day one. Ship the breaker in
-[shadow mode](guides/states.md#metrics_only-safe-rollout) — it records real
+[shadow mode](guides/states.md#safe-rollout) — it records real
 failure and slow-call rates without rejecting anything — tune against live data,
 then switch to enforcing:
 
@@ -1527,9 +1533,12 @@ until you tune it down — safe to leave on while you observe.
 ## Sharing config with a Registry
 
 ```python
-from interlock import Config, Registry
+from interlock import Config, Registry, State
 
-registry = Registry(config=Config(minimum_number_of_calls=20))
+registry = Registry(
+    config=Config(minimum_number_of_calls=20),
+    initial_state=State.METRICS_ONLY,
+)
 
 payments = registry.get('payments')  # shared default
 search = registry.get('search', config=Config(window_size=500))  # per-name override
@@ -1537,7 +1546,10 @@ search = registry.get('search', config=Config(window_size=500))  # per-name over
 
 The override applies only when the breaker is first created; later `get` calls
 with the same name return the existing instance and ignore the `config`
-argument.
+argument. `initial_state` is also assigned once, inside the registry lock,
+before a newly created breaker can serve traffic. See
+[Safe rollout](states.md#safe-rollout) for using
+`METRICS_ONLY` in production.
 
 ---
 
@@ -1619,12 +1631,46 @@ breaker.metrics_only()  # observe in production without enforcing
 breaker.reset()  # start enforcing with a clean window
 ```
 
-### `METRICS_ONLY` — safe rollout
+### Safe rollout
 
 Shadow mode is the key to introducing a breaker without risk: it records the
 exact failure and slow-call rates real traffic produces, so you can tune
 thresholds against live data before letting the breaker reject anything. It
 costs almost nothing to leave on.
+
+Set the mode at construction when no call may be admitted first:
+
+```python
+from interlock import CircuitBreaker, Registry, State
+
+breaker = CircuitBreaker(name='payments', initial_state=State.METRICS_ONLY)
+registry = Registry(initial_state=State.METRICS_ONLY)
+```
+
+`Registry` applies the state while holding its creation lock and publishes the
+breaker only afterwards. Every name created later therefore starts in shadow
+mode too. Construction is not a state transition, so it does not emit a
+synthetic `CLOSED → METRICS_ONLY` listener event.
+
+Only stable states are valid at construction: `CLOSED`, `FORCED_OPEN`,
+`DISABLED` and `METRICS_ONLY`. `OPEN` and `HALF_OPEN` require timing, probe and
+failure history, so passing either as `initial_state` raises `ValueError`.
+
+For a production rollout:
+
+1. Deploy with `initial_state=State.METRICS_ONLY` and an `EventListener` that
+   exports call outcomes.
+2. Observe failure and slow-call rates, then tune `Config` against real traffic.
+3. Deploy a new breaker, registry or transport with `initial_state=State.CLOSED`
+   (the default). The enforcing instance starts with a fresh window.
+
+Prefer a new deployment for step 3. Calling `reset()` enforces immediately for
+an existing breaker, but a registry configured with `METRICS_ONLY` would still
+apply that original initial state to hosts first seen later.
+
+For local diagnosis, `registry.get_existing(name)` returns a cached breaker or
+`None` without creating one. Inspect its `state` and `snapshot()`; use listeners
+rather than polling snapshots for production metrics.
 
 ## Coordinated state (optional)
 
@@ -2355,6 +2401,10 @@ Every integration follows the same rules, so learning one means knowing all:
 - **One breaker per host.** HTTP integrations key breakers by request host:
   a failing `api.a` never trips `api.b`. Breakers are created lazily in a
   shared [`Registry`](../reference.md).
+- **Safe rollout before enforcement.** Pass
+  `initial_state=State.METRICS_ONLY` to record real traffic without rejecting
+  it. The state is applied before each lazy breaker serves its first request;
+  deploy a new integration with `CLOSED` after tuning thresholds.
 - **One classification model.** Responses are classified by an
   `HttpStatusClassifier` — by default the canonical retryable set
   (`429, 500, 502, 503, 504`) plus any transport exception counts as a
@@ -2368,6 +2418,10 @@ Every integration follows the same rules, so learning one means knowing all:
 - **Zero-dependency core.** Integrations live in `interlock.integrations.*`
   as optional extras; `import interlock` itself never pulls anything beyond
   the standard library.
+- **Explicit ownership and teardown.** Transports and adapters close their
+  native connection resources together with their breaker registry. The
+  aiohttp middleware exposes `aclose()` because `ClientSession` does not own
+  middleware resources.
 
 ## Support tiers
 
@@ -2661,6 +2715,37 @@ client = httpx2.AsyncClient(transport=transport)
 response = await client.get('https://api.example.com/v1/users')
 ```
 
+Closing the client closes both the wrapped connection pool and every breaker
+created by the transport.
+
+## Safe production rollout
+
+Start in shadow mode when introducing the integration to existing traffic:
+
+```python
+import httpx2
+
+from interlock import State
+from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
+
+transport = AsyncCircuitBreakerTransport(
+    httpx2.AsyncHTTPTransport(),
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+Every host created later starts in `METRICS_ONLY` before its first request: it
+records outcomes but never raises `CircuitOpenError`. Use the listener for
+production metrics. For local diagnosis,
+`transport.registry.get_existing(host)` returns an existing breaker without
+creating one; inspect its `state` and `snapshot()`.
+
+After tuning thresholds, deploy a new transport with the default
+`initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
+transport configured for shadow mode would still create future hosts in
+`METRICS_ONLY`. See the complete [safe-rollout guide](../guides/states.md#safe-rollout).
+
 ## Per-host isolation
 
 Each host gets its own breaker, created lazily and cached. A failing
@@ -2742,7 +2827,13 @@ middleware = CircuitBreakerMiddleware()
 async with aiohttp.ClientSession(middlewares=(middleware,)) as session:
     async with session.get('https://api.example.com/orders') as response:
         orders = await response.json()
+
+await middleware.aclose()
 ```
+
+`ClientSession` does not own middleware resources. Call `middleware.aclose()`
+during application shutdown; it releases every per-host breaker and is
+idempotent.
 
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
@@ -2752,6 +2843,26 @@ made.
 The breaker observes the time to *response headers*; reading the body happens
 outside the guarded call — the same semantics as the
 [httpx2 transport](httpx2.md).
+
+## Safe production rollout
+
+Pass `initial_state=State.METRICS_ONLY` to record real outcomes without
+rejecting requests. The state is applied to every lazily created host before
+its first request:
+
+```python
+from interlock import State
+
+middleware = CircuitBreakerMiddleware(
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+The public `middleware.registry` supports local diagnosis with
+`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+production metrics, then deploy a new middleware with the default `CLOSED`
+state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 
@@ -2776,7 +2887,8 @@ Any custom `FailureClassifier` works too — see
 ## Tuning and observability
 
 The middleware accepts the same collaborators as `CircuitBreaker` — `config`,
-`clock`, `classifier`, `listener`. One middleware instance holds one registry
+`clock`, `initial_state`, `classifier`, `listener`. One middleware instance
+holds one registry
 of per-host breakers; reuse the instance across sessions to share breaker
 state, or create separate instances to isolate them. For application-level
 retries combine with the [tenacity integration](tenacity.md) and read
@@ -2828,10 +2940,33 @@ session.mount('http://', adapter)
 response = session.get('https://api.example.com/orders')
 ```
 
+Closing the session closes the adapter's connection pools and every breaker it
+created.
+
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
 request raises [`CircuitOpenError`](../reference.md) *before* a connection is
 made.
+
+## Safe production rollout
+
+Pass `initial_state=State.METRICS_ONLY` to record real outcomes without
+rejecting requests. The state is applied to every lazily created host before
+its first request:
+
+```python
+from interlock import State
+
+adapter = CircuitBreakerAdapter(
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+The public `adapter.registry` supports local diagnosis with
+`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+production metrics, then deploy a new adapter with the default `CLOSED` state
+to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 
@@ -2856,7 +2991,8 @@ Any custom `FailureClassifier` works too — see
 ## Tuning and observability
 
 The adapter accepts the same collaborators as `CircuitBreaker` — `config`,
-`clock`, `classifier`, `listener` — and forwards everything else
+`clock`, `initial_state`, `classifier`, `listener` — and forwards everything
+else
 (`pool_connections`, `max_retries`, ...) to `HTTPAdapter`. Note that
 `max_retries` is urllib3's connection-level retry; for application-level
 retries combine with the [tenacity integration](tenacity.md) and read
@@ -3539,7 +3675,8 @@ dependency-free.
 ## `CircuitBreaker`
 
 ```python
-CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None, storage=None)
+CircuitBreaker(*, name, config=None, clock=None, initial_state=State.CLOSED,
+               classifier=None, listener=None, storage=None)
 ```
 
 A named breaker for sync and async callables.
@@ -3547,6 +3684,8 @@ A named breaker for sync and async callables.
 - **Use as** a decorator (`@breaker`), a sync/async context manager
   (`with` / `async with`), or `breaker.call(fn, *args, **kwargs)`.
 - **Properties:** `name: str`, `state: State`.
+- **`initial_state`** — one of `CLOSED`, `FORCED_OPEN`, `DISABLED` or
+  `METRICS_ONLY`; transitional `OPEN` / `HALF_OPEN` raise `ValueError`.
 - **`snapshot() -> WindowSnapshot`** — current, self-consistent window aggregates;
   concurrent call settlement cannot expose a partially updated window.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
@@ -3569,15 +3708,18 @@ See [Configuration](guides/configuration.md) for every field. Raises
 ## `Registry`
 
 ```python
-Registry(*, config=None, clock=None, classifier=None, listener=None, storage=None)
+Registry(*, config=None, clock=None, initial_state=State.CLOSED,
+         classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
+registry.get_existing(name) -> CircuitBreaker | None
 registry.close_all() / await registry.aclose_all()
 ```
 
 Creates and caches named breakers. The same name always returns the same
 instance; the per-call `config` override applies only at creation. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
-name.
+name. `initial_state` is assigned before a lazy breaker is published;
+`get_existing()` inspects the cache without creating a missing name.
 
 `close_all()` / `aclose_all()` close every breaker created so far. The cache is
 kept, so `get()` keeps returning the same, torn-down instances instead of
@@ -3691,37 +3833,45 @@ Implement any of these to swap a core behaviour:
 
 Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 
-- **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
+- **`CircuitBreakerTransport(transport, *, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
   exceptions and statuses `429, 500, 502, 503, 504` (override the set via
   `failure_statuses`).
 
-See the [httpx2 integration](integrations/httpx2.md).
+Both transports expose their per-host `registry`; `close()` / `aclose()` release
+the wrapped transport and every breaker in that registry. See the
+[httpx2 integration](integrations/httpx2.md).
 
 ## aiohttp adapters
 
 Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations.aiohttp`:
 
-- **`CircuitBreakerMiddleware(*, config=None, clock=None, classifier=None, listener=None)`** —
+- **`CircuitBreakerMiddleware(*, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
 - **`HttpStatusClassifier(failure_statuses=None)`** — same policy as the
   httpx2 variant, reading `ClientResponse.status`.
 
-See the [aiohttp integration](integrations/aiohttp.md).
+It exposes its `registry`; call `await middleware.aclose()` during application
+shutdown. See the [aiohttp integration](integrations/aiohttp.md).
 
 ## requests adapters
 
 Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
 
-- **`CircuitBreakerAdapter(*, config=None, clock=None, classifier=None, listener=None, **adapter_kwargs)`** —
+- **`CircuitBreakerAdapter(*, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
 - **`HttpStatusClassifier(failure_statuses=None)`** — same policy, reading
   `Response.status_code`.
 
-See the [requests integration](integrations/requests.md).
+It exposes its `registry`; closing the adapter or owning session releases both
+the connection pools and breaker resources. See the
+[requests integration](integrations/requests.md).
 
 ## tenacity helpers
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,13 +8,18 @@
 
 Key facts for answering questions about interlock:
 
-- Single public class `CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None, storage=None)`.
+- Single public class `CircuitBreaker(*, name, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None, storage=None)`.
 - Three usage forms over one `call()` primitive: decorator `@breaker`, context
   manager (`with` and `async with`), and `breaker.call(fn, *args, **kwargs)`.
 - The context manager cannot do result-based classification (it sees only the
   block's exception and duration); the decorator and `call` can.
 - States: `CLOSED`, `OPEN`, `HALF_OPEN`, plus operator overrides `FORCED_OPEN`,
   `DISABLED`, `METRICS_ONLY`. Manual control: `reset/force_open/disable/metrics_only`.
+- `initial_state` accepts `CLOSED`, `FORCED_OPEN`, `DISABLED` or `METRICS_ONLY`;
+  use `METRICS_ONLY` for a production shadow rollout. `Registry` applies it
+  before publishing each lazy breaker, and `get_existing(name)` inspects the
+  cache without creating a missing breaker.
 - `OPEN → HALF_OPEN` is lazy by default (on the first call after
   `wait_duration_in_open`); set `Config.auto_transition=True` for a timer that
   makes the move proactively and emits the event without waiting for a call.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -32,7 +32,7 @@ Translate the trip condition like this:
 
 There is no exact arithmetic conversion, because the two models answer
 different questions. A safe way to pick numbers is to run in
-[shadow mode](guides/states.md#metrics_only-safe-rollout) first (see
+[shadow mode](guides/states.md#safe-rollout) first (see
 [Roll out incrementally](#roll-out-incrementally) below) and read the real
 rates off `breaker.snapshot()` before enforcing.
 
@@ -376,7 +376,7 @@ After migrating, expect these behavioural differences — all intended:
 ## Roll out incrementally
 
 You do not have to trust new threshold numbers on day one. Ship the breaker in
-[shadow mode](guides/states.md#metrics_only-safe-rollout) — it records real
+[shadow mode](guides/states.md#safe-rollout) — it records real
 failure and slow-call rates without rejecting anything — tune against live data,
 then switch to enforcing:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,7 +7,8 @@ dependency-free.
 ## `CircuitBreaker`
 
 ```python
-CircuitBreaker(*, name, config=None, clock=None, classifier=None, listener=None, storage=None)
+CircuitBreaker(*, name, config=None, clock=None, initial_state=State.CLOSED,
+               classifier=None, listener=None, storage=None)
 ```
 
 A named breaker for sync and async callables.
@@ -15,6 +16,8 @@ A named breaker for sync and async callables.
 - **Use as** a decorator (`@breaker`), a sync/async context manager
   (`with` / `async with`), or `breaker.call(fn, *args, **kwargs)`.
 - **Properties:** `name: str`, `state: State`.
+- **`initial_state`** — one of `CLOSED`, `FORCED_OPEN`, `DISABLED` or
+  `METRICS_ONLY`; transitional `OPEN` / `HALF_OPEN` raise `ValueError`.
 - **`snapshot() -> WindowSnapshot`** — current, self-consistent window aggregates;
   concurrent call settlement cannot expose a partially updated window.
 - **Manual control:** `reset()`, `force_open()`, `disable()`, `metrics_only()`.
@@ -37,15 +40,18 @@ See [Configuration](guides/configuration.md) for every field. Raises
 ## `Registry`
 
 ```python
-Registry(*, config=None, clock=None, classifier=None, listener=None, storage=None)
+Registry(*, config=None, clock=None, initial_state=State.CLOSED,
+         classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
+registry.get_existing(name) -> CircuitBreaker | None
 registry.close_all() / await registry.aclose_all()
 ```
 
 Creates and caches named breakers. The same name always returns the same
 instance; the per-call `config` override applies only at creation. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
-name.
+name. `initial_state` is assigned before a lazy breaker is published;
+`get_existing()` inspects the cache without creating a missing name.
 
 `close_all()` / `aclose_all()` close every breaker created so far. The cache is
 kept, so `get()` keeps returning the same, torn-down instances instead of
@@ -159,37 +165,45 @@ Implement any of these to swap a core behaviour:
 
 Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 
-- **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
+- **`CircuitBreakerTransport(transport, *, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
   exceptions and statuses `429, 500, 502, 503, 504` (override the set via
   `failure_statuses`).
 
-See the [httpx2 integration](integrations/httpx2.md).
+Both transports expose their per-host `registry`; `close()` / `aclose()` release
+the wrapped transport and every breaker in that registry. See the
+[httpx2 integration](integrations/httpx2.md).
 
 ## aiohttp adapters
 
 Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations.aiohttp`:
 
-- **`CircuitBreakerMiddleware(*, config=None, clock=None, classifier=None, listener=None)`** —
+- **`CircuitBreakerMiddleware(*, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
 - **`HttpStatusClassifier(failure_statuses=None)`** — same policy as the
   httpx2 variant, reading `ClientResponse.status`.
 
-See the [aiohttp integration](integrations/aiohttp.md).
+It exposes its `registry`; call `await middleware.aclose()` during application
+shutdown. See the [aiohttp integration](integrations/aiohttp.md).
 
 ## requests adapters
 
 Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
 
-- **`CircuitBreakerAdapter(*, config=None, clock=None, classifier=None, listener=None, **adapter_kwargs)`** —
+- **`CircuitBreakerAdapter(*, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
 - **`HttpStatusClassifier(failure_statuses=None)`** — same policy, reading
   `Response.status_code`.
 
-See the [requests integration](integrations/requests.md).
+It exposes its `registry`; closing the adapter or owning session releases both
+the connection pools and breaker resources. See the
+[requests integration](integrations/requests.md).
 
 ## tenacity helpers
 

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -62,6 +62,8 @@ class Engine:
         name: Breaker name, surfaced on ``CircuitOpenError``.
         config: Thresholds, window and timing.
         clock: Time source; injected for deterministic tests.
+        initial_state: Stable state in which the breaker starts. Transitional
+            ``OPEN`` and ``HALF_OPEN`` states are rejected.
         classifier: Decides which outcomes count as failures. Defaults to
             ``DefaultFailureClassifier`` (any raised exception is a failure).
         listener: Observability hooks, dispatched through ``notify`` — a hook
@@ -78,6 +80,7 @@ class Engine:
         name: str,
         config: Config,
         clock: Clock,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
         storage: Storage | AsyncStorage | None = None,
@@ -87,7 +90,11 @@ class Engine:
         self._clock = clock
         self._classifier = classifier if classifier is not None else DefaultFailureClassifier()
         self._listener = listener
-        self._machine = StateMachine(config=config, clock=clock)
+        self._machine = StateMachine(
+            config=config,
+            clock=clock,
+            initial_state=initial_state,
+        )
         self._lock = threading.Lock()
         self._last_failure: BaseException | None = None
         self._timer: threading.Timer | None = None

--- a/interlock/_initial_state.py
+++ b/interlock/_initial_state.py
@@ -1,0 +1,17 @@
+"""Validation for states that can exist without transition history."""
+
+from interlock.state import State
+
+_SUPPORTED_INITIAL_STATES = (
+    State.CLOSED,
+    State.FORCED_OPEN,
+    State.DISABLED,
+    State.METRICS_ONLY,
+)
+
+
+def validate_initial_state(initial_state: object) -> None:
+    """Reject states that require transition history before they are valid."""
+    if not isinstance(initial_state, State) or initial_state not in _SUPPORTED_INITIAL_STATES:
+        supported = ', '.join(state.value for state in _SUPPORTED_INITIAL_STATES)
+        raise ValueError(f'initial_state must be one of {{{supported}}}, got {initial_state!r}')

--- a/interlock/_state_machine.py
+++ b/interlock/_state_machine.py
@@ -22,6 +22,7 @@ Three special states are operator overrides: ``FORCED_OPEN`` (reject all),
 metrics, never trip).
 """
 
+from interlock._initial_state import validate_initial_state
 from interlock._windows import build_window
 from interlock.config import Config
 from interlock.outcome import Outcome
@@ -42,11 +43,18 @@ class StateMachine:
     ``Clock``.
     """
 
-    def __init__(self, *, config: Config, clock: Clock) -> None:
+    def __init__(
+        self,
+        *,
+        config: Config,
+        clock: Clock,
+        initial_state: State = State.CLOSED,
+    ) -> None:
+        validate_initial_state(initial_state)
         self._config = config
         self._clock = clock
         self._window = build_window(config=config, clock=clock)
-        self._state = State.CLOSED
+        self._state = initial_state
         self._opened_at = 0.0
         self._generation = 0
         self._reset_probes()

--- a/interlock/breaker.py
+++ b/interlock/breaker.py
@@ -41,6 +41,10 @@ class CircuitBreaker:
         config: Thresholds, window and timing. Defaults to ``Config()``.
         clock: Time source. Defaults to ``SystemClock`` (real monotonic time);
             inject a fake for deterministic tests.
+        initial_state: Stable state in which the breaker starts. Use
+            ``State.METRICS_ONLY`` for a shadow rollout that records real
+            traffic without rejecting calls. ``OPEN`` and ``HALF_OPEN`` are
+            transitional and rejected as initial states.
         classifier: Decides which outcomes count as failures. Defaults to any
             raised exception being a failure.
         listener: Observability hooks (state changes, calls, rejections,
@@ -50,6 +54,9 @@ class CircuitBreaker:
             state. A coordinated breaker matches its storage's runtime: a sync
             ``Storage`` serves only the sync API, an ``AsyncStorage`` only the
             async one; without a storage the breaker stays fully dual.
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -58,6 +65,7 @@ class CircuitBreaker:
         name: str,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
         storage: Storage | AsyncStorage | None = None,
@@ -67,6 +75,7 @@ class CircuitBreaker:
             name=name,
             config=config if config is not None else Config(),
             clock=clock if clock is not None else SystemClock(),
+            initial_state=initial_state,
             classifier=classifier,
             listener=listener,
             storage=storage,

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -34,6 +34,7 @@ from aiohttp import ClientHandlerType, ClientRequest, ClientResponse
 from interlock.config import Config
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
+from interlock.state import State
 
 __all__ = ('CircuitBreakerMiddleware', 'HttpStatusClassifier')
 
@@ -86,8 +87,13 @@ class CircuitBreakerMiddleware:
         config: Thresholds, window and timing for every host's breaker.
         clock: Time source for the breakers; inject a fake for deterministic
             tests.
+        initial_state: Stable state assigned before a host's first request.
+            Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -95,15 +101,26 @@ class CircuitBreakerMiddleware:
         *,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
     ) -> None:
         self._registry = Registry(
             config=config,
             clock=clock,
+            initial_state=initial_state,
             classifier=classifier if classifier is not None else HttpStatusClassifier(),
             listener=listener,
         )
+
+    @property
+    def registry(self) -> Registry:
+        """The per-host registry, exposed for diagnostics and operator control."""
+        return self._registry
+
+    async def aclose(self) -> None:
+        """Release every per-host breaker's background resources."""
+        await self._registry.aclose_all()
 
     async def __call__(self, request: ClientRequest, handler: ClientHandlerType) -> ClientResponse:
         """Run the request under its host's breaker.

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -22,6 +22,7 @@ a custom ``classifier`` to change that policy.
 
 import http
 from collections.abc import Iterable
+from contextlib import AsyncExitStack, ExitStack
 from typing import cast
 
 from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
@@ -29,6 +30,7 @@ from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
 from interlock.config import Config
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
+from interlock.state import State
 
 __all__ = (
     'AsyncCircuitBreakerTransport',
@@ -88,14 +90,17 @@ def _host(request: Request) -> str:
 
 
 def _build_registry(
+    *,
     config: Config | None,
     clock: Clock | None,
+    initial_state: State,
     classifier: FailureClassifier | None,
     listener: EventListener | None,
 ) -> Registry:
     return Registry(
         config=config,
         clock=clock,
+        initial_state=initial_state,
         classifier=classifier if classifier is not None else HttpStatusClassifier(),
         listener=listener,
     )
@@ -109,8 +114,13 @@ class CircuitBreakerTransport(BaseTransport):
         config: Thresholds, window and timing for every host's breaker.
         clock: Time source for the breakers; inject a fake for deterministic
             tests.
+        initial_state: Stable state assigned before a host's first request.
+            Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -119,11 +129,23 @@ class CircuitBreakerTransport(BaseTransport):
         *,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
     ) -> None:
         self._transport = transport
-        self._registry = _build_registry(config, clock, classifier, listener)
+        self._registry = _build_registry(
+            config=config,
+            clock=clock,
+            initial_state=initial_state,
+            classifier=classifier,
+            listener=listener,
+        )
+
+    @property
+    def registry(self) -> Registry:
+        """The per-host registry, exposed for diagnostics and operator control."""
+        return self._registry
 
     def handle_request(self, request: Request) -> Response:
         """Run the request under its host's breaker.
@@ -137,8 +159,10 @@ class CircuitBreakerTransport(BaseTransport):
         return guarded(request)
 
     def close(self) -> None:
-        """Close the wrapped transport, releasing its connection pool."""
-        self._transport.close()
+        """Release the wrapped transport and every per-host breaker."""
+        with ExitStack() as stack:
+            stack.callback(self._registry.close_all)
+            self._transport.close()
 
 
 class AsyncCircuitBreakerTransport(AsyncBaseTransport):
@@ -149,8 +173,13 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         config: Thresholds, window and timing for every host's breaker.
         clock: Time source for the breakers; inject a fake for deterministic
             tests.
+        initial_state: Stable state assigned before a host's first request.
+            Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -159,11 +188,23 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         *,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
     ) -> None:
         self._transport = transport
-        self._registry = _build_registry(config, clock, classifier, listener)
+        self._registry = _build_registry(
+            config=config,
+            clock=clock,
+            initial_state=initial_state,
+            classifier=classifier,
+            listener=listener,
+        )
+
+    @property
+    def registry(self) -> Registry:
+        """The per-host registry, exposed for diagnostics and operator control."""
+        return self._registry
 
     async def handle_async_request(self, request: Request) -> Response:
         """Run the request under its host's breaker.
@@ -177,5 +218,7 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         return await guarded(request)
 
     async def aclose(self) -> None:
-        """Close the wrapped transport, releasing its connection pool."""
-        await self._transport.aclose()
+        """Release the wrapped transport and every per-host breaker."""
+        async with AsyncExitStack() as stack:
+            stack.push_async_callback(self._registry.aclose_all)
+            await self._transport.aclose()

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -23,6 +23,7 @@ successes. Supply a custom ``classifier`` to change that policy.
 
 import http
 from collections.abc import Iterable, Mapping
+from contextlib import ExitStack
 from typing import cast
 from urllib.parse import urlsplit
 
@@ -32,6 +33,7 @@ from requests.adapters import HTTPAdapter
 from interlock.config import Config
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
+from interlock.state import State
 
 __all__ = ('CircuitBreakerAdapter', 'HttpStatusClassifier')
 
@@ -87,10 +89,15 @@ class CircuitBreakerAdapter(HTTPAdapter):
         config: Thresholds, window and timing for every host's breaker.
         clock: Time source for the breakers; inject a fake for deterministic
             tests.
+        initial_state: Stable state assigned before a host's first request.
+            Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
         adapter_kwargs: Passed through to ``HTTPAdapter`` (pool sizes,
             ``max_retries``, ...).
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -98,6 +105,7 @@ class CircuitBreakerAdapter(HTTPAdapter):
         *,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
         **adapter_kwargs: object,
@@ -106,9 +114,21 @@ class CircuitBreakerAdapter(HTTPAdapter):
         self._registry = Registry(
             config=config,
             clock=clock,
+            initial_state=initial_state,
             classifier=classifier if classifier is not None else HttpStatusClassifier(),
             listener=listener,
         )
+
+    @property
+    def registry(self) -> Registry:
+        """The per-host registry, exposed for diagnostics and operator control."""
+        return self._registry
+
+    def close(self) -> None:
+        """Release the adapter's connection pools and every per-host breaker."""
+        with ExitStack() as stack:
+            stack.callback(self._registry.close_all)
+            super().close()
 
     def send(  # noqa: PLR0913, PLR0917 - mirrors HTTPAdapter.send, the native extension point
         self,

--- a/interlock/registry.py
+++ b/interlock/registry.py
@@ -6,11 +6,14 @@ default ``Config`` unless a per-name override is supplied at creation.
 """
 
 import threading
+from contextlib import AsyncExitStack, ExitStack
 
 from interlock._clock import SystemClock
+from interlock._initial_state import validate_initial_state
 from interlock.breaker import CircuitBreaker
 from interlock.config import Config
 from interlock.protocols import AsyncStorage, Clock, EventListener, FailureClassifier, Storage
+from interlock.state import State
 
 __all__ = ('Registry',)
 
@@ -22,12 +25,18 @@ class Registry:
         config: Default config shared by breakers without an override.
             Defaults to ``Config()``.
         clock: Time source shared by all breakers. Defaults to ``SystemClock``.
+        initial_state: Stable state assigned to every breaker before it is
+            published from the registry. Use ``State.METRICS_ONLY`` for a
+            shadow rollout. Defaults to ``State.CLOSED``.
         classifier: Failure policy shared by every breaker. Defaults to the
             breaker's own default (any raised exception is a failure).
         listener: Observability hooks shared by every breaker. Defaults to
             no observation.
         storage: Shared backend for coordinated state, handed to every breaker
             (each coordinates under its own name). Defaults to local state.
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -35,12 +44,15 @@ class Registry:
         *,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
         storage: Storage | AsyncStorage | None = None,
     ) -> None:
+        validate_initial_state(initial_state)
         self._config = config if config is not None else Config()
         self._clock = clock if clock is not None else SystemClock()
+        self._initial_state = initial_state
         self._classifier = classifier
         self._listener = listener
         self._storage = storage
@@ -65,6 +77,7 @@ class Registry:
                     name=name,
                     config=config if config is not None else self._config,
                     clock=self._clock,
+                    initial_state=self._initial_state,
                     classifier=self._classifier,
                     listener=self._listener,
                     storage=self._storage,
@@ -72,6 +85,11 @@ class Registry:
                 self._breakers[name] = breaker
 
             return breaker
+
+    def get_existing(self, name: str) -> CircuitBreaker | None:
+        """Return a cached breaker without creating one for a missing name."""
+        with self._lock:
+            return self._breakers.get(name)
 
     def close_all(self) -> None:
         """Release the background resources of every breaker created so far.
@@ -83,8 +101,9 @@ class Registry:
             InterlockError: If the registry's storage is asynchronous; use
                 ``aclose_all`` there.
         """
-        for breaker in self._snapshot():
-            breaker.close()
+        with ExitStack() as stack:
+            for breaker in self._snapshot():
+                stack.callback(breaker.close)
 
     async def aclose_all(self) -> None:
         """Release every breaker's background resources; the async mirror.
@@ -93,8 +112,9 @@ class Registry:
             InterlockError: If the registry's storage is synchronous; use
                 ``close_all`` there.
         """
-        for breaker in self._snapshot():
-            await breaker.aclose()
+        async with AsyncExitStack() as stack:
+            for breaker in self._snapshot():
+                stack.push_async_callback(breaker.aclose)
 
     def _snapshot(self) -> tuple[CircuitBreaker, ...]:
         """The breakers created so far; taken under the lock, closed outside it."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,12 @@ ban-relative-imports = "all"
 "interlock/breaker.py" = [
   "PLR0913", # the public constructor mirrors the engine's keyword-only collaborators
 ]
+"interlock/registry.py" = [
+  "PLR0913", # the registry takes keyword-only defaults shared by every lazy breaker
+]
+"interlock/integrations/httpx2.py" = [
+  "PLR0913", # transports take the wrapped transport plus keyword-only breaker collaborators
+]
 "interlock/integrations/tenacity.py" = [
   "PLR0913", # RetryStrategy takes keyword-only tenacity policy collaborators
 ]

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -5,10 +5,11 @@ from typing import cast
 import pytest
 from aiohttp import ClientHandlerType, ClientRequest, ClientResponse, ClientSession, web
 from aiohttp.test_utils import TestServer
+from pytest_mock import MockerFixture
 from tests.conftest import FakeClock
 from yarl import URL
 
-from interlock import CircuitOpenError, Config
+from interlock import CircuitOpenError, Config, State
 from interlock.integrations.aiohttp import CircuitBreakerMiddleware, HttpStatusClassifier
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
@@ -114,6 +115,40 @@ async def test__middleware__client_errors__do_not_trip(fake_clock: FakeClock) ->
         assert response.status == 404
 
     assert handler.calls == 5
+
+
+@pytest.mark.asyncio
+async def test__middleware__metrics_only_failures__record_without_rejecting(
+    fake_clock: FakeClock,
+) -> None:
+    middleware = CircuitBreakerMiddleware(
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+    )
+    handler = _handler([503] * 5)
+
+    for _ in range(5):
+        response = await middleware(
+            _request('https://api.a/x'),
+            cast('ClientHandlerType', handler),
+        )
+        assert response.status == 503
+
+    breaker = middleware.registry.get_existing('api.a')
+    assert breaker is not None
+    assert breaker.state is State.METRICS_ONLY
+    assert breaker.snapshot().failed_calls == 5
+
+
+@pytest.mark.asyncio
+async def test__middleware__aclose__releases_registry(mocker: MockerFixture) -> None:
+    middleware = CircuitBreakerMiddleware()
+    aclose_all = mocker.spy(middleware.registry, 'aclose_all')
+
+    await middleware.aclose()
+
+    aclose_all.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_breaker.py
+++ b/tests/test_breaker.py
@@ -82,6 +82,43 @@ def test__init__defaults__usable_without_config_or_clock() -> None:
     assert breaker.state is State.CLOSED
 
 
+@pytest.mark.parametrize(
+    'initial_state',
+    [State.CLOSED, State.FORCED_OPEN, State.DISABLED, State.METRICS_ONLY],
+)
+def test__init__supported_initial_state__starts_in_requested_state(initial_state: State) -> None:
+    breaker = CircuitBreaker(name='rollout', initial_state=initial_state)
+
+    assert breaker.state is initial_state
+
+
+@pytest.mark.parametrize('initial_state', [State.OPEN, State.HALF_OPEN])
+def test__init__transitional_initial_state__raises_value_error(initial_state: State) -> None:
+    with pytest.raises(ValueError, match='initial_state'):
+        CircuitBreaker(name='invalid', initial_state=initial_state)
+
+
+def test__init__metrics_only__records_without_tripping_or_synthetic_transition(
+    config: Config,
+    fake_clock: FakeClock,
+    listener: RecordingListener,
+) -> None:
+    breaker = CircuitBreaker(
+        name='shadow',
+        initial_state=State.METRICS_ONLY,
+        config=config,
+        clock=fake_clock,
+        listener=listener,
+    )
+
+    _fail(breaker)
+    _fail(breaker)
+
+    assert breaker.state is State.METRICS_ONLY
+    assert breaker.snapshot() == WindowSnapshot(total_calls=4, failed_calls=4, slow_calls=0)
+    assert listener.state_changes == []
+
+
 def test__name__exposes_breaker_name(breaker: CircuitBreaker) -> None:
     assert breaker.name == 'svc'
 

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -3,9 +3,10 @@ from collections.abc import Callable
 import httpx2
 import pytest
 from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
-from tests.conftest import FakeClock
+from pytest_mock import MockerFixture
+from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitOpenError, Config
+from interlock import CircuitOpenError, Config, Outcome, State
 from interlock.integrations.httpx2 import (
     AsyncCircuitBreakerTransport,
     CircuitBreakerTransport,
@@ -126,13 +127,31 @@ def test__sync_transport__breakers_isolated_per_host(fake_clock: FakeClock) -> N
     assert transport.handle_request(_request('https://good.example.com/')).status_code == 200
 
 
-def test__sync_transport__close__delegates_to_wrapped() -> None:
+def test__sync_transport__close__releases_wrapped_transport_and_registry(
+    mocker: MockerFixture,
+) -> None:
     inner = _SyncStub(lambda _request: Response(200))
     transport = CircuitBreakerTransport(inner)
+    close_all = mocker.spy(transport.registry, 'close_all')
 
     transport.close()
 
     assert inner.closed
+    close_all.assert_called_once_with()
+
+
+def test__sync_transport__wrapped_close_raises__still_releases_registry(
+    mocker: MockerFixture,
+) -> None:
+    inner = _SyncStub(lambda _request: Response(200))
+    transport = CircuitBreakerTransport(inner)
+    mocker.patch.object(inner, 'close', side_effect=RuntimeError('close failed'))
+    close_all = mocker.spy(transport.registry, 'close_all')
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        transport.close()
+
+    close_all.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -161,13 +180,101 @@ async def test__async_transport__server_errors__open_breaker_for_host(
 
 
 @pytest.mark.asyncio
-async def test__async_transport__aclose__delegates_to_wrapped() -> None:
+async def test__async_transport__aclose__releases_wrapped_transport_and_registry(
+    mocker: MockerFixture,
+) -> None:
     inner = _AsyncStub(lambda _request: Response(200))
     transport = AsyncCircuitBreakerTransport(inner)
+    aclose_all = mocker.spy(transport.registry, 'aclose_all')
 
     await transport.aclose()
 
     assert inner.closed
+    aclose_all.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test__async_transport__wrapped_aclose_raises__still_releases_registry(
+    mocker: MockerFixture,
+) -> None:
+    inner = _AsyncStub(lambda _request: Response(200))
+    transport = AsyncCircuitBreakerTransport(inner)
+    mocker.patch.object(inner, 'aclose', side_effect=RuntimeError('close failed'))
+    aclose_all = mocker.spy(transport.registry, 'aclose_all')
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        await transport.aclose()
+
+    aclose_all.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test__async_transport__metrics_only_server_errors__records_without_rejecting(
+    fake_clock: FakeClock,
+    listener: RecordingListener,
+) -> None:
+    inner = _AsyncStub(lambda _request: Response(503))
+    transport = AsyncCircuitBreakerTransport(
+        inner,
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+        listener=listener,
+    )
+
+    for _ in range(5):
+        response = await transport.handle_async_request(_request())
+        assert response.status_code == 503
+
+    breaker = transport.registry.get_existing('api.example.com')
+    assert breaker is not None
+    assert breaker.state is State.METRICS_ONLY
+    assert breaker.snapshot().failed_calls == 5
+    assert [outcome for outcome, _duration in listener.calls] == [Outcome.FAILURE] * 5
+
+
+@pytest.mark.asyncio
+async def test__async_transport__metrics_only_transport_exception__propagates_and_records(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(_request: Request) -> Response:
+        raise httpx2.ConnectError('down')
+
+    transport = AsyncCircuitBreakerTransport(
+        _AsyncStub(boom),
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+    )
+
+    with pytest.raises(httpx2.ConnectError, match='down'):
+        await transport.handle_async_request(_request())
+
+    breaker = transport.registry.get_existing('api.example.com')
+    assert breaker is not None
+    assert breaker.snapshot().failed_calls == 1
+
+
+@pytest.mark.asyncio
+async def test__async_transport__metrics_only_new_hosts__all_start_in_shadow_mode(
+    fake_clock: FakeClock,
+) -> None:
+    inner = _AsyncStub(lambda _request: Response(503))
+    transport = AsyncCircuitBreakerTransport(
+        inner,
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+    )
+
+    for host in ('api-a.example.com', 'api-b.example.com'):
+        for _ in range(3):
+            response = await transport.handle_async_request(_request(f'https://{host}/'))
+            assert response.status_code == 503
+
+        breaker = transport.registry.get_existing(host)
+        assert breaker is not None
+        assert breaker.state is State.METRICS_ONLY
 
 
 def test__http_status_classifier__custom_statuses__override_default_set() -> None:

--- a/tests/test_initial_state.py
+++ b/tests/test_initial_state.py
@@ -1,0 +1,10 @@
+from typing import cast
+
+import pytest
+
+from interlock import CircuitBreaker, State
+
+
+def test__circuit_breaker__non_state_initial_value__raises_value_error() -> None:
+    with pytest.raises(ValueError, match='initial_state'):
+        CircuitBreaker(name='invalid', initial_state=cast('State', 'metrics_only'))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_mock import MockerFixture
 
 from conftest import FakeClock
 from interlock import CircuitBreaker, Config, Registry, State
@@ -32,6 +33,74 @@ def test__get__different_names__returns_distinct_instances() -> None:
     registry = Registry()
 
     assert registry.get('a') is not registry.get('b')
+
+
+@pytest.mark.parametrize(
+    'initial_state',
+    [State.CLOSED, State.FORCED_OPEN, State.DISABLED, State.METRICS_ONLY],
+)
+def test__get__supported_initial_state__applies_to_every_new_breaker(
+    initial_state: State,
+) -> None:
+    registry = Registry(initial_state=initial_state)
+
+    assert registry.get('a').state is initial_state
+    assert registry.get('b').state is initial_state
+
+
+@pytest.mark.parametrize('initial_state', [State.OPEN, State.HALF_OPEN])
+def test__init__transitional_initial_state__raises_value_error(initial_state: State) -> None:
+    with pytest.raises(ValueError, match='initial_state'):
+        Registry(initial_state=initial_state)
+
+
+def test__get_existing__missing_name__does_not_create_breaker() -> None:
+    registry = Registry()
+
+    assert registry.get_existing('missing') is None
+
+
+def test__get_existing__created_name__returns_cached_breaker() -> None:
+    registry = Registry()
+    breaker = registry.get('payments')
+
+    assert registry.get_existing('payments') is breaker
+
+
+def test__close_all__one_breaker_raises__still_closes_the_rest(
+    mocker: MockerFixture,
+) -> None:
+    registry = Registry()
+    first = registry.get('first')
+    second = registry.get('second')
+    first_close = mocker.patch.object(first, 'close', autospec=True)
+    mocker.patch.object(second, 'close', autospec=True, side_effect=RuntimeError('close failed'))
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        registry.close_all()
+
+    first_close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test__aclose_all__one_breaker_raises__still_closes_the_rest(
+    mocker: MockerFixture,
+) -> None:
+    registry = Registry()
+    first = registry.get('first')
+    second = registry.get('second')
+    first_close = mocker.patch.object(first, 'aclose', autospec=True)
+    mocker.patch.object(
+        second,
+        'aclose',
+        autospec=True,
+        side_effect=RuntimeError('close failed'),
+    )
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        await registry.aclose_all()
+
+    first_close.assert_awaited_once_with()
 
 
 def test__get__per_name_override__applies_custom_config(fake_clock: FakeClock) -> None:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -9,7 +9,7 @@ from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
 from tests.conftest import FakeClock
 
-from interlock import CircuitOpenError, Config
+from interlock import CircuitOpenError, Config, State
 from interlock.integrations.requests import CircuitBreakerAdapter, HttpStatusClassifier
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
@@ -98,6 +98,38 @@ def test__adapter__client_errors__do_not_trip(mocker: MockerFixture, fake_clock:
         assert adapter.send(_prepared('https://api.a/x')).status_code == 404
 
     assert transport.call_count == 5
+
+
+def test__adapter__metrics_only_failures__record_without_rejecting(
+    mocker: MockerFixture,
+    fake_clock: FakeClock,
+) -> None:
+    transport = _patch_transport(mocker, [_response(503)] * 5)
+    adapter = CircuitBreakerAdapter(
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+    )
+
+    for _ in range(5):
+        assert adapter.send(_prepared('https://api.a/x')).status_code == 503
+
+    breaker = adapter.registry.get_existing('api.a')
+    assert breaker is not None
+    assert breaker.state is State.METRICS_ONLY
+    assert breaker.snapshot().failed_calls == 5
+    assert transport.call_count == 5
+
+
+def test__adapter__close__releases_pools_and_registry(mocker: MockerFixture) -> None:
+    parent_close = mocker.patch.object(HTTPAdapter, 'close', autospec=True)
+    adapter = CircuitBreakerAdapter()
+    close_all = mocker.spy(adapter.registry, 'close_all')
+
+    adapter.close()
+
+    parent_close.assert_called_once_with(adapter)
+    close_all.assert_called_once_with()
 
 
 def test__adapter__transport_exception__counts_as_failure(

--- a/tests/typing_surface.py
+++ b/tests/typing_surface.py
@@ -10,9 +10,11 @@ suite cannot observe it.
 
 from typing import assert_type
 
-from interlock import CircuitBreaker, Pipeline
+from interlock import CircuitBreaker, Pipeline, Registry, State
 
 breaker = CircuitBreaker(name='typing-surface')
+shadow_breaker = CircuitBreaker(name='shadow', initial_state=State.METRICS_ONLY)
+registry = Registry(initial_state=State.METRICS_ONLY)
 pipeline = Pipeline()
 
 


### PR DESCRIPTION
## Summary

- Add validated stable initial states for CircuitBreaker and Registry, including race-free lazy registry creation.
- Expose the same rollout control and registry diagnostics through httpx2, aiohttp, and requests integrations.
- Close per-host breaker resources together with integration resources and document the METRICS_ONLY rollout flow.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

None