### PR TITLE
feat: add classic httpx transport integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Pin extras to minimum supported versions
         run: >-
           uv pip install
+          'httpx==0.27.0'
           'httpx2==2.4.0'
           'fastapi==0.128.0'
           'redis==5.0.0'
@@ -110,6 +111,8 @@ jobs:
       - name: Integration tests against minimum versions
         run: >-
           uv run --no-sync pytest
+          tests/test_httpx.py
+          tests/test_httpx_e2e.py
           tests/test_httpx2.py
           tests/test_httpx2_e2e.py
           tests/test_fastapi.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,10 +101,10 @@ With 3+ arguments, keyword arguments only.
 
 ```python
 # bad
-breaker = CircuitBreaker('payments', 5, 60, True)
+config = Config(0.5, 10, 60.0)
 
 # good
-breaker = CircuitBreaker(name='payments', failure_threshold=5, reset_timeout=60, half_open=True)
+config = Config(failure_rate_threshold=0.5, minimum_number_of_calls=10, wait_duration_in_open=60.0)
 ```
 
 ### Functions
@@ -151,7 +151,7 @@ def get_state(name: str) -> State:
 
 - pytest, functions only (no test classes).
 - Naming: `test__unit_of_work__state_under_test__expected_behavior` (lower case).
-  Example: `test__sliding_window__failure_rate_above_threshold__opens_circuit`.
+  Example: `test__closed__failure_rate_at_threshold__opens`.
 - Test files mirror the package layout: `interlock/window.py` → `tests/test_window.py`.
 - One test — one behaviour. Arrange-Act-Assert structure.
 - Fixtures for repeated setup. `pytest-mock` to isolate external dependencies.
@@ -161,14 +161,12 @@ def get_state(name: str) -> State:
   and races.
 
 ```python
-def test__sliding_window__failure_rate_above_threshold__opens_circuit(
-    fake_clock: Clock,
-) -> None:
-    window = CountBasedWindow(size=10, clock=fake_clock)
+def test__count_based__majority_failures__failure_rate_above_threshold() -> None:
+    window = CountBasedSlidingWindow(size=10)
     for _ in range(6):
         window.record(Outcome.FAILURE)
 
-    assert window.failure_rate() >= 0.5
+    assert window.snapshot().failure_rate >= 0.5
 ```
 
 ## Documentation and naming

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ bar for simplicity, reliability and dependency hygiene is higher than usual.
   below the usual 3.12 default: a foundational library values reach.
 - **Zero-dependency core** — stdlib only. A fault-tolerance tool must not depend on someone
   else's reliability. Everything external goes through optional extras
-  (`interlock-cb[httpx2]`, `[aiohttp]`, `[requests]`, `[tenacity]`, `[fastapi]`, `[litestar]`, `[redis]`, `[otel]`).
+  (`interlock-cb[httpx2]`, `[httpx]`, `[aiohttp]`, `[requests]`, `[tenacity]`, `[fastapi]`, `[litestar]`, `[redis]`, `[otel]`).
 - **Pydantic ≥ 2.0 — extras only, NEVER in the core.** The core config is a frozen dataclass with
   eager validation. Pydantic is acceptable only where it is optional.
 - **uv** — package manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   API appears before project comparisons, the feature language is less brittle, and optional
   integrations are presented in one compact, linked overview instead of several partial examples.
 
