### PR TITLE
feat: allow type-safe partial event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Partial `EventListener` implementations now pass strict type checking.** A
+  listener that only needs one hook previously had to stub all ten before mypy,
+  pyright and pyrefly would accept it, despite runtime dispatch already treating
+  every hook as optional. `EventListener` now provides inherited no-op hooks, so
+  subclasses override only what they observe and remain compatible when later
+  releases add hooks; structurally complete listeners continue to work without
+  inheritance.
+
 - **Direct-call baseline and threaded-contention benchmarks**, closing out the
   two gaps left in #84. The CodSpeed suite reported the absolute cost of every
   protected path but not the number a prospective user actually wants — the

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -24,9 +24,10 @@ returns, so a slow listener never serialises throughput.
 
 The three storage hooks fire only for breakers coordinated through a shared
 [storage](../integrations/redis.md); the three pipeline hooks fire from
-[pipeline strategies](pipeline.md) given a `listener=`. Every hook is
-dispatched only if present — a listener that defines just the ones it cares
-about keeps working.
+[pipeline strategies](pipeline.md) given a `listener=`. Every hook is dispatched
+only if present, and the protocol supplies no-op implementations for subclasses.
+A listener can therefore override just the hooks it cares about and keeps
+working when a later interlock version adds a new hook.
 
 ## Listener failures are isolated
 
@@ -119,11 +120,15 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 
 ## Custom listeners
 
-Any object with the hooks you care about satisfies the protocol — no base class
-to inherit, and no need to stub out the rest:
+For a partial listener that strict type checkers can verify, inherit
+`EventListener` and override only the hooks you need. Every inherited hook is a
+no-op:
 
 ```python
-class RejectionCounter:
+from interlock import EventListener
+
+
+class RejectionCounter(EventListener):
     def __init__(self) -> None:
         self.rejected = 0
 
@@ -131,5 +136,7 @@ class RejectionCounter:
         self.rejected += 1
 ```
 
-Implement the full protocol when you want static checking to catch a typo in a
-hook name; a misspelled hook is simply never called, since dispatch is by name.
+Inheritance is optional for a listener that implements the complete protocol:
+structural typing continues to accept it. At runtime, dispatch is still by name
+and skips any missing hook, including on older listener objects that do not
+inherit `EventListener`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1796,9 +1796,10 @@ returns, so a slow listener never serialises throughput.
 
 The three storage hooks fire only for breakers coordinated through a shared
 [storage](../integrations/redis.md); the three pipeline hooks fire from
-[pipeline strategies](pipeline.md) given a `listener=`. Every hook is
-dispatched only if present — a listener that defines just the ones it cares
-about keeps working.
+[pipeline strategies](pipeline.md) given a `listener=`. Every hook is dispatched
+only if present, and the protocol supplies no-op implementations for subclasses.
+A listener can therefore override just the hooks it cares about and keeps
+working when a later interlock version adds a new hook.
 
 ## Listener failures are isolated
 
@@ -1891,11 +1892,15 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 
 ## Custom listeners
 
-Any object with the hooks you care about satisfies the protocol — no base class
-to inherit, and no need to stub out the rest:
+For a partial listener that strict type checkers can verify, inherit
+`EventListener` and override only the hooks you need. Every inherited hook is a
+no-op:
 
 ```python
-class RejectionCounter:
+from interlock import EventListener
+
+
+class RejectionCounter(EventListener):
     def __init__(self) -> None:
         self.rejected = 0
 
@@ -1903,8 +1908,10 @@ class RejectionCounter:
         self.rejected += 1
 ```
 
