### PR TITLE
fix: lower the accidental opentelemetry-api floor in the otel extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           'httpx2==2.4.0'
           'fastapi==0.128.0'
           'redis==5.0.0'
-          'opentelemetry-api==1.43.0'
+          'opentelemetry-api==1.20.0'
           'tenacity==9.0.0'
           'requests==2.31.0'
           'aiohttp==3.12.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   threads one at a time, so the number is lock-path work, not wall-clock
   contention.
 
+### Changed
+
+- **Lowered the `otel` extra's floor from `opentelemetry-api>=1.43.0` back to
+  `>=1.20.0`.** The higher floor was never a requirement of `OTelEventListener`
+  — it arrived as a side effect of a routine Dependabot bump that moved the dev
+  pin and the extra's floor together. `opentelemetry-distro`/SDK releases pin
+  the whole OTel stack to one API version, so the stale floor forced adopters
+  on an older distro to choose between upgrading their entire OTel stack and
+  dropping `interlock-cb[otel]` — for a listener whose calls
+  (`get_meter`, `create_histogram`, `create_counter`) have been stable across
+  that range. `.github/workflows/ci.yml`'s `extras-min` job now pins and tests
+  against `opentelemetry-api==1.20.0`; the dev dependency group stays on the
+  current version.
+
 ## [2.4.0] - 2026-08-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,13 @@ the wall-clock cost of real contention.
 - **Keep the core dependency-free.** Anything external belongs in an extra
   (e.g. `interlock-cb[httpx2]`, `interlock-cb[tenacity]`, `interlock-cb[redis]`),
   imported lazily.
+- **An extra's floor is a compatibility statement, not a dev pin.** It says the
+  oldest host-library version the integration works on, and only an API the
+  code actually needs justifies raising it. A routine Dependabot bump lands on
+  the `dependency-groups.dev` pin (what we develop against) — never let it
+  carry the `[project.optional-dependencies]` floor along with it. Raising a
+  floor on purpose means updating the matching pin in the `extras-min` job in
+  `.github/workflows/ci.yml` too.
 - **Conventional commits.** Use `feat:`, `fix:`, `docs:`, `refactor:`, `test:`,
   `chore:`, `perf:`, `ci:` prefixes.
 - **Update the docs and CHANGELOG.** User-facing changes update the relevant

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -96,6 +96,10 @@ explicitly, so the core stays dependency-free:
 uv add 'interlock-cb[otel]'
 ```
 
+Supports `opentelemetry-api>=1.20.0` — the listener only calls
+`get_meter`/`create_histogram`/`create_counter`, stable across any
+`opentelemetry-distro`/SDK release from that version on.
+
 ```python
 from interlock import CircuitBreaker
 from interlock.integrations.otel import OTelEventListener

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1868,6 +1868,10 @@ explicitly, so the core stays dependency-free:
 uv add 'interlock-cb[otel]'
 ```
 
+Supports `opentelemetry-api>=1.20.0` — the listener only calls
+`get_meter`/`create_histogram`/`create_counter`, stable across any
+`opentelemetry-distro`/SDK release from that version on.
+
 ```python
 from interlock import CircuitBreaker
 from interlock.integrations.otel import OTelEventListener

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-otel = ["opentelemetry-api>=1.43.0"]
+otel = ["opentelemetry-api>=1.20.0"]
 httpx = ["httpx>=0.27.0"]
 httpx2 = ["httpx2>=2.4.0"]
 fastapi = ["fastapi>=0.128.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1008,7 +1008,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.27.0" },
     { name = "httpx2", marker = "extra == 'httpx2'", specifier = ">=2.4.0" },
     { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.23.0" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.43.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "requests", marker = "extra == 'requests'", specifier = ">=2.31.0" },
     { name = "tenacity", marker = "extra == 'tenacity'", specifier = ">=9.0.0" },


### PR DESCRIPTION
## Summary

`pyproject.toml` declared `otel = ["opentelemetry-api>=1.43.0"]`. That floor
was never a requirement of the code: it arrived as a side effect of a routine
dependency bump (3d664ad, #7) that moved the dev pin, the extra's lower bound
and the `extras-min` CI pin together. Git history shows the extra's floor was
originally `>=1.20.0` at introduction — the bump silently raised a
compatibility statement while only intending to bump what we develop against.

`OTelEventListener` only calls `metrics.get_meter`, `Meter.create_histogram`
and `Meter.create_counter`, API that has been stable for years. Verified
locally: `tests/test_otel.py` passes unchanged against
`opentelemetry-api==1.20.0`.

The cost to adopters was real: `opentelemetry-distro`/SDK releases pin the
whole OTel stack to one API version, so the stale floor forced anyone on an
older distro to choose between upgrading their entire OTel stack and dropping
`interlock-cb[otel]` — for a listener that would have worked fine.

## Changes

- Lower the `otel` extra floor back to `opentelemetry-api>=1.20.0` and pin
  `.github/workflows/ci.yml`'s `extras-min` job to the same version, so CI
  proves it on 3.11.
- Keep the `dependency-groups.dev` pin at the current version — development
  continues against the latest.
- Document the rule in `CONTRIBUTING.md`: an extra's floor is a compatibility
  statement, not a dev pin, and a routine bump must never carry both together.
- `CHANGELOG.md` entry under `[Unreleased]` → `Changed`.

## Extras floor audit

Checked git history for every other extra (`httpx`, `httpx2`, `fastapi`,
`redis`, `litestar`, `tenacity`, `requests`, `aiohttp`): each floor was set
once at introduction (in the PR that added the integration) and has never
been touched by a routine bump commit. None of them are equally accidental.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — n/a, no library
      code changed; `tests/test_otel.py` verified against the new floor
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass — n/a,
      no Python source changed
- [x] Docs updated (`docs/`) for user-facing changes — n/a, no `docs/` page
      references the version number
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changed

- Lower the `otel` extra compatibility floor to `opentelemetry-api>=1.20.0`.
- Test `opentelemetry-api==1.20.0` in `extras-min` while retaining the current development pin.
- Document compatibility floors and development pins in `CONTRIBUTING.md`.
- Audit other extras and confirm that their floors are intentional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->