+### Added
+
+- **httpx now has a first-class transport integration (#82).** Install
+  `interlock-cb[httpx]` and wrap `httpx.HTTPTransport` or
+  `httpx.AsyncHTTPTransport` to apply one breaker per request host without
+  decorators. The sync and async wrappers preserve streaming responses,
+  delegate client cleanup, reject host-less URLs before I/O, and use the same
+  configurable `429, 500, 502, 503, 504` failure policy as the existing HTTP
+  integrations. Unit and real-loopback tests run against both the minimum
+  supported httpx 0.27.0 and the locked latest version in CI.
+
 ## [2.3.0] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `DISABLED` and `METRICS_ONLY` are valid, while transitional `OPEN` / `HALF_OPEN`
   fail fast. Lazy registry creation applies the state before publishing a breaker,
   so per-host HTTP integrations can deploy in shadow mode without a first-call race.
-  The httpx2 transport, aiohttp middleware and requests adapter expose their registry
-  for diagnostics and accept the same option.
+  The httpx2 and httpx transports, aiohttp middleware and requests adapter expose
+  their registry for diagnostics and accept the same option.
 
 - **httpx now has a first-class transport integration (#82).** Install
   `interlock-cb[httpx]` and wrap `httpx.HTTPTransport` or
@@ -33,9 +33,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **Closing an HTTP integration now also releases its per-host breakers.** The httpx2
-  transports and requests adapter close both their native connection resources and
-  the registry; the aiohttp middleware exposes `aclose()` for application shutdown.
+- **Custom httpx transports now receive their context-manager lifecycle calls.**
+  The sync and async circuit-breaker wrappers delegate context entry and exit to
+  the wrapped transport, so transports that acquire resources on entry are ready
+  before their first request and can perform their own exit handling.
+
+- **Closing an HTTP integration now also releases its per-host breakers.** The httpx
+  and httpx2 transports and requests adapter close both their native connection
+  resources and the registry; the aiohttp middleware exposes `aclose()` for
+  application shutdown.
 
 ## [2.3.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `interlock-cb[httpx]` and wrap `httpx.HTTPTransport` or
   `httpx.AsyncHTTPTransport` to apply one breaker per request host without
   decorators. The sync and async wrappers preserve streaming responses,
-  delegate client cleanup, reject host-less URLs before I/O, and use the same
+  delegate the wrapped transport's full lifecycle (context entry and exit,
+  `close()` / `aclose()`), reject host-less URLs before I/O, and use the same
   configurable `429, 500, 502, 503, 504` failure policy as the existing HTTP
   integrations. Unit and real-loopback tests run against both the minimum
   supported httpx 0.27.0 and the locked latest version in CI.
@@ -33,15 +34,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **Custom httpx transports now receive their context-manager lifecycle calls.**
-  The sync and async circuit-breaker wrappers delegate context entry and exit to
-  the wrapped transport, so transports that acquire resources on entry are ready
-  before their first request and can perform their own exit handling.
+- **The httpx2 transports now delegate context-manager entry and exit to the
+  wrapped transport.** Entering `with client:` (or `async with client:`)
+  previously never entered the wrapped transport, so a custom transport that
+  acquires resources in `__enter__` / `__aenter__` was not ready before its
+  first request. Exit now also releases every per-host breaker, matching
+  `close()` / `aclose()`.
 
-- **Closing an HTTP integration now also releases its per-host breakers.** The httpx
-  and httpx2 transports and requests adapter close both their native connection
-  resources and the registry; the aiohttp middleware exposes `aclose()` for
-  application shutdown.
+- **Closing an HTTP integration now also releases its per-host breakers.** The httpx2
+  transports and requests adapter close both their native connection resources and
+  the registry; the aiohttp middleware exposes `aclose()` for application shutdown.
 
 ## [2.3.0] - 2026-08-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+@AGENTS.md
+@CLAUDE.local.md

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ By default, transport exceptions and the canonical retryable statuses
 | Integration | Install | Documentation |
 |---|---|---|
 | httpx2 | `interlock-cb[httpx2]` | [Per-host transport](docs/integrations/httpx2.md) |
+| httpx | `interlock-cb[httpx]` | [Per-host transport](docs/integrations/httpx.md) |
 | aiohttp | `interlock-cb[aiohttp]` | [Client middleware](docs/integrations/aiohttp.md) |
 | requests | `interlock-cb[requests]` | [Session adapter](docs/integrations/requests.md) |
 | FastAPI | `interlock-cb[fastapi]` | [`503 + Retry-After` handler](docs/integrations/fastapi.md) |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -30,7 +30,7 @@ choice.
 | Composable resilience pipeline (retry × breaker × bulkhead × timeout × fallback) | ✅ | — | — | — | — |
 | Fully typed API (`py.typed`) | ✅ | — | — | — | ✅ |
 | Signature-preserving decorator (`ParamSpec`) | ✅ | — | — | — | — |
-| HTTP client integrations (httpx2 / aiohttp / requests) | ✅ | — | — | — | — |
+| HTTP client integrations (httpx2 / httpx / aiohttp / requests) | ✅ | — | — | — | — |
 | Retry composition helpers (tenacity) | ✅ | — | — | — | — |
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
@@ -84,9 +84,9 @@ a consecutive-failure threshold with a TTL on the open state.
   atomic across racing instances and half-open probes are budgeted globally,
   with graceful degradation to local state when Redis is down
   ([Redis integration](integrations/redis.md)).
-- **Meets your stack where it is.** Per-host breakers ship for httpx2,
-  aiohttp and requests; tenacity glue composes retries correctly; FastAPI and Litestar
-  map rejections to `503 + Retry-After`
+- **Meets your stack where it is.** Per-host breakers ship for httpx2, httpx,
+  aiohttp and requests; tenacity glue composes retries correctly; FastAPI and
+  Litestar map rejections to `503 + Retry-After`
   ([integrations overview](integrations/index.md)).
 
 The honest trade-off: interlock-cb requires Python ≥ 3.11 and has not had

--- a/docs/correctness.md
+++ b/docs/correctness.md
@@ -157,7 +157,8 @@ too slow to run against a real clock.
 ## Lower-bound dependency versions are tested, not guessed
 
 Every optional extra declares a minimum version in `pyproject.toml`
-(`httpx2>=2.4.0`, `redis>=5.0.0`, and so on). The `extras-min` job re-pins each
+(`httpx>=0.27.0`, `httpx2>=2.4.0`, `redis>=5.0.0`, and so on). The
+`extras-min` job re-pins each
 one to exactly that floor and runs the integration suite against it
 ([`ci.yml`](https://github.com/bagowix/interlock/blob/main/.github/workflows/ci.yml)) —
 so a lower bound is a tested claim, not an untested guess about how far back

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -199,6 +199,6 @@ invisible again — no strategy ever fires.
 
 These demos hand-roll their guarded clients so you can debug the mechanics.
 In real code you usually don't have to: the [integrations](integrations/index.md)
-apply the same per-dependency pattern to httpx2, aiohttp, requests and
+apply the same per-dependency pattern to httpx2, httpx, aiohttp, requests and
 FastAPI transparently, and the [resilience pipeline](guides/pipeline.md)
 composes the breaker with timeout, bulkhead, retry and fallback declaratively.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,6 +27,7 @@ add the ones you need (same names with `pip install` / `poetry add`):
 uv add 'interlock-cb[fastapi]'  # CircuitOpenError -> 503 + Retry-After
 uv add 'interlock-cb[litestar]' # same for Litestar
 uv add 'interlock-cb[httpx2]'   # per-host httpx2 transport
+uv add 'interlock-cb[httpx]'    # per-host httpx transport
 uv add 'interlock-cb[aiohttp]'  # per-host aiohttp client middleware
 uv add 'interlock-cb[requests]' # per-host requests session adapter
 uv add 'interlock-cb[tenacity]' # retry x breaker composition helpers
@@ -133,5 +134,5 @@ breaker.snapshot()  # WindowSnapshot: total_calls, failed_calls, slow_calls,
 - [States & manual control](guides/states.md)
 - [Failure classification](guides/failure-classification.md)
 - [Observability](guides/observability.md)
-- [Integrations](integrations/index.md) — FastAPI, Litestar, httpx2, aiohttp, requests, tenacity, Redis
+- [Integrations](integrations/index.md) — FastAPI, Litestar, httpx2, httpx, aiohttp, requests, tenacity, Redis
 - [Resilience pipeline](guides/pipeline.md) — compose timeout, bulkhead, retry and fallback around the breaker

--- a/docs/guides/failure-classification.md
+++ b/docs/guides/failure-classification.md
@@ -58,7 +58,9 @@ class IgnoreNotFound:
 
 ## HTTP out of the box
 
-For httpx2, you do not need to write this yourself — the
-[httpx2 integration](../integrations/httpx2.md) ships `HttpStatusClassifier`,
-which treats transport exceptions and the canonical retryable statuses
-(`429, 500, 502, 503, 504`) as failures.
+For HTTP clients, you do not need to write this yourself — the
+[httpx2](../integrations/httpx2.md), [httpx](../integrations/httpx.md),
+[aiohttp](../integrations/aiohttp.md), and
+[requests](../integrations/requests.md) integrations ship
+`HttpStatusClassifier`, which treats transport exceptions and the canonical
+retryable statuses (`429, 500, 502, 503, 504`) as failures.

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -1,0 +1,98 @@
+# httpx
+
+The `interlock-cb[httpx]` extra wraps an
+[httpx](https://www.python-httpx.org/) transport so a circuit breaker is
+applied **per host** transparently. It supports httpx 0.27.0 and newer.
+
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[httpx]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[httpx]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[httpx]'
+    ```
+
+## Synchronous client
+
+```python
+import httpx
+from interlock.integrations.httpx import CircuitBreakerTransport
+
+transport = CircuitBreakerTransport(httpx.HTTPTransport())
+client = httpx.Client(transport=transport)
+
+response = client.get('https://api.example.com/v1/users')
+```
+
+## Asynchronous client
+
+```python
+import httpx
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport
+
+transport = AsyncCircuitBreakerTransport(httpx.AsyncHTTPTransport())
+client = httpx.AsyncClient(transport=transport)
+
+response = await client.get('https://api.example.com/v1/users')
+```
+
+Use the client as a context manager. Closing it delegates `close()` or
+`aclose()` to the wrapped transport and releases the connection pool.
+
+## Per-host isolation
+
+Each host gets its own lazily created breaker. A failing
+`api.a.example.com` trips only that host; traffic to `api.b.example.com`
+continues normally. An open breaker raises `CircuitOpenError` before the
+wrapped transport performs I/O. A request URL without a host raises
+`ValueError` for the same reason: there is no dependency identity to key on.
+
+## What counts as a failure
+
+The default `HttpStatusClassifier` counts these as failures:
+
+- transport exceptions raised before a response is returned;
+- response statuses `429, 500, 502, 503, 504`.
+
+Other responses, including caller errors such as `404`, count as successes.
+Pass `HttpStatusClassifier(failure_statuses={...})` or another
+`FailureClassifier` to change the policy.
+
+## Streaming responses
+
+The wrapper returns the original `httpx.Response` unchanged, so sync and async
+streaming remain lazy and connection cleanup keeps httpx's normal semantics.
+Because the circuit-breaker call completes when response headers arrive, an
+exception raised later while consuming a streaming body is outside that call
+and is not recorded by the breaker.
+
+## Tuning
+
+`config`, `clock`, `classifier`, and `listener` are shared by every per-host
+breaker created by the transport:
+
+```python
+import httpx
+
+from interlock import Config, LoggingEventListener
+from interlock.integrations.httpx import CircuitBreakerTransport
+
+transport = CircuitBreakerTransport(
+    httpx.HTTPTransport(),
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    listener=LoggingEventListener(),
+)
+```
+
+The transport never retries. If another layer owns retries, keep them bounded
+and stop retrying when the breaker raises `CircuitOpenError`.

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -47,7 +47,36 @@ response = await client.get('https://api.example.com/v1/users')
 ```
 
 Use the client as a context manager. Closing it delegates `close()` or
-`aclose()` to the wrapped transport and releases the connection pool.
+`aclose()` to the wrapped transport and releases both the connection pool and
+every breaker created by the transport.
+
+## Safe production rollout
+
+Start in shadow mode when introducing the integration to existing traffic:
+
+```python
+import httpx
+
+from interlock import State
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport
+
+transport = AsyncCircuitBreakerTransport(
+    httpx.AsyncHTTPTransport(),
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+Every host created later starts in `METRICS_ONLY` before its first request: it
+records outcomes but never raises `CircuitOpenError`. Use the listener for
+production metrics. For local diagnosis,
+`transport.registry.get_existing(host)` returns an existing breaker without
+creating one; inspect its `state` and `snapshot()`.
+
+After tuning thresholds, deploy a new transport with the default
+`initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
+transport configured for shadow mode would still create future hosts in
+`METRICS_ONLY`. See the complete [safe-rollout guide](../guides/states.md#safe-rollout).
 
 ## Per-host isolation
 
@@ -72,14 +101,16 @@ Pass `HttpStatusClassifier(failure_statuses={...})` or another
 
 The wrapper returns the original `httpx.Response` unchanged, so sync and async
 streaming remain lazy and connection cleanup keeps httpx's normal semantics.
+Context entry and exit are delegated to the wrapped transport, including for
+custom transports that acquire resources in `__enter__` or `__aenter__`.
 Because the circuit-breaker call completes when response headers arrive, an
 exception raised later while consuming a streaming body is outside that call
 and is not recorded by the breaker.
 
 ## Tuning
 
-`config`, `clock`, `classifier`, and `listener` are shared by every per-host
-breaker created by the transport:
+`config`, `clock`, `initial_state`, `classifier`, and `listener` are shared by
+every per-host breaker created by the transport:
 
 ```python
 import httpx

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -4,6 +4,9 @@ The `interlock-cb[httpx2]` extra wraps an [httpx2](https://pypi.org/project/http
 transport so a circuit breaker is applied **per host** transparently — no
 decorators or `call` wrappers in your request code.
 
+`interlock-cb` is listed in httpx2's official
+[third-party packages directory](https://github.com/pydantic/httpx2/blob/main/docs/third_party_packages.md#interlock-cb).
+
 === "uv"
 
     ```bash

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -49,8 +49,10 @@ client = httpx2.AsyncClient(transport=transport)
 response = await client.get('https://api.example.com/v1/users')
 ```
 
-Closing the client closes both the wrapped connection pool and every breaker
-created by the transport.
+Use the client as a context manager. Context entry and exit are delegated to
+the wrapped transport, including for custom transports that acquire resources
+in `__enter__` or `__aenter__`. Closing the client closes both the wrapped
+connection pool and every breaker created by the transport.
 
 ## Safe production rollout
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -11,6 +11,7 @@ per named dependency) with no decorators in call sites.
 | [FastAPI](fastapi.md) | `interlock-cb[fastapi]` | `Depends`-injected breakers and a `CircuitOpenError → 503 + Retry-After` handler |
 | [Litestar](litestar.md) | `interlock-cb[litestar]` | `Provide`-injected breakers and a `CircuitOpenError → 503 + Retry-After` handler (Litestar ≥ 2.23) |
 | [httpx2](httpx2.md) | `interlock-cb[httpx2]` | `CircuitBreakerTransport` / `AsyncCircuitBreakerTransport` — per-host breaker at the transport level |
+| [httpx](httpx.md) | `interlock-cb[httpx]` | `CircuitBreakerTransport` / `AsyncCircuitBreakerTransport` — per-host transport for httpx clients |
 | [aiohttp](aiohttp.md) | `interlock-cb[aiohttp]` | `CircuitBreakerMiddleware` — per-host breaker as a client middleware (aiohttp ≥ 3.12) |
 | [requests](requests.md) | `interlock-cb[requests]` | `CircuitBreakerAdapter` — per-host breaker mounted on a `Session` |
 | [LLM SDKs](llm.md) | — (recipe) | Guard OpenAI / Anthropic SDK calls with a breaker + bounded retries |
@@ -22,7 +23,7 @@ per named dependency) with no decorators in call sites.
 
 Every integration follows the same rules, so learning one means knowing all:
 
-- **Native extension points only.** A transport (httpx2), a client middleware
+- **Native extension points only.** A transport (httpx2/httpx), a client middleware
   (aiohttp), an adapter (requests), an exception handler (FastAPI). No
   monkey-patching, no private APIs — an integration survives minor releases
   of its host library.

--- a/docs/integrations/llm.md
+++ b/docs/integrations/llm.md
@@ -5,8 +5,9 @@ LLM APIs fail in exactly the ways circuit breakers exist for: rate limits
 LLM calls stops a degraded provider from stalling every request thread, and
 bounded retries recover from blips without amplifying an outage.
 
-This is a **recipe** — no extra needed beyond `interlock-cb[tenacity]`; the
-SDKs raise typed exceptions, which is all the breaker needs.
+You can protect an SDK at either its call boundary, which enables SDK-specific
+classification and slow-call detection, or at the httpx transport,
+which applies transparently to every request made by that client.
 
 ## Classify SDK errors
 
@@ -98,8 +99,33 @@ Give each provider its own breaker name (`anthropic`, `openai`, ...) via a
 shared `Registry` and check `breaker.state` to route around an open provider.
 The [states guide](../guides/states.md) covers manual failover controls.
 
-!!! note "Transport-level alternative"
-    The SDKs are built on classic httpx, which does not take httpx2
-    transports; once they migrate to httpx2 you will be able to drop the
-    decorator entirely and pass a client wrapped with the
-    [httpx2 transport](httpx2.md) instead.
+## Transport-level protection
+
+OpenAI and Anthropic clients accept an httpx client. Install
+`interlock-cb[httpx]`, wrap the SDK's underlying transport, and every endpoint
+on the provider host shares the same breaker:
+
+```python
+import httpx
+from openai import DefaultHttpxClient, OpenAI
+
+from interlock.integrations.httpx import CircuitBreakerTransport
+
+transport = CircuitBreakerTransport(httpx.HTTPTransport())
+
+with OpenAI(
+    http_client=DefaultHttpxClient(transport=transport),
+    max_retries=0,
+) as client:
+    response = client.responses.create(model='gpt-5.5', input='Summarise this document...')
+```
+
+Use `AsyncCircuitBreakerTransport`, `httpx.AsyncHTTPTransport`, and the SDK's
+async client for async applications. `max_retries=0` gives the breaker one
+observable attempt per SDK call; if retries are required, keep one explicit,
+bounded retry owner instead of stacking SDK and application retries.
+
+The transport classifier sees HTTP statuses directly, so no SDK exception
+classifier is needed. Choose the call-boundary recipe above when you also need
+to classify SDK-specific exceptions, measure the complete SDK operation as a
+slow call, or use a breaker name that is not derived from the request host.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2848,7 +2848,36 @@ response = await client.get('https://api.example.com/v1/users')
 ```
 
 Use the client as a context manager. Closing it delegates `close()` or
-`aclose()` to the wrapped transport and releases the connection pool.
+`aclose()` to the wrapped transport and releases both the connection pool and
+every breaker created by the transport.
+
+## Safe production rollout
+
+Start in shadow mode when introducing the integration to existing traffic:
+
+```python
+import httpx
+
+from interlock import State
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport
+
+transport = AsyncCircuitBreakerTransport(
+    httpx.AsyncHTTPTransport(),
+    initial_state=State.METRICS_ONLY,
+    listener=metrics_listener,
+)
+```
+
+Every host created later starts in `METRICS_ONLY` before its first request: it
+records outcomes but never raises `CircuitOpenError`. Use the listener for
+production metrics. For local diagnosis,
+`transport.registry.get_existing(host)` returns an existing breaker without
+creating one; inspect its `state` and `snapshot()`.
+
+After tuning thresholds, deploy a new transport with the default
+`initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
+transport configured for shadow mode would still create future hosts in
+`METRICS_ONLY`. See the complete [safe-rollout guide](../guides/states.md#safe-rollout).
 
 ## Per-host isolation
 
@@ -2873,14 +2902,16 @@ Pass `HttpStatusClassifier(failure_statuses={...})` or another
 
 The wrapper returns the original `httpx.Response` unchanged, so sync and async
 streaming remain lazy and connection cleanup keeps httpx's normal semantics.
+Context entry and exit are delegated to the wrapped transport, including for
+custom transports that acquire resources in `__enter__` or `__aenter__`.
 Because the circuit-breaker call completes when response headers arrive, an
 exception raised later while consuming a streaming body is outside that call
 and is not recorded by the breaker.
 
 ## Tuning
 
-`config`, `clock`, `classifier`, and `listener` are shared by every per-host
-breaker created by the transport:
+`config`, `clock`, `initial_state`, `classifier`, and `listener` are shared by
+every per-host breaker created by the transport:
 
 ```python
 import httpx
@@ -3986,12 +4017,14 @@ the wrapped transport and every breaker in that registry. See the
 Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 `interlock.integrations.httpx`:
 
-- **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
+- **`CircuitBreakerTransport(transport, *, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
   exceptions and statuses `429, 500, 502, 503, 504`.
 
-The transports preserve streaming responses and delegate `close()` / `aclose()`.
+Both transports expose their per-host `registry`, preserve streaming responses,
+and release the wrapped transport and every breaker on `close()` / `aclose()`.
 See the [httpx integration](integrations/httpx.md).
 
 ## aiohttp adapters

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -44,6 +44,7 @@ add the ones you need (same names with `pip install` / `poetry add`):
 uv add 'interlock-cb[fastapi]'  # CircuitOpenError -> 503 + Retry-After
 uv add 'interlock-cb[litestar]' # same for Litestar
 uv add 'interlock-cb[httpx2]'   # per-host httpx2 transport
+uv add 'interlock-cb[httpx]'    # per-host httpx transport
 uv add 'interlock-cb[aiohttp]'  # per-host aiohttp client middleware
 uv add 'interlock-cb[requests]' # per-host requests session adapter
 uv add 'interlock-cb[tenacity]' # retry x breaker composition helpers
@@ -150,7 +151,7 @@ breaker.snapshot()  # WindowSnapshot: total_calls, failed_calls, slow_calls,
 - [States & manual control](guides/states.md)
 - [Failure classification](guides/failure-classification.md)
 - [Observability](guides/observability.md)
-- [Integrations](integrations/index.md) — FastAPI, Litestar, httpx2, aiohttp, requests, tenacity, Redis
+- [Integrations](integrations/index.md) — FastAPI, Litestar, httpx2, httpx, aiohttp, requests, tenacity, Redis
 - [Resilience pipeline](guides/pipeline.md) — compose timeout, bulkhead, retry and fallback around the breaker
 
 ---
@@ -705,7 +706,7 @@ invisible again — no strategy ever fires.
 
 These demos hand-roll their guarded clients so you can debug the mechanics.
 In real code you usually don't have to: the [integrations](integrations/index.md)
-apply the same per-dependency pattern to httpx2, aiohttp, requests and
+apply the same per-dependency pattern to httpx2, httpx, aiohttp, requests and
 FastAPI transparently, and the [resilience pipeline](guides/pipeline.md)
 composes the breaker with timeout, bulkhead, retry and fallback declaratively.
 
@@ -745,7 +746,7 @@ choice.
 | Composable resilience pipeline (retry × breaker × bulkhead × timeout × fallback) | ✅ | — | — | — | — |
 | Fully typed API (`py.typed`) | ✅ | — | — | — | ✅ |
 | Signature-preserving decorator (`ParamSpec`) | ✅ | — | — | — | — |
-| HTTP client integrations (httpx2 / aiohttp / requests) | ✅ | — | — | — | — |
+| HTTP client integrations (httpx2 / httpx / aiohttp / requests) | ✅ | — | — | — | — |
 | Retry composition helpers (tenacity) | ✅ | — | — | — | — |
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
@@ -799,9 +800,9 @@ a consecutive-failure threshold with a TTL on the open state.
   atomic across racing instances and half-open probes are budgeted globally,
   with graceful degradation to local state when Redis is down
   ([Redis integration](integrations/redis.md)).
-- **Meets your stack where it is.** Per-host breakers ship for httpx2,
-  aiohttp and requests; tenacity glue composes retries correctly; FastAPI and Litestar
-  map rejections to `503 + Retry-After`
+- **Meets your stack where it is.** Per-host breakers ship for httpx2, httpx,
+  aiohttp and requests; tenacity glue composes retries correctly; FastAPI and
+  Litestar map rejections to `503 + Retry-After`
   ([integrations overview](integrations/index.md)).
 
 The honest trade-off: interlock-cb requires Python ≥ 3.11 and has not had
@@ -1373,7 +1374,8 @@ too slow to run against a real clock.
 ## Lower-bound dependency versions are tested, not guessed
 
 Every optional extra declares a minimum version in `pyproject.toml`
-(`httpx2>=2.4.0`, `redis>=5.0.0`, and so on). The `extras-min` job re-pins each
+(`httpx>=0.27.0`, `httpx2>=2.4.0`, `redis>=5.0.0`, and so on). The
+`extras-min` job re-pins each
 one to exactly that floor and runs the integration suite against it
 ([`ci.yml`](https://github.com/bagowix/interlock/blob/main/.github/workflows/ci.yml)) —
 so a lower bound is a tested claim, not an untested guess about how far back
@@ -1711,10 +1713,12 @@ class IgnoreNotFound:
 
 ## HTTP out of the box
 
-For httpx2, you do not need to write this yourself — the
-[httpx2 integration](../integrations/httpx2.md) ships `HttpStatusClassifier`,
-which treats transport exceptions and the canonical retryable statuses
-(`429, 500, 502, 503, 504`) as failures.
+For HTTP clients, you do not need to write this yourself — the
+[httpx2](../integrations/httpx2.md), [httpx](../integrations/httpx.md),
+[aiohttp](../integrations/aiohttp.md), and
+[requests](../integrations/requests.md) integrations ship
+`HttpStatusClassifier`, which treats transport exceptions and the canonical
+retryable statuses (`429, 500, 502, 503, 504`) as failures.
 
 ---
 
@@ -2337,6 +2341,7 @@ per named dependency) with no decorators in call sites.
 | [FastAPI](fastapi.md) | `interlock-cb[fastapi]` | `Depends`-injected breakers and a `CircuitOpenError → 503 + Retry-After` handler |
 | [Litestar](litestar.md) | `interlock-cb[litestar]` | `Provide`-injected breakers and a `CircuitOpenError → 503 + Retry-After` handler (Litestar ≥ 2.23) |
 | [httpx2](httpx2.md) | `interlock-cb[httpx2]` | `CircuitBreakerTransport` / `AsyncCircuitBreakerTransport` — per-host breaker at the transport level |
+| [httpx](httpx.md) | `interlock-cb[httpx]` | `CircuitBreakerTransport` / `AsyncCircuitBreakerTransport` — per-host transport for httpx clients |
 | [aiohttp](aiohttp.md) | `interlock-cb[aiohttp]` | `CircuitBreakerMiddleware` — per-host breaker as a client middleware (aiohttp ≥ 3.12) |
 | [requests](requests.md) | `interlock-cb[requests]` | `CircuitBreakerAdapter` — per-host breaker mounted on a `Session` |
 | [LLM SDKs](llm.md) | — (recipe) | Guard OpenAI / Anthropic SDK calls with a breaker + bounded retries |
@@ -2348,7 +2353,7 @@ per named dependency) with no decorators in call sites.
 
 Every integration follows the same rules, so learning one means knowing all:
 
-- **Native extension points only.** A transport (httpx2), a client middleware
+- **Native extension points only.** A transport (httpx2/httpx), a client middleware
   (aiohttp), an adapter (requests), an exception handler (FastAPI). No
   monkey-patching, no private APIs — an integration survives minor releases
   of its host library.
@@ -2619,6 +2624,9 @@ The `interlock-cb[httpx2]` extra wraps an [httpx2](https://pypi.org/project/http
 transport so a circuit breaker is applied **per host** transparently — no
 decorators or `call` wrappers in your request code.
 
+`interlock-cb` is listed in httpx2's official
+[third-party packages directory](https://github.com/pydantic/httpx2/blob/main/docs/third_party_packages.md#interlock-cb).
+
 === "uv"
 
     ```bash
@@ -2701,6 +2709,109 @@ transport = CircuitBreakerTransport(
 
 Supply your own `classifier` to change the failure policy — for example to also
 fail on `408 Request Timeout`.
+
+---
+
+<!-- source: docs/integrations/httpx.md -->
+
+# httpx
+
+The `interlock-cb[httpx]` extra wraps an
+[httpx](https://www.python-httpx.org/) transport so a circuit breaker is
+applied **per host** transparently. It supports httpx 0.27.0 and newer.
+
+=== "uv"
+
+    ```bash
+    uv add 'interlock-cb[httpx]'
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install 'interlock-cb[httpx]'
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add 'interlock-cb[httpx]'
+    ```
+
+## Synchronous client
+
+```python
+import httpx
+from interlock.integrations.httpx import CircuitBreakerTransport
+
+transport = CircuitBreakerTransport(httpx.HTTPTransport())
+client = httpx.Client(transport=transport)
+
+response = client.get('https://api.example.com/v1/users')
+```
+
+## Asynchronous client
+
+```python
+import httpx
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport
+
+transport = AsyncCircuitBreakerTransport(httpx.AsyncHTTPTransport())
+client = httpx.AsyncClient(transport=transport)
+
+response = await client.get('https://api.example.com/v1/users')
+```
+
+Use the client as a context manager. Closing it delegates `close()` or
+`aclose()` to the wrapped transport and releases the connection pool.
+
+## Per-host isolation
+
+Each host gets its own lazily created breaker. A failing
+`api.a.example.com` trips only that host; traffic to `api.b.example.com`
+continues normally. An open breaker raises `CircuitOpenError` before the
+wrapped transport performs I/O. A request URL without a host raises
+`ValueError` for the same reason: there is no dependency identity to key on.
+
+## What counts as a failure
+
+The default `HttpStatusClassifier` counts these as failures:
+
+- transport exceptions raised before a response is returned;
+- response statuses `429, 500, 502, 503, 504`.
+
+Other responses, including caller errors such as `404`, count as successes.
+Pass `HttpStatusClassifier(failure_statuses={...})` or another
+`FailureClassifier` to change the policy.
+
+## Streaming responses
+
+The wrapper returns the original `httpx.Response` unchanged, so sync and async
+streaming remain lazy and connection cleanup keeps httpx's normal semantics.
+Because the circuit-breaker call completes when response headers arrive, an
+exception raised later while consuming a streaming body is outside that call
+and is not recorded by the breaker.
+
+## Tuning
+
+`config`, `clock`, `classifier`, and `listener` are shared by every per-host
+breaker created by the transport:
+
+```python
+import httpx
+
+from interlock import Config, LoggingEventListener
+from interlock.integrations.httpx import CircuitBreakerTransport
+
+transport = CircuitBreakerTransport(
+    httpx.HTTPTransport(),
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    listener=LoggingEventListener(),
+)
+```
+
+The transport never retries. If another layer owns retries, keep them bounded
+and stop retrying when the breaker raises `CircuitOpenError`.
 
 ---
 
@@ -2873,8 +2984,9 @@ LLM APIs fail in exactly the ways circuit breakers exist for: rate limits
 LLM calls stops a degraded provider from stalling every request thread, and
 bounded retries recover from blips without amplifying an outage.
 
-This is a **recipe** — no extra needed beyond `interlock-cb[tenacity]`; the
-SDKs raise typed exceptions, which is all the breaker needs.
+You can protect an SDK at either its call boundary, which enables SDK-specific
+classification and slow-call detection, or at the httpx transport,
+which applies transparently to every request made by that client.
 
 ## Classify SDK errors
 
@@ -2966,11 +3078,36 @@ Give each provider its own breaker name (`anthropic`, `openai`, ...) via a
 shared `Registry` and check `breaker.state` to route around an open provider.
 The [states guide](../guides/states.md) covers manual failover controls.
 
-!!! note "Transport-level alternative"
-    The SDKs are built on classic httpx, which does not take httpx2
-    transports; once they migrate to httpx2 you will be able to drop the
-    decorator entirely and pass a client wrapped with the
-    [httpx2 transport](httpx2.md) instead.
+## Transport-level protection
+
+OpenAI and Anthropic clients accept an httpx client. Install
+`interlock-cb[httpx]`, wrap the SDK's underlying transport, and every endpoint
+on the provider host shares the same breaker:
+
+```python
+import httpx
+from openai import DefaultHttpxClient, OpenAI
+
+from interlock.integrations.httpx import CircuitBreakerTransport
+
+transport = CircuitBreakerTransport(httpx.HTTPTransport())
+
+with OpenAI(
+    http_client=DefaultHttpxClient(transport=transport),
+    max_retries=0,
+) as client:
+    response = client.responses.create(model='gpt-5.5', input='Summarise this document...')
+```
+
+Use `AsyncCircuitBreakerTransport`, `httpx.AsyncHTTPTransport`, and the SDK's
+async client for async applications. `max_retries=0` gives the breaker one
+observable attempt per SDK call; if retries are required, keep one explicit,
+bounded retry owner instead of stacking SDK and application retries.
+
+The transport classifier sees HTTP statuses directly, so no SDK exception
+classifier is needed. Choose the call-boundary recipe above when you also need
+to classify SDK-specific exceptions, measure the complete SDK operation as a
+slow call, or use a breaker name that is not derived from the request host.
 
 ---
 
@@ -3699,6 +3836,19 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 
 See the [httpx2 integration](integrations/httpx2.md).
 
+## httpx adapters
+
+Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
+`interlock.integrations.httpx`:
+
+- **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
+- **`AsyncCircuitBreakerTransport(transport, *, ...)`**
+- **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
+  exceptions and statuses `429, 500, 502, 503, 504`.
+
+The transports preserve streaming responses and delegate `close()` / `aclose()`.
+See the [httpx integration](integrations/httpx.md).
+
 ## aiohttp adapters
 
 Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations.aiohttp`:
@@ -3706,8 +3856,8 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
 - **`CircuitBreakerMiddleware(*, config=None, clock=None, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
-- **`HttpStatusClassifier(failure_statuses=None)`** — same policy as the
-  httpx2 variant, reading `ClientResponse.status`.
+- **`HttpStatusClassifier(failure_statuses=None)`** — same canonical HTTP
+  policy, reading `ClientResponse.status`.
 
 See the [aiohttp integration](integrations/aiohttp.md).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2723,8 +2723,10 @@ client = httpx2.AsyncClient(transport=transport)
 response = await client.get('https://api.example.com/v1/users')
 ```
 
-Closing the client closes both the wrapped connection pool and every breaker
-created by the transport.
+Use the client as a context manager. Context entry and exit are delegated to
+the wrapped transport, including for custom transports that acquire resources
+in `__enter__` or `__aenter__`. Closing the client closes both the wrapped
+connection pool and every breaker created by the transport.
 
 ## Safe production rollout
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -55,6 +55,7 @@ Key facts for answering questions about interlock:
 - [FastAPI integration](integrations/fastapi.md): Depends-injected breaker, 503 + Retry-After.
 - [Litestar integration](integrations/litestar.md): Provide-injected breaker, 503 + Retry-After (Litestar ≥ 2.23).
 - [httpx2 integration](integrations/httpx2.md): per-host transport breaker.
+- [httpx integration](integrations/httpx.md): per-host transport, including LLM SDK clients.
 - [aiohttp integration](integrations/aiohttp.md): per-host client-middleware breaker (aiohttp ≥ 3.12).
 - [requests integration](integrations/requests.md): per-host adapter breaker via `session.mount(...)`.
 - [LLM SDKs recipe](integrations/llm.md): guard OpenAI / Anthropic calls — breaker + slow-call detection + bounded retries.
@@ -66,5 +67,5 @@ Key facts for answering questions about interlock:
 ## Optional
 
 - [Full documentation](llms-full.txt): every page above inlined into one file.
-- Extras: `interlock-cb[fastapi]` (FastAPI 503 mapping), `interlock-cb[litestar]` (Litestar 503 mapping), `interlock-cb[httpx2]` (transport), `interlock-cb[aiohttp]` (client middleware), `interlock-cb[requests]` (session adapter), `interlock-cb[tenacity]` (retry glue), `interlock-cb[redis]` (shared distributed state), `interlock-cb[otel]` (OpenTelemetry metrics).
+- Extras: `interlock-cb[fastapi]` (FastAPI 503 mapping), `interlock-cb[litestar]` (Litestar 503 mapping), `interlock-cb[httpx]` / `[httpx2]` (transports), `interlock-cb[aiohttp]` (client middleware), `interlock-cb[requests]` (session adapter), `interlock-cb[tenacity]` (retry glue), `interlock-cb[redis]` (shared distributed state), `interlock-cb[otel]` (OpenTelemetry metrics).
 - Source and changelog: see the repository `CHANGELOG.md`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -181,12 +181,14 @@ the wrapped transport and every breaker in that registry. See the
 Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 `interlock.integrations.httpx`:
 
-- **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
+- **`CircuitBreakerTransport(transport, *, config=None, clock=None,
+  initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
   exceptions and statuses `429, 500, 502, 503, 504`.
 
-The transports preserve streaming responses and delegate `close()` / `aclose()`.
+Both transports expose their per-host `registry`, preserve streaming responses,
+and release the wrapped transport and every breaker on `close()` / `aclose()`.
 See the [httpx integration](integrations/httpx.md).
 
 ## aiohttp adapters

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -167,6 +167,19 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 
 See the [httpx2 integration](integrations/httpx2.md).
 
+## httpx adapters
+
+Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
+`interlock.integrations.httpx`:
+
+- **`CircuitBreakerTransport(transport, *, config=None, clock=None, classifier=None, listener=None)`**
+- **`AsyncCircuitBreakerTransport(transport, *, ...)`**
+- **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
+  exceptions and statuses `429, 500, 502, 503, 504`.
+
+The transports preserve streaming responses and delegate `close()` / `aclose()`.
+See the [httpx integration](integrations/httpx.md).
+
 ## aiohttp adapters
 
 Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations.aiohttp`:
@@ -174,8 +187,8 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
 - **`CircuitBreakerMiddleware(*, config=None, clock=None, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
-- **`HttpStatusClassifier(failure_statuses=None)`** — same policy as the
-  httpx2 variant, reading `ClientResponse.status`.
+- **`HttpStatusClassifier(failure_statuses=None)`** — same canonical HTTP
+  policy, reading `ClientResponse.status`.
 
 See the [aiohttp integration](integrations/aiohttp.md).
 

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -16,13 +16,16 @@ unchanged, preserving httpx's streaming semantics.
 
 import http
 from collections.abc import Iterable
-from typing import cast
+from contextlib import AsyncExitStack, ExitStack
+from types import TracebackType
+from typing import Self, cast
 
 from httpx import AsyncBaseTransport, BaseTransport, Request, Response
 
 from interlock.config import Config
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
+from interlock.state import State
 
 __all__ = (
     'AsyncCircuitBreakerTransport',
@@ -72,14 +75,17 @@ def _host(request: Request) -> str:
 
 
 def _build_registry(
+    *,
     config: Config | None,
     clock: Clock | None,
+    initial_state: State,
     classifier: FailureClassifier | None,
     listener: EventListener | None,
 ) -> Registry:
     return Registry(
         config=config,
         clock=clock,
+        initial_state=initial_state,
         classifier=classifier if classifier is not None else HttpStatusClassifier(),
         listener=listener,
     )
@@ -92,8 +98,13 @@ class CircuitBreakerTransport(BaseTransport):
         transport: Wrapped transport that performs requests.
         config: Thresholds, window and timing for every host's breaker.
         clock: Time source for the breakers.
+        initial_state: Stable state assigned before a host's first request.
+            Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -102,6 +113,7 @@ class CircuitBreakerTransport(BaseTransport):
         *,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
     ) -> None:
@@ -109,9 +121,15 @@ class CircuitBreakerTransport(BaseTransport):
         self._registry = _build_registry(
             config=config,
             clock=clock,
+            initial_state=initial_state,
             classifier=classifier,
             listener=listener,
         )
+
+    @property
+    def registry(self) -> Registry:
+        """The per-host registry, exposed for diagnostics and operator control."""
+        return self._registry
 
     def handle_request(self, request: Request) -> Response:
         """Run a request under the breaker for its host.
@@ -124,9 +142,27 @@ class CircuitBreakerTransport(BaseTransport):
         guarded = breaker(self._transport.handle_request)
         return guarded(request)
 
+    def __enter__(self) -> Self:
+        """Enter the wrapped transport's context and return this wrapper."""
+        self._transport.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        """Exit the wrapped transport's context and release every breaker."""
+        with ExitStack() as stack:
+            stack.callback(self._registry.close_all)
+            self._transport.__exit__(exc_type, exc_value, traceback)
+
     def close(self) -> None:
-        """Close the wrapped transport and its connection pool."""
-        self._transport.close()
+        """Release the wrapped transport and every per-host breaker."""
+        with ExitStack() as stack:
+            stack.callback(self._registry.close_all)
+            self._transport.close()
 
 
 class AsyncCircuitBreakerTransport(AsyncBaseTransport):
@@ -136,8 +172,13 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         transport: Wrapped async transport that performs requests.
         config: Thresholds, window and timing for every host's breaker.
         clock: Time source for the breakers.
+        initial_state: Stable state assigned before a host's first request.
+            Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+
+    Raises:
+        ValueError: If ``initial_state`` is not a supported stable state.
     """
 
     def __init__(
@@ -146,6 +187,7 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         *,
         config: Config | None = None,
         clock: Clock | None = None,
+        initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
     ) -> None:
@@ -153,9 +195,15 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         self._registry = _build_registry(
             config=config,
             clock=clock,
+            initial_state=initial_state,
             classifier=classifier,
             listener=listener,
         )
+
+    @property
+    def registry(self) -> Registry:
+        """The per-host registry, exposed for diagnostics and operator control."""
+        return self._registry
 
     async def handle_async_request(self, request: Request) -> Response:
         """Run a request under the breaker for its host.
@@ -168,6 +216,24 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         guarded = breaker(self._transport.handle_async_request)
         return await guarded(request)
 
+    async def __aenter__(self) -> Self:
+        """Enter the wrapped transport's context and return this wrapper."""
+        await self._transport.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        """Exit the wrapped transport's context and release every breaker."""
+        async with AsyncExitStack() as stack:
+            stack.push_async_callback(self._registry.aclose_all)
+            await self._transport.__aexit__(exc_type, exc_value, traceback)
+
     async def aclose(self) -> None:
-        """Close the wrapped transport and its connection pool."""
-        await self._transport.aclose()
+        """Release the wrapped transport and every per-host breaker."""
+        async with AsyncExitStack() as stack:
+            stack.push_async_callback(self._registry.aclose_all)
+            await self._transport.aclose()

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -1,30 +1,24 @@
-"""httpx2 transport integration — requires the ``httpx2`` extra.
+"""httpx transport integration — requires the ``httpx`` extra.
 
-This module imports ``httpx2`` and is deliberately *not* re-exported from
+This module imports ``httpx`` and is deliberately not re-exported from
 ``interlock`` so the core stays zero-dependency. Install with
-``pip install interlock[httpx2]`` and wrap your transport explicitly::
+``pip install interlock-cb[httpx]`` and wrap a transport explicitly::
 
-    import httpx2
-    from interlock.integrations.httpx2 import CircuitBreakerTransport
+    import httpx
+    from interlock.integrations.httpx import CircuitBreakerTransport
 
-    transport = CircuitBreakerTransport(httpx2.HTTPTransport())
-    client = httpx2.Client(transport=transport)
+    transport = CircuitBreakerTransport(httpx.HTTPTransport())
+    client = httpx.Client(transport=transport)
 
-The wrapper applies one circuit breaker **per host** transparently: no
-decorators in user code. Each host gets its own breaker (a slow or failing
-``api.a`` must not trip ``api.b``), created lazily and shared across requests.
-
-By default a response counts as a failure when its status is one of
-``HttpStatusClassifier``'s — the canonical retryable set ``429, 500, 502, 503,
-504`` — and any transport exception (connect/read errors) is a failure. Supply
-a custom ``classifier`` to change that policy.
+The wrapper applies one circuit breaker per host. Responses are returned
+unchanged, preserving httpx's streaming semantics.
 """
 
 import http
 from collections.abc import Iterable
 from typing import cast
 
-from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
+from httpx import AsyncBaseTransport, BaseTransport, Request, Response
 
 from interlock.config import Config
 from interlock.protocols import Clock, EventListener, FailureClassifier
@@ -36,33 +30,23 @@ __all__ = (
     'HttpStatusClassifier',
 )
 
-# Mirrors urllib3's recommended ``status_forcelist`` (also used by AWS/Google):
-# transient server-side conditions where the dependency is unhealthy or
-# overloaded. Permanent 5xx (501 Not Implemented, 505) are excluded — retrying
-# or tripping the breaker cannot help a contract/protocol error.
 _FAILURE_STATUSES = frozenset(
     {
-        http.HTTPStatus.TOO_MANY_REQUESTS,  # 429
-        http.HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
-        http.HTTPStatus.BAD_GATEWAY,  # 502
-        http.HTTPStatus.SERVICE_UNAVAILABLE,  # 503
-        http.HTTPStatus.GATEWAY_TIMEOUT,  # 504
+        http.HTTPStatus.TOO_MANY_REQUESTS,
+        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+        http.HTTPStatus.BAD_GATEWAY,
+        http.HTTPStatus.SERVICE_UNAVAILABLE,
+        http.HTTPStatus.GATEWAY_TIMEOUT,
     }
 )
 
 
 class HttpStatusClassifier:
-    """Counts transport exceptions and unhealthy-status responses as failures.
-
-    A returned response is a failure when its status is in ``failure_statuses``
-    — by default the canonical retryable set (``429, 500, 502, 503, 504``);
-    any raised exception is a failure. Other responses — including ``4xx``
-    client mistakes like ``404`` — are successes, so they never trip the
-    breaker.
+    """Count transport exceptions and unhealthy-status responses as failures.
 
     Args:
         failure_statuses: Statuses to count as failures instead of the
-            canonical set.
+            canonical set ``429, 500, 502, 503, 504``.
     """
 
     def __init__(self, *, failure_statuses: Iterable[int] | None = None) -> None:
@@ -79,7 +63,7 @@ class HttpStatusClassifier:
 
 
 def _host(request: Request) -> str:
-    """The host keying the request's breaker; empty hosts are rejected eagerly."""
+    """Return the host key, rejecting URLs that cannot identify a dependency."""
     host = request.url.host
     if not host:
         raise ValueError(f'Request URL has no host to key a breaker on: {request.url!s}')
@@ -102,13 +86,12 @@ def _build_registry(
 
 
 class CircuitBreakerTransport(BaseTransport):
-    """A synchronous transport that guards each host with a circuit breaker.
+    """Guard every host reached by a synchronous httpx transport.
 
     Args:
-        transport: The wrapped transport that performs the actual request.
+        transport: Wrapped transport that performs requests.
         config: Thresholds, window and timing for every host's breaker.
-        clock: Time source for the breakers; inject a fake for deterministic
-            tests.
+        clock: Time source for the breakers.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
     """
@@ -131,29 +114,28 @@ class CircuitBreakerTransport(BaseTransport):
         )
 
     def handle_request(self, request: Request) -> Response:
-        """Run the request under its host's breaker.
+        """Run a request under the breaker for its host.
 
         Raises:
             CircuitOpenError: If the host's breaker is open.
-            ValueError: If the request URL carries no host to key a breaker on.
+            ValueError: If the request URL has no host.
         """
         breaker = self._registry.get(_host(request))
         guarded = breaker(self._transport.handle_request)
         return guarded(request)
 
     def close(self) -> None:
-        """Close the wrapped transport, releasing its connection pool."""
+        """Close the wrapped transport and its connection pool."""
         self._transport.close()
 
 
 class AsyncCircuitBreakerTransport(AsyncBaseTransport):
-    """An asynchronous transport that guards each host with a circuit breaker.
+    """Guard every host reached by an asynchronous httpx transport.
 
     Args:
-        transport: The wrapped async transport that performs the request.
+        transport: Wrapped async transport that performs requests.
         config: Thresholds, window and timing for every host's breaker.
-        clock: Time source for the breakers; inject a fake for deterministic
-            tests.
+        clock: Time source for the breakers.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
     """
@@ -176,16 +158,16 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         )
 
     async def handle_async_request(self, request: Request) -> Response:
-        """Run the request under its host's breaker.
+        """Run a request under the breaker for its host.
 
         Raises:
             CircuitOpenError: If the host's breaker is open.
-            ValueError: If the request URL carries no host to key a breaker on.
+            ValueError: If the request URL has no host.
         """
         breaker = self._registry.get(_host(request))
         guarded = breaker(self._transport.handle_async_request)
         return await guarded(request)
 
     async def aclose(self) -> None:
-        """Close the wrapped transport, releasing its connection pool."""
+        """Close the wrapped transport and its connection pool."""
         await self._transport.aclose()

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -10,8 +10,15 @@ This module imports ``httpx`` and is deliberately not re-exported from
     transport = CircuitBreakerTransport(httpx.HTTPTransport())
     client = httpx.Client(transport=transport)
 
-The wrapper applies one circuit breaker per host. Responses are returned
-unchanged, preserving httpx's streaming semantics.
+The wrapper applies one circuit breaker **per host** transparently: no
+decorators in user code. Each host gets its own breaker (a slow or failing
+``api.a`` must not trip ``api.b``), created lazily and shared across requests.
+Responses are returned unchanged, preserving httpx's streaming semantics.
+
+By default a response counts as a failure when its status is one of
+``HttpStatusClassifier``'s — the canonical retryable set ``429, 500, 502, 503,
+504`` — and any transport exception (connect/read errors) is a failure. Supply
+a custom ``classifier`` to change that policy.
 """
 
 import http
@@ -33,23 +40,33 @@ __all__ = (
     'HttpStatusClassifier',
 )
 
+# Mirrors urllib3's recommended ``status_forcelist`` (also used by AWS/Google):
+# transient server-side conditions where the dependency is unhealthy or
+# overloaded. Permanent 5xx (501 Not Implemented, 505) are excluded — retrying
+# or tripping the breaker cannot help a contract/protocol error.
 _FAILURE_STATUSES = frozenset(
     {
-        http.HTTPStatus.TOO_MANY_REQUESTS,
-        http.HTTPStatus.INTERNAL_SERVER_ERROR,
-        http.HTTPStatus.BAD_GATEWAY,
-        http.HTTPStatus.SERVICE_UNAVAILABLE,
-        http.HTTPStatus.GATEWAY_TIMEOUT,
+        http.HTTPStatus.TOO_MANY_REQUESTS,  # 429
+        http.HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
+        http.HTTPStatus.BAD_GATEWAY,  # 502
+        http.HTTPStatus.SERVICE_UNAVAILABLE,  # 503
+        http.HTTPStatus.GATEWAY_TIMEOUT,  # 504
     }
 )
 
 
 class HttpStatusClassifier:
-    """Count transport exceptions and unhealthy-status responses as failures.
+    """Counts transport exceptions and unhealthy-status responses as failures.
+
+    A returned response is a failure when its status is in ``failure_statuses``
+    — by default the canonical retryable set (``429, 500, 502, 503, 504``);
+    any raised exception is a failure. Other responses — including ``4xx``
+    client mistakes like ``404`` — are successes, so they never trip the
+    breaker.
 
     Args:
         failure_statuses: Statuses to count as failures instead of the
-            canonical set ``429, 500, 502, 503, 504``.
+            canonical set.
     """
 
     def __init__(self, *, failure_statuses: Iterable[int] | None = None) -> None:

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -23,7 +23,8 @@ a custom ``classifier`` to change that policy.
 import http
 from collections.abc import Iterable
 from contextlib import AsyncExitStack, ExitStack
-from typing import cast
+from types import TracebackType
+from typing import Self, cast
 
 from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
 
@@ -158,6 +159,22 @@ class CircuitBreakerTransport(BaseTransport):
         guarded = breaker(self._transport.handle_request)
         return guarded(request)
 
+    def __enter__(self) -> Self:
+        """Enter the wrapped transport's context and return this wrapper."""
+        self._transport.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        """Exit the wrapped transport's context and release every breaker."""
+        with ExitStack() as stack:
+            stack.callback(self._registry.close_all)
+            self._transport.__exit__(exc_type, exc_value, traceback)
+
     def close(self) -> None:
         """Release the wrapped transport and every per-host breaker."""
         with ExitStack() as stack:
@@ -216,6 +233,22 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         breaker = self._registry.get(_host(request))
         guarded = breaker(self._transport.handle_async_request)
         return await guarded(request)
+
+    async def __aenter__(self) -> Self:
+        """Enter the wrapped transport's context and return this wrapper."""
+        await self._transport.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        """Exit the wrapped transport's context and release every breaker."""
+        async with AsyncExitStack() as stack:
+            stack.push_async_callback(self._registry.aclose_all)
+            await self._transport.__aexit__(exc_type, exc_value, traceback)
 
     async def aclose(self) -> None:
         """Release the wrapped transport and every per-host breaker."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = []
 
 [project.optional-dependencies]
 otel = ["opentelemetry-api>=1.43.0"]
+httpx = ["httpx>=0.27.0"]
 httpx2 = ["httpx2>=2.4.0"]
 fastapi = ["fastapi>=0.128.0"]
 redis = ["redis>=5.0.0"]
@@ -242,6 +243,8 @@ pytest_add_cli_args_test_selection = [
   "--ignore=tests/test_examples.py",
   "--ignore=tests/test_aiohttp.py",
   "--ignore=tests/test_fastapi.py",
+  "--ignore=tests/test_httpx.py",
+  "--ignore=tests/test_httpx_e2e.py",
   "--ignore=tests/test_httpx2.py",
   "--ignore=tests/test_httpx2_e2e.py",
   "--ignore=tests/test_litestar.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ ban-relative-imports = "all"
 "interlock/registry.py" = [
   "PLR0913", # the registry takes keyword-only defaults shared by every lazy breaker
 ]
+"interlock/integrations/httpx.py" = [
+  "PLR0913", # transports take the wrapped transport plus keyword-only breaker collaborators
+]
 "interlock/integrations/httpx2.py" = [
   "PLR0913", # transports take the wrapped transport plus keyword-only breaker collaborators
 ]

--- a/scripts/build_llms_full.py
+++ b/scripts/build_llms_full.py
@@ -33,6 +33,7 @@ _PAGES = (
     'integrations/fastapi.md',
     'integrations/litestar.md',
     'integrations/httpx2.md',
+    'integrations/httpx.md',
     'integrations/aiohttp.md',
     'integrations/requests.md',
     'integrations/llm.md',

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,10 +1,13 @@
 from collections.abc import AsyncIterator, Callable, Iterator
+from types import TracebackType
+from typing import Self
 
 import httpx
 import pytest
-from tests.conftest import FakeClock
+from pytest_mock import MockerFixture
+from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitOpenError, Config
+from interlock import CircuitOpenError, Config, Outcome, State
 from interlock.integrations.httpx import (
     AsyncCircuitBreakerTransport,
     CircuitBreakerTransport,
@@ -52,6 +55,56 @@ class _AsyncStub(httpx.AsyncBaseTransport):
         self.closed = True
 
 
+class _SyncLifecycleStub(_SyncStub):
+    def __init__(self) -> None:
+        super().__init__(self._handle)
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self) -> Self:
+        self.entered = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        self.exited = True
+        super().__exit__(exc_type, exc_value, traceback)
+
+    def _handle(self, _request: httpx.Request) -> httpx.Response:
+        if not self.entered:
+            raise RuntimeError('transport was not entered')
+        return httpx.Response(200)
+
+
+class _AsyncLifecycleStub(_AsyncStub):
+    def __init__(self) -> None:
+        super().__init__(self._handle)
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> Self:
+        self.entered = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        self.exited = True
+        await super().__aexit__(exc_type, exc_value, traceback)
+
+    def _handle(self, _request: httpx.Request) -> httpx.Response:
+        if not self.entered:
+            raise RuntimeError('transport was not entered')
+        return httpx.Response(200)
+
+
 def _request(url: str = 'https://api.example.com/v1') -> httpx.Request:
     return httpx.Request('GET', url)
 
@@ -91,6 +144,19 @@ def test__sync_transport__success_response__passes_through(fake_clock: FakeClock
     response = transport.handle_request(_request())
 
     assert response.status_code == 200
+
+
+def test__sync_transport__context_manager__delegates_wrapped_lifecycle() -> None:
+    inner = _SyncLifecycleStub()
+    transport = CircuitBreakerTransport(inner)
+
+    with transport as entered:
+        response = entered.handle_request(_request())
+
+    assert entered is transport
+    assert response.status_code == 200
+    assert inner.exited
+    assert inner.closed
 
 
 def test__sync_transport__streaming_response__preserves_stream(fake_clock: FakeClock) -> None:
@@ -183,13 +249,55 @@ def test__sync_transport__url_without_host__raises_value_error(fake_clock: FakeC
     assert inner.calls == 0
 
 
-def test__sync_transport__close__delegates_to_wrapped() -> None:
+def test__sync_transport__close__releases_wrapped_transport_and_registry(
+    mocker: MockerFixture,
+) -> None:
     inner = _SyncStub(lambda _request: httpx.Response(200))
     transport = CircuitBreakerTransport(inner)
+    close_all = mocker.spy(transport.registry, 'close_all')
 
     transport.close()
 
     assert inner.closed
+    close_all.assert_called_once_with()
+
+
+def test__sync_transport__wrapped_close_raises__still_releases_registry(
+    mocker: MockerFixture,
+) -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(200))
+    transport = CircuitBreakerTransport(inner)
+    mocker.patch.object(inner, 'close', side_effect=RuntimeError('close failed'))
+    close_all = mocker.spy(transport.registry, 'close_all')
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        transport.close()
+
+    close_all.assert_called_once_with()
+
+
+def test__sync_transport__metrics_only_server_errors__records_without_rejecting(
+    fake_clock: FakeClock,
+    listener: RecordingListener,
+) -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(503))
+    transport = CircuitBreakerTransport(
+        inner,
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+        listener=listener,
+    )
+
+    for _ in range(5):
+        response = transport.handle_request(_request())
+        assert response.status_code == 503
+
+    breaker = transport.registry.get_existing('api.example.com')
+    assert breaker is not None
+    assert breaker.state is State.METRICS_ONLY
+    assert breaker.snapshot().failed_calls == 5
+    assert [outcome for outcome, _duration in listener.calls] == [Outcome.FAILURE] * 5
 
 
 @pytest.mark.asyncio
@@ -200,6 +308,20 @@ async def test__async_transport__success_response__passes_through(fake_clock: Fa
     response = await transport.handle_async_request(_request())
 
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test__async_transport__context_manager__delegates_wrapped_lifecycle() -> None:
+    inner = _AsyncLifecycleStub()
+    transport = AsyncCircuitBreakerTransport(inner)
+
+    async with transport as entered:
+        response = await entered.handle_async_request(_request())
+
+    assert entered is transport
+    assert response.status_code == 200
+    assert inner.exited
+    assert inner.closed
 
 
 @pytest.mark.asyncio
@@ -300,10 +422,74 @@ async def test__async_transport__url_without_host__raises_value_error(
 
 
 @pytest.mark.asyncio
-async def test__async_transport__aclose__delegates_to_wrapped() -> None:
+async def test__async_transport__aclose__releases_wrapped_transport_and_registry(
+    mocker: MockerFixture,
+) -> None:
     inner = _AsyncStub(lambda _request: httpx.Response(200))
     transport = AsyncCircuitBreakerTransport(inner)
+    aclose_all = mocker.spy(transport.registry, 'aclose_all')
 
     await transport.aclose()
 
     assert inner.closed
+    aclose_all.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test__async_transport__wrapped_aclose_raises__still_releases_registry(
+    mocker: MockerFixture,
+) -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(200))
+    transport = AsyncCircuitBreakerTransport(inner)
+    mocker.patch.object(inner, 'aclose', side_effect=RuntimeError('close failed'))
+    aclose_all = mocker.spy(transport.registry, 'aclose_all')
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        await transport.aclose()
+
+    aclose_all.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test__async_transport__metrics_only_transport_exception__propagates_and_records(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('down', request=request)
+
+    transport = AsyncCircuitBreakerTransport(
+        _AsyncStub(boom),
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+    )
+
+    with pytest.raises(httpx.ConnectError, match='down'):
+        await transport.handle_async_request(_request())
+
+    breaker = transport.registry.get_existing('api.example.com')
+    assert breaker is not None
+    assert breaker.state is State.METRICS_ONLY
+    assert breaker.snapshot().failed_calls == 1
+
+
+@pytest.mark.asyncio
+async def test__async_transport__metrics_only_new_hosts__all_start_in_shadow_mode(
+    fake_clock: FakeClock,
+) -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(503))
+    transport = AsyncCircuitBreakerTransport(
+        inner,
+        initial_state=State.METRICS_ONLY,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+    )
+
+    for host in ('api-a.example.com', 'api-b.example.com'):
+        for _ in range(3):
+            response = await transport.handle_async_request(_request(f'https://{host}/'))
+            assert response.status_code == 503
+
+        breaker = transport.registry.get_existing(host)
+        assert breaker is not None
+        assert breaker.state is State.METRICS_ONLY

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,0 +1,309 @@
+from collections.abc import AsyncIterator, Callable, Iterator
+
+import httpx
+import pytest
+from tests.conftest import FakeClock
+
+from interlock import CircuitOpenError, Config
+from interlock.integrations.httpx import (
+    AsyncCircuitBreakerTransport,
+    CircuitBreakerTransport,
+    HttpStatusClassifier,
+)
+
+_TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
+
+
+class _SyncStream(httpx.SyncByteStream):
+    def __iter__(self) -> Iterator[bytes]:
+        yield b'streamed'
+
+
+class _AsyncStream(httpx.AsyncByteStream):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield b'streamed'
+
+
+class _SyncStub(httpx.BaseTransport):
+    def __init__(self, handler: Callable[[httpx.Request], httpx.Response]) -> None:
+        self._handler = handler
+        self.calls = 0
+        self.closed = False
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        return self._handler(request)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _AsyncStub(httpx.AsyncBaseTransport):
+    def __init__(self, handler: Callable[[httpx.Request], httpx.Response]) -> None:
+        self._handler = handler
+        self.calls = 0
+        self.closed = False
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        return self._handler(request)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _request(url: str = 'https://api.example.com/v1') -> httpx.Request:
+    return httpx.Request('GET', url)
+
+
+def test__http_status_classifier__exception__is_failure() -> None:
+    classifier = HttpStatusClassifier()
+
+    assert classifier.is_failure(result=None, exception=httpx.ConnectError('boom'))
+
+
+@pytest.mark.parametrize('status', [429, 500, 502, 503, 504])
+def test__http_status_classifier__retryable_status__is_failure(status: int) -> None:
+    classifier = HttpStatusClassifier()
+
+    assert classifier.is_failure(result=httpx.Response(status), exception=None)
+
+
+@pytest.mark.parametrize('status', [200, 301, 400, 404, 418, 501, 505])
+def test__http_status_classifier__healthy_or_permanent_status__is_success(status: int) -> None:
+    classifier = HttpStatusClassifier()
+
+    assert not classifier.is_failure(result=httpx.Response(status), exception=None)
+
+
+def test__http_status_classifier__custom_statuses__override_default_set() -> None:
+    classifier = HttpStatusClassifier(failure_statuses={404, 408})
+
+    assert classifier.is_failure(result=httpx.Response(404), exception=None)
+    assert classifier.is_failure(result=httpx.Response(408), exception=None)
+    assert not classifier.is_failure(result=httpx.Response(500), exception=None)
+
+
+def test__sync_transport__success_response__passes_through(fake_clock: FakeClock) -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(200))
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    response = transport.handle_request(_request())
+
+    assert response.status_code == 200
+
+
+def test__sync_transport__streaming_response__preserves_stream(fake_clock: FakeClock) -> None:
+    response = httpx.Response(200, stream=_SyncStream())
+    inner = _SyncStub(lambda _request: response)
+    transport = CircuitBreakerTransport(inner, clock=fake_clock)
+
+    returned = transport.handle_request(_request())
+
+    assert returned is response
+    assert b''.join(returned.iter_raw()) == b'streamed'
+
+
+def test__sync_transport__server_errors__open_breaker_for_host(fake_clock: FakeClock) -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(503))
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    transport.handle_request(_request())
+    transport.handle_request(_request())
+
+    with pytest.raises(CircuitOpenError):
+        transport.handle_request(_request())
+    assert inner.calls == 2
+
+
+def test__sync_transport__transport_exception__opens_breaker(fake_clock: FakeClock) -> None:
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('down', request=request)
+
+    inner = _SyncStub(boom)
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    for _ in range(2):
+        with pytest.raises(httpx.ConnectError):
+            transport.handle_request(_request())
+
+    with pytest.raises(CircuitOpenError):
+        transport.handle_request(_request())
+
+
+def test__sync_transport__client_errors__never_open(fake_clock: FakeClock) -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(404))
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    for _ in range(10):
+        assert transport.handle_request(_request()).status_code == 404
+
+
+def test__sync_transport__custom_classifier__uses_configured_statuses(
+    fake_clock: FakeClock,
+) -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(404))
+    classifier = HttpStatusClassifier(failure_statuses={404})
+    transport = CircuitBreakerTransport(
+        inner,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+        classifier=classifier,
+    )
+
+    transport.handle_request(_request())
+    transport.handle_request(_request())
+
+    with pytest.raises(CircuitOpenError):
+        transport.handle_request(_request())
+
+
+def test__sync_transport__breakers_isolated_per_host(fake_clock: FakeClock) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503) if request.url.host == 'bad.example.com' else httpx.Response(200)
+
+    inner = _SyncStub(handler)
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    transport.handle_request(_request('https://bad.example.com/'))
+    transport.handle_request(_request('https://bad.example.com/'))
+
+    with pytest.raises(CircuitOpenError):
+        transport.handle_request(_request('https://bad.example.com/'))
+    assert transport.handle_request(_request('https://good.example.com/')).status_code == 200
+
+
+def test__sync_transport__url_without_host__raises_value_error(fake_clock: FakeClock) -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(200))
+    transport = CircuitBreakerTransport(inner, clock=fake_clock)
+
+    with pytest.raises(ValueError, match='no host'):
+        transport.handle_request(_request('/relative/path'))
+
+    assert inner.calls == 0
+
+
+def test__sync_transport__close__delegates_to_wrapped() -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(200))
+    transport = CircuitBreakerTransport(inner)
+
+    transport.close()
+
+    assert inner.closed
+
+
+@pytest.mark.asyncio
+async def test__async_transport__success_response__passes_through(fake_clock: FakeClock) -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(200))
+    transport = AsyncCircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    response = await transport.handle_async_request(_request())
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test__async_transport__streaming_response__preserves_stream(
+    fake_clock: FakeClock,
+) -> None:
+    response = httpx.Response(200, stream=_AsyncStream())
+    inner = _AsyncStub(lambda _request: response)
+    transport = AsyncCircuitBreakerTransport(inner, clock=fake_clock)
+
+    returned = await transport.handle_async_request(_request())
+
+    assert returned is response
+    assert b''.join([chunk async for chunk in returned.aiter_raw()]) == b'streamed'
+
+
+@pytest.mark.asyncio
+async def test__async_transport__server_errors__open_breaker_for_host(
+    fake_clock: FakeClock,
+) -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(500))
+    transport = AsyncCircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    await transport.handle_async_request(_request())
+    await transport.handle_async_request(_request())
+
+    with pytest.raises(CircuitOpenError):
+        await transport.handle_async_request(_request())
+    assert inner.calls == 2
+
+
+@pytest.mark.asyncio
+async def test__async_transport__transport_exception__opens_breaker(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError('down', request=request)
+
+    inner = _AsyncStub(boom)
+    transport = AsyncCircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    for _ in range(2):
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(_request())
+
+    with pytest.raises(CircuitOpenError):
+        await transport.handle_async_request(_request())
+
+
+@pytest.mark.asyncio
+async def test__async_transport__custom_classifier__uses_configured_statuses(
+    fake_clock: FakeClock,
+) -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(404))
+    classifier = HttpStatusClassifier(failure_statuses={404})
+    transport = AsyncCircuitBreakerTransport(
+        inner,
+        config=_TRIP_FAST,
+        clock=fake_clock,
+        classifier=classifier,
+    )
+
+    await transport.handle_async_request(_request())
+    await transport.handle_async_request(_request())
+
+    with pytest.raises(CircuitOpenError):
+        await transport.handle_async_request(_request())
+
+
+@pytest.mark.asyncio
+async def test__async_transport__breakers_isolated_per_host(fake_clock: FakeClock) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503) if request.url.host == 'bad.example.com' else httpx.Response(200)
+
+    inner = _AsyncStub(handler)
+    transport = AsyncCircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    await transport.handle_async_request(_request('https://bad.example.com/'))
+    await transport.handle_async_request(_request('https://bad.example.com/'))
+
+    with pytest.raises(CircuitOpenError):
+        await transport.handle_async_request(_request('https://bad.example.com/'))
+    response = await transport.handle_async_request(_request('https://good.example.com/'))
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test__async_transport__url_without_host__raises_value_error(
+    fake_clock: FakeClock,
+) -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(200))
+    transport = AsyncCircuitBreakerTransport(inner, clock=fake_clock)
+
+    with pytest.raises(ValueError, match='no host'):
+        await transport.handle_async_request(_request('/relative/path'))
+
+    assert inner.calls == 0
+
+
+@pytest.mark.asyncio
+async def test__async_transport__aclose__delegates_to_wrapped() -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(200))
+    transport = AsyncCircuitBreakerTransport(inner)
+
+    await transport.aclose()
+
+    assert inner.closed

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -1,4 +1,6 @@
 from collections.abc import Callable
+from types import TracebackType
+from typing import Self
 
 import httpx2
 import pytest
@@ -44,6 +46,56 @@ class _AsyncStub(AsyncBaseTransport):
         self.closed = True
 
 
+class _SyncLifecycleStub(_SyncStub):
+    def __init__(self) -> None:
+        super().__init__(self._handle)
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self) -> Self:
+        self.entered = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        self.exited = True
+        super().__exit__(exc_type, exc_value, traceback)
+
+    def _handle(self, _request: Request) -> Response:
+        if not self.entered:
+            raise RuntimeError('transport was not entered')
+        return Response(200)
+
+
+class _AsyncLifecycleStub(_AsyncStub):
+    def __init__(self) -> None:
+        super().__init__(self._handle)
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> Self:
+        self.entered = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: TracebackType | None = None,
+    ) -> None:
+        self.exited = True
+        await super().__aexit__(exc_type, exc_value, traceback)
+
+    def _handle(self, _request: Request) -> Response:
+        if not self.entered:
+            raise RuntimeError('transport was not entered')
+        return Response(200)
+
+
 def _request(url: str = 'https://api.example.com/v1') -> Request:
     return Request('GET', url)
 
@@ -75,6 +127,19 @@ def test__sync_transport__success_response__passes_through(fake_clock: FakeClock
     response = transport.handle_request(_request())
 
     assert response.status_code == 200
+
+
+def test__sync_transport__context_manager__delegates_wrapped_lifecycle() -> None:
+    inner = _SyncLifecycleStub()
+    transport = CircuitBreakerTransport(inner)
+
+    with transport as entered:
+        response = entered.handle_request(_request())
+
+    assert entered is transport
+    assert response.status_code == 200
+    assert inner.exited
+    assert inner.closed
 
 
 def test__sync_transport__server_errors__open_breaker_for_host(fake_clock: FakeClock) -> None:
@@ -162,6 +227,20 @@ async def test__async_transport__success_response__passes_through(fake_clock: Fa
     response = await transport.handle_async_request(_request())
 
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test__async_transport__context_manager__delegates_wrapped_lifecycle() -> None:
+    inner = _AsyncLifecycleStub()
+    transport = AsyncCircuitBreakerTransport(inner)
+
+    async with transport as entered:
+        response = await entered.handle_async_request(_request())
+
+    assert entered is transport
+    assert response.status_code == 200
+    assert inner.exited
+    assert inner.closed
 
 
 @pytest.mark.asyncio

--- a/tests/test_httpx_e2e.py
+++ b/tests/test_httpx_e2e.py
@@ -1,0 +1,163 @@
+"""Loopback tests for the httpx transport integration."""
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+from tests.conftest import FakeClock, Upstream, closed_port
+
+from interlock import CircuitOpenError, Config
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport, CircuitBreakerTransport
+
+_TRIP_FAST = Config(
+    minimum_number_of_calls=2,
+    failure_rate_threshold=0.5,
+    permitted_calls_in_half_open=1,
+)
+_PAST_OPEN_WAIT = 61.0
+
+
+def _sync_client(fake_clock: FakeClock) -> httpx.Client:
+    transport = CircuitBreakerTransport(httpx.HTTPTransport(), config=_TRIP_FAST, clock=fake_clock)
+    return httpx.Client(transport=transport)
+
+
+def _async_client(fake_clock: FakeClock) -> httpx.AsyncClient:
+    transport = AsyncCircuitBreakerTransport(
+        httpx.AsyncHTTPTransport(), config=_TRIP_FAST, clock=fake_clock
+    )
+    return httpx.AsyncClient(transport=transport)
+
+
+def test__httpx_e2e_sync__healthy_upstream__passes_response_through(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    backend = Upstream(status=200, body=b'pong')
+
+    with _sync_client(fake_clock) as client:
+        response = client.get(serve(backend))
+
+    assert response.status_code == 200
+    assert response.text == 'pong'
+    assert backend.received == 1
+
+
+def test__httpx_e2e_sync__upstream_5xx_for_a_period__opens_then_recovers(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    backend = Upstream(status=503)
+    url = serve(backend)
+
+    with _sync_client(fake_clock) as client:
+        assert client.get(url).status_code == 503
+        assert client.get(url).status_code == 503
+
+        with pytest.raises(CircuitOpenError) as rejected:
+            client.get(url)
+        assert backend.received == 2
+        assert rejected.value.breaker_name == '127.0.0.1'
+        assert rejected.value.retry_after == 60.0
+
+        backend.status = 200
+        fake_clock.advance(_PAST_OPEN_WAIT)
+        assert client.get(url).status_code == 200
+        assert client.get(url).status_code == 200
+
+    assert backend.received == 4
+
+
+def test__httpx_e2e_sync__probe_still_failing__reopens(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    backend = Upstream(status=503)
+    url = serve(backend)
+
+    with _sync_client(fake_clock) as client:
+        client.get(url)
+        client.get(url)
+        fake_clock.advance(_PAST_OPEN_WAIT)
+        assert client.get(url).status_code == 503
+
+        with pytest.raises(CircuitOpenError):
+            client.get(url)
+
+    assert backend.received == 3
+
+
+def test__httpx_e2e_sync__connection_refused__opens_breaker(fake_clock: FakeClock) -> None:
+    url = f'http://127.0.0.1:{closed_port()}/'
+
+    with _sync_client(fake_clock) as client:
+        for _ in range(2):
+            with pytest.raises(httpx.ConnectError):
+                client.get(url)
+
+        with pytest.raises(CircuitOpenError) as rejected:
+            client.get(url)
+        assert isinstance(rejected.value.last_failure, httpx.ConnectError)
+
+
+def test__httpx_e2e_sync__breakers_isolated_per_host(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    bad = Upstream(status=503)
+    good = Upstream(status=200)
+    bad_url = serve(bad, url_host='127.0.0.1')
+    good_url = serve(good, url_host='localhost')
+
+    with _sync_client(fake_clock) as client:
+        client.get(bad_url)
+        client.get(bad_url)
+        with pytest.raises(CircuitOpenError):
+            client.get(bad_url)
+
+        assert client.get(good_url).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test__httpx_e2e_async__healthy_upstream__passes_response_through(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    backend = Upstream(status=200, body=b'pong')
+
+    async with _async_client(fake_clock) as client:
+        response = await client.get(serve(backend))
+
+    assert response.status_code == 200
+    assert response.text == 'pong'
+    assert backend.received == 1
+
+
+@pytest.mark.asyncio
+async def test__httpx_e2e_async__upstream_5xx_for_a_period__opens_then_recovers(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    backend = Upstream(status=503)
+    url = serve(backend)
+
+    async with _async_client(fake_clock) as client:
+        assert (await client.get(url)).status_code == 503
+        assert (await client.get(url)).status_code == 503
+
+        with pytest.raises(CircuitOpenError):
+            await client.get(url)
+        assert backend.received == 2
+
+        backend.status = 200
+        fake_clock.advance(_PAST_OPEN_WAIT)
+        assert (await client.get(url)).status_code == 200
+
+    assert backend.received == 3
+
+
+@pytest.mark.asyncio
+async def test__httpx_e2e_async__connection_refused__opens_breaker(fake_clock: FakeClock) -> None:
+    url = f'http://127.0.0.1:{closed_port()}/'
+
+    async with _async_client(fake_clock) as client:
+        for _ in range(2):
+            with pytest.raises(httpx.ConnectError):
+                await client.get(url)
+
+        with pytest.raises(CircuitOpenError):
+            await client.get(url)

--- a/uv.lock
+++ b/uv.lock
@@ -944,6 +944,9 @@ aiohttp = [
 fastapi = [
     { name = "fastapi" },
 ]
+httpx = [
+    { name = "httpx" },
+]
 httpx2 = [
     { name = "httpx2" },
 ]
@@ -1002,6 +1005,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.12.0" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.128.0" },
+    { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.27.0" },
     { name = "httpx2", marker = "extra == 'httpx2'", specifier = ">=2.4.0" },
     { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.23.0" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.43.0" },
@@ -1009,7 +1013,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'requests'", specifier = ">=2.31.0" },
     { name = "tenacity", marker = "extra == 'tenacity'", specifier = ">=9.0.0" },
 ]
-provides-extras = ["aiohttp", "fastapi", "httpx2", "litestar", "otel", "redis", "requests", "tenacity"]
+provides-extras = ["aiohttp", "fastapi", "httpx", "httpx2", "litestar", "otel", "redis", "requests", "tenacity"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,7 +14,7 @@ nav = [
     { "Migration" = "migration.md" },
     { "Correctness and testing" = "correctness.md" },
     { "Guides" = ["guides/configuration.md", "guides/states.md", "guides/failure-classification.md", "guides/observability.md", "guides/timeout.md", "guides/retries.md", "guides/pipeline.md"] },
-    { "Integrations" = ["integrations/index.md", "integrations/fastapi.md", "integrations/litestar.md", "integrations/httpx2.md", "integrations/aiohttp.md", "integrations/requests.md", "integrations/llm.md", "integrations/tenacity.md", "integrations/redis.md", "integrations/frameworks.md"] },
+    { "Integrations" = ["integrations/index.md", "integrations/fastapi.md", "integrations/litestar.md", "integrations/httpx2.md", "integrations/httpx.md", "integrations/aiohttp.md", "integrations/requests.md", "integrations/llm.md", "integrations/tenacity.md", "integrations/redis.md", "integrations/frameworks.md"] },
     { "Reference" = ["reference.md"] },
 ]
 


### PR DESCRIPTION
## Summary

Adds first-class sync and async transport wrappers for classic httpx, with one circuit breaker per request host and configurable HTTP status classification.

The integration preserves streaming responses, delegates the wrapped transport's full lifecycle (context entry/exit and `close()` / `aclose()`), rejects host-less URLs before I/O, and keeps the core dependency-free behind the `httpx` optional extra. It includes unit and loopback coverage, minimum-version CI coverage, and updates the integration, API, LLM SDK, comparison, and generated documentation.

## Also in this PR

- **Fix (httpx2):** the httpx2 transports now delegate context-manager entry/exit to the wrapped transport — previously `with client:` never entered it, so custom transports acquiring resources in `__enter__` / `__aenter__` were not ready before their first request. Exit also releases every per-host breaker.
- **AGENTS.md:** the `[httpx]` extra joins the extras list; two code examples that used non-existent API (`failure_threshold` / `reset_timeout`, `CountBasedWindow(clock=...)`) are rewritten against the real `Config` and `CountBasedSlidingWindow` surface.
- The two-line root `CLAUDE.md` (`@AGENTS.md` import) is now committed — deliberate, so agent tooling picks up the project guide out of the box.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #82