-Implement the full protocol when you want static checking to catch a typo in a
-hook name; a misspelled hook is simply never called, since dispatch is by name.
+Inheritance is optional for a listener that implements the complete protocol:
+structural typing continues to accept it. At runtime, dispatch is still by name
+and skips any missing hook, including on older listener objects that do not
+inherit `EventListener`.
 
 ---
 

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -5,6 +5,9 @@ This keeps the state machine I/O-free and lets storage, windows, clocks,
 classification and observability be swapped without touching it.
 """
 
+# EventListener hooks are deliberately concrete no-ops; their parameters form the public contract.
+# ruff: noqa: ARG002, RET501
+
 from typing import Protocol, runtime_checkable
 
 from interlock.outcome import Outcome
@@ -193,24 +196,26 @@ class EventListener(Protocol):
 
     Every hook is dispatched by name and only if defined, so a listener may
     implement just the ones it needs and one written before a hook existed
-    keeps working unchanged. See ``docs/guides/observability.md``.
+    keeps working unchanged. Inherit this protocol to make a partial listener
+    type-check: its default hook implementations are no-ops. See the partial
+    listener pattern in ``docs/guides/observability.md``.
     """
 
     def on_state_change(self, *, name: str, old: State, new: State) -> None:
         """Called after the breaker transitions between states."""
-        ...
+        return None
 
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
         """Called after a protected call completes, success or failure."""
-        ...
+        return None
 
     def on_rejected(self, *, name: str) -> None:
         """Called when a call is rejected because the circuit is open."""
-        ...
+        return None
 
     def on_reset(self, *, name: str) -> None:
         """Called when the breaker is manually reset."""
-        ...
+        return None
 
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
         """Called when the shared storage backend becomes unavailable.
@@ -220,11 +225,11 @@ class EventListener(Protocol):
         only — a listener of your own that raises is logged, never reported
         here.
         """
-        ...
+        return None
 
     def on_storage_recovered(self, *, name: str) -> None:
         """Called when the shared storage backend becomes reachable again."""
-        ...
+        return None
 
     def on_storage_write_dropped(self, *, name: str) -> None:
         """Called when a coordinated write is dropped by a full write queue.
@@ -234,7 +239,7 @@ class EventListener(Protocol):
         keeps protecting the process locally. The shared state is reconciled
         by the next successful poll and by ``state_ttl``.
         """
-        ...
+        return None
 
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None:
         """Called by a pipeline retry layer before it sleeps between attempts.
@@ -242,12 +247,12 @@ class EventListener(Protocol):
         ``attempt`` is the number of the attempt that just failed; ``delay``
         is the upcoming backoff in seconds.
         """
-        ...
+        return None
 
     def on_bulkhead_rejected(self, *, name: str) -> None:
         """Called when a pipeline bulkhead rejects a call (no free slot)."""
-        ...
+        return None
 
     def on_fallback(self, *, name: str, error: BaseException) -> None:
         """Called when a pipeline fallback substitutes a value for ``error``."""
-        ...
+        return None

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -15,7 +15,7 @@ import pytest
 
 from conftest import ExplodingListener, FakeClock, RecordingListener
 from inmemory_storage import AsyncInMemoryStorage, InMemoryStorage
-from interlock import CircuitBreaker, CircuitOpenError, Config, State
+from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, State
 from interlock._coordination import (
     AsyncCoordinator,
     SyncCoordinator,
@@ -28,6 +28,38 @@ from interlock.shared import SharedState
 
 NAME = 'svc'
 WAIT = 5.0
+
+
+class _CallListener(EventListener):
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Outcome]] = []
+
+    def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
+        self.calls.append((name, outcome))
+
+
+class _RejectionListener(EventListener):
+    def __init__(self) -> None:
+        self.names: list[str] = []
+
+    def on_rejected(self, *, name: str) -> None:
+        self.names.append(name)
+
+
+def _notify_inherited_hooks(listener: EventListener) -> None:
+    hooks: tuple[tuple[str, dict[str, object]], ...] = (
+        ('on_state_change', {'old': State.CLOSED, 'new': State.OPEN}),
+        ('on_rejected', {}),
+        ('on_reset', {}),
+        ('on_storage_degraded', {'error': ValueError('storage')}),
+        ('on_storage_recovered', {}),
+        ('on_storage_write_dropped', {}),
+        ('on_retry', {'attempt': 1, 'delay': 0.1}),
+        ('on_bulkhead_rejected', {}),
+        ('on_fallback', {'error': ValueError('fallback')}),
+    )
+    for hook, kwargs in hooks:
+        notify(listener, hook, name=NAME, **kwargs)
 
 
 @pytest.fixture
@@ -85,6 +117,22 @@ def test__notify__listener_without_the_hook__skips_dispatch() -> None:
     pre_v2 = cast('EventListener', RecordingListener())
 
     notify(pre_v2, 'on_fallback', name=NAME, error=ValueError('x'))
+
+
+def test__partial_listeners__own_hooks_and_inherited_hooks__only_own_hooks_have_effect() -> None:
+    call_listener = _CallListener()
+    rejection_listener = _RejectionListener()
+    breaker = CircuitBreaker(name=NAME, listener=call_listener)
+    rejection_breaker = CircuitBreaker(name=NAME, listener=rejection_listener)
+
+    assert isinstance(call_listener, EventListener)
+    assert breaker.call(lambda: 'ok') == 'ok'
+    assert rejection_breaker.call(lambda: 'ok') == 'ok'
+    notify(rejection_listener, 'on_rejected', name=NAME)
+    _notify_inherited_hooks(call_listener)
+
+    assert call_listener.calls == [(NAME, Outcome.SUCCESS)]
+    assert rejection_listener.names == [NAME]
 
 
 def test__notify__raising_hook__is_logged_with_context(

--- a/tests/typing_surface.py
+++ b/tests/typing_surface.py
@@ -10,7 +10,34 @@ suite cannot observe it.
 
 from typing import assert_type
 
-from interlock import CircuitBreaker, Pipeline, Registry, State
+from interlock import (
+    BulkheadStrategy,
+    CircuitBreaker,
+    EventListener,
+    FallbackStrategy,
+    LoggingEventListener,
+    Outcome,
+    Pipeline,
+    Registry,
+    State,
+)
+from interlock.integrations.tenacity import RetryStrategy
+
+
+class _CallListener(EventListener):
+    def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
+        return None
+
+
+partial_listener = _CallListener()
+partial_breaker = CircuitBreaker(name='partial-listener', listener=partial_listener)
+partial_registry = Registry(listener=partial_listener)
+partial_bulkhead = BulkheadStrategy(1, listener=partial_listener)
+partial_fallback = FallbackStrategy(lambda _error: None, listener=partial_listener)
+partial_retry = RetryStrategy(listener=partial_listener)
+complete_listener_breaker = CircuitBreaker(
+    name='complete-listener', listener=LoggingEventListener()
+)
 
 breaker = CircuitBreaker(name='typing-surface')
 shadow_breaker = CircuitBreaker(name='shadow', initial_state=State.METRICS_ONLY)


### PR DESCRIPTION
## Summary

- make EventListener hooks inherited no-ops so partial subclasses pass strict type checking
- pin partial and complete listener compatibility across CircuitBreaker, Registry, and pipeline strategies
- document the type-safe partial-listener pattern and update the LLM documentation mirror

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] uv run ruff format --check and uv run ruff check pass
- [x] uv run mypy, uv run pyright and uv run pyrefly check pass
- [x] Docs updated (docs/) for user-facing changes
- [x] CHANGELOG.md [Unreleased] updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Added

- `EventListener` now provides no-op hooks for partial listener implementations.
- Partial listeners can override only the hooks they need while remaining type-checker compatible.
- Added documentation for partial listeners and structural listeners.

### Fixed

- Runtime dispatch skips undefined listener hooks.
- `CircuitBreaker`, `Registry`, and pipeline strategies support partial `EventListener` implementations.

### Changed

- Updated listener typing coverage and notification tests.
- Regenerated `docs/llms-full.txt`.
- Updated the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->