### PR TITLE
feat: share registries across transport integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   releases add hooks; structurally complete listeners continue to work without
   inheritance.
 
+- **Transport integrations can share a caller-owned `Registry` across
+  clients.** Previously each httpx2/httpx transport, aiohttp middleware, and
+  requests adapter built an isolated registry, so clients calling the same
+  host accumulated separate windows and could disagree about dependency
+  health. The new `registry=` option gives them one breaker per host and one
+  policy source, rejects conflicting construction options, and leaves teardown
+  to the registry's owner while still closing each wrapped connection pool.
+
 - **Direct-call baseline and threaded-contention benchmarks**, closing out the
   two gaps left in #84. The CodSpeed suite reported the absolute cost of every
   protected path but not the number a prospective user actually wants — the

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -51,6 +51,34 @@ The breaker observes the time to *response headers*; reading the body happens
 outside the guarded call — the same semantics as the
 [httpx2 transport](httpx2.md).
 
+## Share one registry across sessions
+
+Several middleware instances can share one caller-owned registry, so traffic
+to the same host contributes to one breaker and one sliding window:
+
+```python
+from interlock import Config, Registry
+from interlock.integrations.aiohttp import CircuitBreakerMiddleware, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+middleware_a = CircuitBreakerMiddleware(registry=registry)
+middleware_b = CircuitBreakerMiddleware(registry=registry)
+```
+
+Do not omit the classifier when HTTP statuses should affect the breaker. A
+bare `Registry` uses exception-only classification, so a returned `503` counts
+as a success. The registry owns `config`, `clock`, `initial_state`,
+`classifier`, and `listener`; passing any of them to the middleware together
+with `registry` raises `ValueError`.
+
+Calling `aclose()` on middleware that received a registry leaves that registry
+usable by other sessions. The application owns it and must call
+`await registry.aclose_all()` once during shutdown.
+
 ## Safe production rollout
 
 Pass `initial_state=State.METRICS_ONLY` to record real outcomes without

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -75,9 +75,9 @@ as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; passing any of them to the middleware together
 with `registry` raises `ValueError`.
 
-Calling `aclose()` on middleware that received a registry leaves that registry
-usable by other sessions. The application owns it and must call
-`await registry.aclose_all()` once during shutdown.
+Calling `aclose()` automatically closes the breakers only when the middleware
+owns the registry. An injected registry remains open until the application
+explicitly calls `await registry.aclose_all()` during shutdown.
 
 ## Safe production rollout
 

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -86,6 +86,43 @@ continues normally. An open breaker raises `CircuitOpenError` before the
 wrapped transport performs I/O. A request URL without a host raises
 `ValueError` for the same reason: there is no dependency identity to key on.
 
+## Share one registry across clients
+
+Inject one caller-owned `Registry` when several clients should observe the
+same dependency health. The transports then resolve the same host to the same
+breaker and contribute to one sliding window:
+
+```python
+import httpx
+
+from interlock import Config, Registry
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+client_a = httpx.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx.AsyncHTTPTransport(), registry=registry)
+)
+client_b = httpx.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx.AsyncHTTPTransport(), registry=registry)
+)
+```
+
+The classifier is intentional: a bare `Registry` classifies raised exceptions
+but treats returned responses, including `503`, as successes. Configure
+`HttpStatusClassifier` to retain the transport's default status policy. A
+supplied registry also owns `config`, `clock`, `initial_state`, `classifier`,
+and `listener`; combining `registry` with any of those transport options raises
+`ValueError` instead of silently ignoring one source of configuration.
+
+Closing a client closes its wrapped connection pool, not the injected
+registry. The application must call `await registry.aclose_all()` once during
+async shutdown, or `registry.close_all()` when every guarded client is
+synchronous.
+
 ## What counts as a failure
 
 The default `HttpStatusClassifier` counts these as failures:

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -118,10 +118,11 @@ supplied registry also owns `config`, `clock`, `initial_state`, `classifier`,
 and `listener`; combining `registry` with any of those transport options raises
 `ValueError` instead of silently ignoring one source of configuration.
 
-Closing a client closes its wrapped connection pool, not the injected
-registry. The application must call `await registry.aclose_all()` once during
-async shutdown, or `registry.close_all()` when every guarded client is
-synchronous.
+Closing a client automatically closes its breakers only when the transport
+owns the registry. An injected registry remains open while the wrapped
+connection pool closes; the application must explicitly call
+`await registry.aclose_all()` during async shutdown, or `registry.close_all()`
+when every guarded client is synchronous.
 
 ## What counts as a failure
 

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -123,10 +123,11 @@ status policy; otherwise a returned `503` counts as a success. The supplied
 registry owns `config`, `clock`, `initial_state`, `classifier`, and `listener`,
 so none of those options may also be passed to the transport.
 
-Closing either client still closes its wrapped connection pool but leaves the
-shared registry usable by the other client. The application owns the registry
-and must call `await registry.aclose_all()` once during async shutdown (or
-`registry.close_all()` when all guarded clients are synchronous).
+Closing a client automatically closes its breakers only when the transport
+owns the registry. An injected registry remains open while the wrapped
+connection pool closes; the application must explicitly call
+`await registry.aclose_all()` during async shutdown (or `registry.close_all()`
+when all guarded clients are synchronous).
 
 ## What counts as a failure
 

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -92,6 +92,42 @@ correct than global state — each host's health is observed independently.
 When a host's breaker is open, its requests raise `CircuitOpenError` before
 reaching the network.
 
+## Share one registry across clients
+
+Pass a caller-owned `Registry` when several clients reach the same dependency.
+Requests for the same host then use one breaker instance and one sliding
+window, even when they travel through different transports:
+
+```python
+import httpx2
+
+from interlock import Config, Registry
+from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+client_a = httpx2.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx2.AsyncHTTPTransport(), registry=registry)
+)
+client_b = httpx2.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx2.AsyncHTTPTransport(), registry=registry)
+)
+```
+
+`Registry` uses exception-only classification by default. Always configure
+`HttpStatusClassifier` as above when you want the integration's normal HTTP
+status policy; otherwise a returned `503` counts as a success. The supplied
+registry owns `config`, `clock`, `initial_state`, `classifier`, and `listener`,
+so none of those options may also be passed to the transport.
+
+Closing either client still closes its wrapped connection pool but leaves the
+shared registry usable by the other client. The application owns the registry
+and must call `await registry.aclose_all()` once during async shutdown (or
+`registry.close_all()` when all guarded clients are synchronous).
+
 ## What counts as a failure
 
 By default the transport uses `HttpStatusClassifier`:

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -77,9 +77,10 @@ as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; combining `registry` with any of those adapter
 options raises `ValueError`.
 
-Closing either session still releases its adapter's connection pools, but it
-does not close the injected registry. The application owns the registry and
-must call `registry.close_all()` once during shutdown.
+Closing a session automatically closes its breakers only when the adapter owns
+the registry. An injected registry remains open while its connection pools
+close; the application must explicitly call `registry.close_all()` during
+shutdown.
 
 ## Safe production rollout
 

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -48,6 +48,39 @@ created lazily and shared across requests. When a host's circuit is open the
 request raises [`CircuitOpenError`](../reference.md) *before* a connection is
 made.
 
+## Share one registry across sessions
+
+Inject a caller-owned `Registry` when independent sessions should use one
+breaker and one sliding window for the same host:
+
+```python
+import requests
+
+from interlock import Config, Registry
+from interlock.integrations.requests import CircuitBreakerAdapter, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+session_a = requests.Session()
+session_a.mount('https://', CircuitBreakerAdapter(registry=registry))
+
+session_b = requests.Session()
+session_b.mount('https://', CircuitBreakerAdapter(registry=registry))
+```
+
+The explicit classifier preserves the adapter's normal status policy. Without
+it, a bare `Registry` classifies exceptions only and a returned `503` counts
+as a success. The registry owns `config`, `clock`, `initial_state`,
+`classifier`, and `listener`; combining `registry` with any of those adapter
+options raises `ValueError`.
+
+Closing either session still releases its adapter's connection pools, but it
+does not close the injected registry. The application owns the registry and
+must call `registry.close_all()` once during shutdown.
+
 ## Safe production rollout
 
 Pass `initial_state=State.METRICS_ONLY` to record real outcomes without

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2808,10 +2808,11 @@ status policy; otherwise a returned `503` counts as a success. The supplied
 registry owns `config`, `clock`, `initial_state`, `classifier`, and `listener`,
 so none of those options may also be passed to the transport.
 
-Closing either client still closes its wrapped connection pool but leaves the
-shared registry usable by the other client. The application owns the registry
-and must call `await registry.aclose_all()` once during async shutdown (or
-`registry.close_all()` when all guarded clients are synchronous).
+Closing a client automatically closes its breakers only when the transport
+owns the registry. An injected registry remains open while the wrapped
+connection pool closes; the application must explicitly call
+`await registry.aclose_all()` during async shutdown (or `registry.close_all()`
+when all guarded clients are synchronous).
 
 ## What counts as a failure
 
@@ -2968,10 +2969,11 @@ supplied registry also owns `config`, `clock`, `initial_state`, `classifier`,
 and `listener`; combining `registry` with any of those transport options raises
 `ValueError` instead of silently ignoring one source of configuration.
 
-Closing a client closes its wrapped connection pool, not the injected
-registry. The application must call `await registry.aclose_all()` once during
-async shutdown, or `registry.close_all()` when every guarded client is
-synchronous.
+Closing a client automatically closes its breakers only when the transport
+owns the registry. An injected registry remains open while the wrapped
+connection pool closes; the application must explicitly call
+`await registry.aclose_all()` during async shutdown, or `registry.close_all()`
+when every guarded client is synchronous.
 
 ## What counts as a failure
 
@@ -3096,9 +3098,9 @@ as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; passing any of them to the middleware together
 with `registry` raises `ValueError`.
 
-Calling `aclose()` on middleware that received a registry leaves that registry
-usable by other sessions. The application owns it and must call
-`await registry.aclose_all()` once during shutdown.
+Calling `aclose()` automatically closes the breakers only when the middleware
+owns the registry. An injected registry remains open until the application
+explicitly calls `await registry.aclose_all()` during shutdown.
 
 ## Safe production rollout
 
@@ -3233,9 +3235,10 @@ as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; combining `registry` with any of those adapter
 options raises `ValueError`.
 
-Closing either session still releases its adapter's connection pools, but it
-does not close the injected registry. The application owns the registry and
-must call `registry.close_all()` once during shutdown.
+Closing a session automatically closes its breakers only when the adapter owns
+the registry. An injected registry remains open while its connection pools
+close; the application must explicitly call `registry.close_all()` during
+shutdown.
 
 ## Safe production rollout
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2777,6 +2777,42 @@ correct than global state — each host's health is observed independently.
 When a host's breaker is open, its requests raise `CircuitOpenError` before
 reaching the network.
 
+## Share one registry across clients
+
+Pass a caller-owned `Registry` when several clients reach the same dependency.
+Requests for the same host then use one breaker instance and one sliding
+window, even when they travel through different transports:
+
+```python
+import httpx2
+
+from interlock import Config, Registry
+from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+client_a = httpx2.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx2.AsyncHTTPTransport(), registry=registry)
+)
+client_b = httpx2.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx2.AsyncHTTPTransport(), registry=registry)
+)
+```
+
+`Registry` uses exception-only classification by default. Always configure
+`HttpStatusClassifier` as above when you want the integration's normal HTTP
+status policy; otherwise a returned `503` counts as a success. The supplied
+registry owns `config`, `clock`, `initial_state`, `classifier`, and `listener`,
+so none of those options may also be passed to the transport.
+
+Closing either client still closes its wrapped connection pool but leaves the
+shared registry usable by the other client. The application owns the registry
+and must call `await registry.aclose_all()` once during async shutdown (or
+`registry.close_all()` when all guarded clients are synchronous).
+
 ## What counts as a failure
 
 By default the transport uses `HttpStatusClassifier`:
@@ -2900,6 +2936,43 @@ continues normally. An open breaker raises `CircuitOpenError` before the
 wrapped transport performs I/O. A request URL without a host raises
 `ValueError` for the same reason: there is no dependency identity to key on.
 
+## Share one registry across clients
+
+Inject one caller-owned `Registry` when several clients should observe the
+same dependency health. The transports then resolve the same host to the same
+breaker and contribute to one sliding window:
+
+```python
+import httpx
+
+from interlock import Config, Registry
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+client_a = httpx.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx.AsyncHTTPTransport(), registry=registry)
+)
+client_b = httpx.AsyncClient(
+    transport=AsyncCircuitBreakerTransport(httpx.AsyncHTTPTransport(), registry=registry)
+)
+```
+
+The classifier is intentional: a bare `Registry` classifies raised exceptions
+but treats returned responses, including `503`, as successes. Configure
+`HttpStatusClassifier` to retain the transport's default status policy. A
+supplied registry also owns `config`, `clock`, `initial_state`, `classifier`,
+and `listener`; combining `registry` with any of those transport options raises
+`ValueError` instead of silently ignoring one source of configuration.
+
+Closing a client closes its wrapped connection pool, not the injected
+registry. The application must call `await registry.aclose_all()` once during
+async shutdown, or `registry.close_all()` when every guarded client is
+synchronous.
+
 ## What counts as a failure
 
 The default `HttpStatusClassifier` counts these as failures:
@@ -2998,6 +3071,34 @@ made.
 The breaker observes the time to *response headers*; reading the body happens
 outside the guarded call — the same semantics as the
 [httpx2 transport](httpx2.md).
+
+## Share one registry across sessions
+
+Several middleware instances can share one caller-owned registry, so traffic
+to the same host contributes to one breaker and one sliding window:
+
+```python
+from interlock import Config, Registry
+from interlock.integrations.aiohttp import CircuitBreakerMiddleware, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+middleware_a = CircuitBreakerMiddleware(registry=registry)
+middleware_b = CircuitBreakerMiddleware(registry=registry)
+```
+
+Do not omit the classifier when HTTP statuses should affect the breaker. A
+bare `Registry` uses exception-only classification, so a returned `503` counts
+as a success. The registry owns `config`, `clock`, `initial_state`,
+`classifier`, and `listener`; passing any of them to the middleware together
+with `registry` raises `ValueError`.
+
+Calling `aclose()` on middleware that received a registry leaves that registry
+usable by other sessions. The application owns it and must call
+`await registry.aclose_all()` once during shutdown.
 
 ## Safe production rollout
 
@@ -3102,6 +3203,39 @@ Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
 request raises [`CircuitOpenError`](../reference.md) *before* a connection is
 made.
+
+## Share one registry across sessions
+
+Inject a caller-owned `Registry` when independent sessions should use one
+breaker and one sliding window for the same host:
+
+```python
+import requests
+
+from interlock import Config, Registry
+from interlock.integrations.requests import CircuitBreakerAdapter, HttpStatusClassifier
+
+registry = Registry(
+    config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
+    classifier=HttpStatusClassifier(),
+)
+
+session_a = requests.Session()
+session_a.mount('https://', CircuitBreakerAdapter(registry=registry))
+
+session_b = requests.Session()
+session_b.mount('https://', CircuitBreakerAdapter(registry=registry))
+```
+
+The explicit classifier preserves the adapter's normal status policy. Without
+it, a bare `Registry` classifies exceptions only and a returned `503` counts
+as a success. The registry owns `config`, `clock`, `initial_state`,
+`classifier`, and `listener`; combining `registry` with any of those adapter
+options raises `ValueError`.
+
+Closing either session still releases its adapter's connection pools, but it
+does not close the injected registry. The application owns the registry and
+must call `registry.close_all()` once during shutdown.
 
 ## Safe production rollout
 

--- a/interlock/integrations/_registry.py
+++ b/interlock/integrations/_registry.py
@@ -1,0 +1,54 @@
+"""Registry construction and ownership shared by transport integrations."""
+
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec
+
+from interlock.config import Config
+from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.registry import Registry
+from interlock.state import State
+
+_P = ParamSpec('_P')
+_REGISTRY_OPTIONS = ('config', 'clock', 'initial_state', 'classifier', 'listener')
+
+
+def reject_registry_options(init: Callable[_P, None]) -> Callable[_P, None]:
+    """Reject constructor options explicitly combined with an injected registry."""
+
+    @wraps(init)
+    def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> None:
+        if kwargs.get('registry') is not None:
+            conflicts = [name for name in _REGISTRY_OPTIONS if name in kwargs]
+            if conflicts:
+                joined = ', '.join(conflicts)
+                raise ValueError(f'registry cannot be combined with: {joined}')
+        init(*args, **kwargs)
+
+    return wrapped
+
+
+def resolve_registry(  # noqa: PLR0913 - mirrors the integration constructors
+    *,
+    registry: Registry | None,
+    config: Config | None,
+    clock: Clock | None,
+    initial_state: State,
+    classifier: FailureClassifier | None,
+    listener: EventListener | None,
+    default_classifier: FailureClassifier,
+) -> tuple[Registry, bool]:
+    """Return the effective registry and whether the integration owns it."""
+    if registry is not None:
+        return registry, False
+
+    return (
+        Registry(
+            config=config,
+            clock=clock,
+            initial_state=initial_state,
+            classifier=classifier if classifier is not None else default_classifier,
+            listener=listener,
+        ),
+        True,
+    )

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -32,6 +32,7 @@ from typing import cast
 from aiohttp import ClientHandlerType, ClientRequest, ClientResponse
 
 from interlock.config import Config
+from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
 from interlock.state import State
@@ -91,12 +92,16 @@ class CircuitBreakerMiddleware:
             Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+        registry: Caller-owned registry shared with other clients. Mutually
+            exclusive with all breaker-construction options above.
 
     Raises:
-        ValueError: If ``initial_state`` is not a supported stable state.
+        ValueError: If ``initial_state`` is unsupported or ``registry`` is
+            combined with a breaker-construction option.
     """
 
-    def __init__(
+    @reject_registry_options
+    def __init__(  # noqa: PLR0913 - mirrors Registry's breaker collaborators
         self,
         *,
         config: Config | None = None,
@@ -104,13 +109,16 @@ class CircuitBreakerMiddleware:
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        registry: Registry | None = None,
     ) -> None:
-        self._registry = Registry(
+        self._registry, self._owns_registry = resolve_registry(
+            registry=registry,
             config=config,
             clock=clock,
             initial_state=initial_state,
-            classifier=classifier if classifier is not None else HttpStatusClassifier(),
+            classifier=classifier,
             listener=listener,
+            default_classifier=HttpStatusClassifier(),
         )
 
     @property
@@ -119,8 +127,9 @@ class CircuitBreakerMiddleware:
         return self._registry
 
     async def aclose(self) -> None:
-        """Release every per-host breaker's background resources."""
-        await self._registry.aclose_all()
+        """Release every breaker owned by this middleware."""
+        if self._owns_registry:
+            await self._registry.aclose_all()
 
     async def __call__(self, request: ClientRequest, handler: ClientHandlerType) -> ClientResponse:
         """Run the request under its host's breaker.

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -30,6 +30,7 @@ from typing import Self, cast
 from httpx import AsyncBaseTransport, BaseTransport, Request, Response
 
 from interlock.config import Config
+from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
 from interlock.state import State
@@ -91,23 +92,6 @@ def _host(request: Request) -> str:
     return host
 
 
-def _build_registry(
-    *,
-    config: Config | None,
-    clock: Clock | None,
-    initial_state: State,
-    classifier: FailureClassifier | None,
-    listener: EventListener | None,
-) -> Registry:
-    return Registry(
-        config=config,
-        clock=clock,
-        initial_state=initial_state,
-        classifier=classifier if classifier is not None else HttpStatusClassifier(),
-        listener=listener,
-    )
-
-
 class CircuitBreakerTransport(BaseTransport):
     """Guard every host reached by a synchronous httpx transport.
 
@@ -119,11 +103,15 @@ class CircuitBreakerTransport(BaseTransport):
             Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+        registry: Caller-owned registry shared with other clients. Mutually
+            exclusive with all breaker-construction options above.
 
     Raises:
-        ValueError: If ``initial_state`` is not a supported stable state.
+        ValueError: If ``initial_state`` is unsupported or ``registry`` is
+            combined with a breaker-construction option.
     """
 
+    @reject_registry_options
     def __init__(
         self,
         transport: BaseTransport,
@@ -133,14 +121,17 @@ class CircuitBreakerTransport(BaseTransport):
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        registry: Registry | None = None,
     ) -> None:
         self._transport = transport
-        self._registry = _build_registry(
+        self._registry, self._owns_registry = resolve_registry(
+            registry=registry,
             config=config,
             clock=clock,
             initial_state=initial_state,
             classifier=classifier,
             listener=listener,
+            default_classifier=HttpStatusClassifier(),
         )
 
     @property
@@ -170,16 +161,20 @@ class CircuitBreakerTransport(BaseTransport):
         exc_value: BaseException | None = None,
         traceback: TracebackType | None = None,
     ) -> None:
-        """Exit the wrapped transport's context and release every breaker."""
+        """Exit the wrapped transport's context and release every owned breaker."""
         with ExitStack() as stack:
-            stack.callback(self._registry.close_all)
+            stack.callback(self._close_registry)
             self._transport.__exit__(exc_type, exc_value, traceback)
 
     def close(self) -> None:
-        """Release the wrapped transport and every per-host breaker."""
+        """Release the wrapped transport and every owned per-host breaker."""
         with ExitStack() as stack:
-            stack.callback(self._registry.close_all)
+            stack.callback(self._close_registry)
             self._transport.close()
+
+    def _close_registry(self) -> None:
+        if self._owns_registry:
+            self._registry.close_all()
 
 
 class AsyncCircuitBreakerTransport(AsyncBaseTransport):
@@ -193,11 +188,15 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
             Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+        registry: Caller-owned registry shared with other clients. Mutually
+            exclusive with all breaker-construction options above.
 
     Raises:
-        ValueError: If ``initial_state`` is not a supported stable state.
+        ValueError: If ``initial_state`` is unsupported or ``registry`` is
+            combined with a breaker-construction option.
     """
 
+    @reject_registry_options
     def __init__(
         self,
         transport: AsyncBaseTransport,
@@ -207,14 +206,17 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        registry: Registry | None = None,
     ) -> None:
         self._transport = transport
-        self._registry = _build_registry(
+        self._registry, self._owns_registry = resolve_registry(
+            registry=registry,
             config=config,
             clock=clock,
             initial_state=initial_state,
             classifier=classifier,
             listener=listener,
+            default_classifier=HttpStatusClassifier(),
         )
 
     @property
@@ -244,13 +246,17 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         exc_value: BaseException | None = None,
         traceback: TracebackType | None = None,
     ) -> None:
-        """Exit the wrapped transport's context and release every breaker."""
+        """Exit the wrapped transport's context and release every owned breaker."""
         async with AsyncExitStack() as stack:
-            stack.push_async_callback(self._registry.aclose_all)
+            stack.push_async_callback(self._aclose_registry)
             await self._transport.__aexit__(exc_type, exc_value, traceback)
 
     async def aclose(self) -> None:
-        """Release the wrapped transport and every per-host breaker."""
+        """Release the wrapped transport and every owned per-host breaker."""
         async with AsyncExitStack() as stack:
-            stack.push_async_callback(self._registry.aclose_all)
+            stack.push_async_callback(self._aclose_registry)
             await self._transport.aclose()
+
+    async def _aclose_registry(self) -> None:
+        if self._owns_registry:
+            await self._registry.aclose_all()

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -29,6 +29,7 @@ from typing import Self, cast
 from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
 
 from interlock.config import Config
+from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
 from interlock.state import State
@@ -90,23 +91,6 @@ def _host(request: Request) -> str:
     return host
 
 
-def _build_registry(
-    *,
-    config: Config | None,
-    clock: Clock | None,
-    initial_state: State,
-    classifier: FailureClassifier | None,
-    listener: EventListener | None,
-) -> Registry:
-    return Registry(
-        config=config,
-        clock=clock,
-        initial_state=initial_state,
-        classifier=classifier if classifier is not None else HttpStatusClassifier(),
-        listener=listener,
-    )
-
-
 class CircuitBreakerTransport(BaseTransport):
     """A synchronous transport that guards each host with a circuit breaker.
 
@@ -119,11 +103,15 @@ class CircuitBreakerTransport(BaseTransport):
             Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+        registry: Caller-owned registry shared with other clients. Mutually
+            exclusive with all breaker-construction options above.
 
     Raises:
-        ValueError: If ``initial_state`` is not a supported stable state.
+        ValueError: If ``initial_state`` is unsupported or ``registry`` is
+            combined with a breaker-construction option.
     """
 
+    @reject_registry_options
     def __init__(
         self,
         transport: BaseTransport,
@@ -133,14 +121,17 @@ class CircuitBreakerTransport(BaseTransport):
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        registry: Registry | None = None,
     ) -> None:
         self._transport = transport
-        self._registry = _build_registry(
+        self._registry, self._owns_registry = resolve_registry(
+            registry=registry,
             config=config,
             clock=clock,
             initial_state=initial_state,
             classifier=classifier,
             listener=listener,
+            default_classifier=HttpStatusClassifier(),
         )
 
     @property
@@ -170,16 +161,20 @@ class CircuitBreakerTransport(BaseTransport):
         exc_value: BaseException | None = None,
         traceback: TracebackType | None = None,
     ) -> None:
-        """Exit the wrapped transport's context and release every breaker."""
+        """Exit the wrapped transport's context and release every owned breaker."""
         with ExitStack() as stack:
-            stack.callback(self._registry.close_all)
+            stack.callback(self._close_registry)
             self._transport.__exit__(exc_type, exc_value, traceback)
 
     def close(self) -> None:
-        """Release the wrapped transport and every per-host breaker."""
+        """Release the wrapped transport and every owned per-host breaker."""
         with ExitStack() as stack:
-            stack.callback(self._registry.close_all)
+            stack.callback(self._close_registry)
             self._transport.close()
+
+    def _close_registry(self) -> None:
+        if self._owns_registry:
+            self._registry.close_all()
 
 
 class AsyncCircuitBreakerTransport(AsyncBaseTransport):
@@ -194,11 +189,15 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
             Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+        registry: Caller-owned registry shared with other clients. Mutually
+            exclusive with all breaker-construction options above.
 
     Raises:
-        ValueError: If ``initial_state`` is not a supported stable state.
+        ValueError: If ``initial_state`` is unsupported or ``registry`` is
+            combined with a breaker-construction option.
     """
 
+    @reject_registry_options
     def __init__(
         self,
         transport: AsyncBaseTransport,
@@ -208,14 +207,17 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        registry: Registry | None = None,
     ) -> None:
         self._transport = transport
-        self._registry = _build_registry(
+        self._registry, self._owns_registry = resolve_registry(
+            registry=registry,
             config=config,
             clock=clock,
             initial_state=initial_state,
             classifier=classifier,
             listener=listener,
+            default_classifier=HttpStatusClassifier(),
         )
 
     @property
@@ -245,13 +247,17 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         exc_value: BaseException | None = None,
         traceback: TracebackType | None = None,
     ) -> None:
-        """Exit the wrapped transport's context and release every breaker."""
+        """Exit the wrapped transport's context and release every owned breaker."""
         async with AsyncExitStack() as stack:
-            stack.push_async_callback(self._registry.aclose_all)
+            stack.push_async_callback(self._aclose_registry)
             await self._transport.__aexit__(exc_type, exc_value, traceback)
 
     async def aclose(self) -> None:
-        """Release the wrapped transport and every per-host breaker."""
+        """Release the wrapped transport and every owned per-host breaker."""
         async with AsyncExitStack() as stack:
-            stack.push_async_callback(self._registry.aclose_all)
+            stack.push_async_callback(self._aclose_registry)
             await self._transport.aclose()
+
+    async def _aclose_registry(self) -> None:
+        if self._owns_registry:
+            await self._registry.aclose_all()

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -31,6 +31,7 @@ from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
 
 from interlock.config import Config
+from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, EventListener, FailureClassifier
 from interlock.registry import Registry
 from interlock.state import State
@@ -93,14 +94,18 @@ class CircuitBreakerAdapter(HTTPAdapter):
             Use ``State.METRICS_ONLY`` for shadow mode.
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every host's breaker.
+        registry: Caller-owned registry shared with other clients. Mutually
+            exclusive with all breaker-construction options above.
         adapter_kwargs: Passed through to ``HTTPAdapter`` (pool sizes,
             ``max_retries``, ...).
 
     Raises:
-        ValueError: If ``initial_state`` is not a supported stable state.
+        ValueError: If ``initial_state`` is unsupported or ``registry`` is
+            combined with a breaker-construction option.
     """
 
-    def __init__(
+    @reject_registry_options
+    def __init__(  # noqa: PLR0913 - mirrors Registry's breaker collaborators
         self,
         *,
         config: Config | None = None,
@@ -108,15 +113,18 @@ class CircuitBreakerAdapter(HTTPAdapter):
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
         listener: EventListener | None = None,
+        registry: Registry | None = None,
         **adapter_kwargs: object,
     ) -> None:
         super().__init__(**adapter_kwargs)  # type: ignore[arg-type]
-        self._registry = Registry(
+        self._registry, self._owns_registry = resolve_registry(
+            registry=registry,
             config=config,
             clock=clock,
             initial_state=initial_state,
-            classifier=classifier if classifier is not None else HttpStatusClassifier(),
+            classifier=classifier,
             listener=listener,
+            default_classifier=HttpStatusClassifier(),
         )
 
     @property
@@ -125,10 +133,14 @@ class CircuitBreakerAdapter(HTTPAdapter):
         return self._registry
 
     def close(self) -> None:
-        """Release the adapter's connection pools and every per-host breaker."""
+        """Release connection pools and every breaker owned by this adapter."""
         with ExitStack() as stack:
-            stack.callback(self._registry.close_all)
+            stack.callback(self._close_registry)
             super().close()
+
+    def _close_registry(self) -> None:
+        if self._owns_registry:
+            self._registry.close_all()
 
     def send(  # noqa: PLR0913, PLR0917 - mirrors HTTPAdapter.send, the native extension point
         self,

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -9,7 +9,7 @@ from pytest_mock import MockerFixture
 from tests.conftest import FakeClock
 from yarl import URL
 
-from interlock import CircuitOpenError, Config, State
+from interlock import CircuitOpenError, Config, Registry, State
 from interlock.integrations.aiohttp import CircuitBreakerMiddleware, HttpStatusClassifier
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
@@ -149,6 +149,49 @@ async def test__middleware__aclose__releases_registry(mocker: MockerFixture) -> 
     await middleware.aclose()
 
     aclose_all.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test__middlewares__shared_registry__merge_window(
+    fake_clock: FakeClock,
+) -> None:
+    registry = Registry(
+        config=_TRIP_FAST,
+        clock=fake_clock,
+        classifier=HttpStatusClassifier(),
+    )
+    first = CircuitBreakerMiddleware(registry=registry)
+    second = CircuitBreakerMiddleware(registry=registry)
+    handler = _handler([503, 503])
+
+    await first(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+    await second(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+    breaker = registry.get_existing('api.a')
+
+    assert first.registry is registry
+    assert second.registry is registry
+    assert breaker is not None
+    assert breaker.snapshot().failed_calls == 2
+    with pytest.raises(CircuitOpenError):
+        await second(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+
+@pytest.mark.asyncio
+async def test__middleware__injected_registry__aclose_preserves_registry(
+    mocker: MockerFixture,
+) -> None:
+    registry = Registry()
+    middleware = CircuitBreakerMiddleware(registry=registry)
+    aclose_all = mocker.spy(registry, 'aclose_all')
+
+    await middleware.aclose()
+
+    aclose_all.assert_not_awaited()
+
+
+def test__middleware__registry_with_config__raises_conflict() -> None:
+    with pytest.raises(ValueError, match='config'):
+        CircuitBreakerMiddleware(registry=Registry(), config=_TRIP_FAST)
 
 
 @pytest.mark.asyncio

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitOpenError, Config, Outcome, State
+from interlock import CircuitOpenError, Config, Outcome, Registry, State
 from interlock.integrations.httpx import (
     AsyncCircuitBreakerTransport,
     CircuitBreakerTransport,
@@ -239,6 +239,69 @@ def test__sync_transport__breakers_isolated_per_host(fake_clock: FakeClock) -> N
     assert transport.handle_request(_request('https://good.example.com/')).status_code == 200
 
 
+def test__sync_transports__shared_registry__merge_window(
+    fake_clock: FakeClock,
+) -> None:
+    registry = Registry(
+        config=_TRIP_FAST,
+        clock=fake_clock,
+        classifier=HttpStatusClassifier(),
+    )
+    first_inner = _SyncStub(lambda _request: httpx.Response(503))
+    second_inner = _SyncStub(lambda _request: httpx.Response(503))
+    first = CircuitBreakerTransport(first_inner, registry=registry)
+    second = CircuitBreakerTransport(second_inner, registry=registry)
+
+    first.handle_request(_request())
+    first_breaker = first.registry.get_existing('api.example.com')
+    second.handle_request(_request())
+    second_breaker = second.registry.get_existing('api.example.com')
+
+    assert first.registry is registry
+    assert second.registry is registry
+    assert first_breaker is not None
+    assert first_breaker is second_breaker
+    assert first_breaker.snapshot().failed_calls == 2
+    with pytest.raises(CircuitOpenError):
+        first.handle_request(_request())
+
+
+def test__sync_transport__injected_registry__closes_only_wrapped_transport(
+    mocker: MockerFixture,
+) -> None:
+    registry = Registry(classifier=HttpStatusClassifier())
+    inner = _SyncStub(lambda _request: httpx.Response(200))
+    transport = CircuitBreakerTransport(inner, registry=registry)
+    close_all = mocker.spy(registry, 'close_all')
+
+    transport.close()
+
+    assert inner.closed
+    close_all.assert_not_called()
+
+
+def test__sync_transport__registry_with_builder_options__raises_all_conflicts(
+    fake_clock: FakeClock,
+    listener: RecordingListener,
+) -> None:
+    registry = Registry()
+
+    with pytest.raises(ValueError, match='registry') as raised:
+        CircuitBreakerTransport(
+            _SyncStub(lambda _request: httpx.Response(200)),
+            registry=registry,
+            config=_TRIP_FAST,
+            clock=fake_clock,
+            initial_state=State.CLOSED,
+            classifier=HttpStatusClassifier(),
+            listener=listener,
+        )
+
+    message = str(raised.value)
+    for name in ('config', 'clock', 'initial_state', 'classifier', 'listener'):
+        assert name in message
+
+
 def test__sync_transport__url_without_host__raises_value_error(fake_clock: FakeClock) -> None:
     inner = _SyncStub(lambda _request: httpx.Response(200))
     transport = CircuitBreakerTransport(inner, clock=fake_clock)
@@ -406,6 +469,30 @@ async def test__async_transport__breakers_isolated_per_host(fake_clock: FakeCloc
         await transport.handle_async_request(_request('https://bad.example.com/'))
     response = await transport.handle_async_request(_request('https://good.example.com/'))
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test__async_transports__shared_registry__survives_one_transport_closing(
+    fake_clock: FakeClock,
+    mocker: MockerFixture,
+) -> None:
+    registry = Registry(clock=fake_clock, classifier=HttpStatusClassifier())
+    first_inner = _AsyncStub(lambda _request: httpx.Response(200))
+    second_inner = _AsyncStub(lambda _request: httpx.Response(200))
+    first = AsyncCircuitBreakerTransport(first_inner, registry=registry)
+    second = AsyncCircuitBreakerTransport(second_inner, registry=registry)
+    aclose_all = mocker.spy(registry, 'aclose_all')
+
+    await first.handle_async_request(_request())
+    await first.aclose()
+    response = await second.handle_async_request(_request())
+
+    assert first_inner.closed
+    assert response.status_code == 200
+    assert second.registry.get_existing('api.example.com') is registry.get_existing(
+        'api.example.com'
+    )
+    aclose_all.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -8,7 +8,7 @@ from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
 from pytest_mock import MockerFixture
 from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitOpenError, Config, Outcome, State
+from interlock import CircuitOpenError, Config, Outcome, Registry, State
 from interlock.integrations.httpx2 import (
     AsyncCircuitBreakerTransport,
     CircuitBreakerTransport,
@@ -205,6 +205,21 @@ def test__sync_transport__close__releases_wrapped_transport_and_registry(
     close_all.assert_called_once_with()
 
 
+def test__sync_transport__injected_registry__closes_only_wrapped_transport(
+    mocker: MockerFixture,
+) -> None:
+    registry = Registry(classifier=HttpStatusClassifier())
+    inner = _SyncStub(lambda _request: Response(200))
+    transport = CircuitBreakerTransport(inner, registry=registry)
+    close_all = mocker.spy(registry, 'close_all')
+
+    transport.close()
+
+    assert transport.registry is registry
+    assert inner.closed
+    close_all.assert_not_called()
+
+
 def test__sync_transport__wrapped_close_raises__still_releases_registry(
     mocker: MockerFixture,
 ) -> None:
@@ -270,6 +285,22 @@ async def test__async_transport__aclose__releases_wrapped_transport_and_registry
 
     assert inner.closed
     aclose_all.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test__async_transport__injected_registry__closes_only_wrapped_transport(
+    mocker: MockerFixture,
+) -> None:
+    registry = Registry(classifier=HttpStatusClassifier())
+    inner = _AsyncStub(lambda _request: Response(200))
+    transport = AsyncCircuitBreakerTransport(inner, registry=registry)
+    aclose_all = mocker.spy(registry, 'aclose_all')
+
+    await transport.aclose()
+
+    assert transport.registry is registry
+    assert inner.closed
+    aclose_all.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_registry.py
+++ b/tests/test_integration_registry.py
@@ -1,0 +1,51 @@
+import pytest
+
+from interlock import Config, Registry, State
+from interlock.integrations._registry import reject_registry_options, resolve_registry
+
+
+class _Classifier:
+    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+        return exception is not None
+
+
+def test__reject_registry_options__compatible_call__delegates() -> None:
+    delegated = False
+
+    def init(*, registry: Registry | None = None) -> None:
+        nonlocal delegated
+        assert registry is not None
+        delegated = True
+
+    wrapped = reject_registry_options(init)
+
+    wrapped(registry=Registry())
+
+    assert delegated
+
+
+def test__reject_registry_options__explicit_builder_option__raises_conflict() -> None:
+    def init(*, registry: Registry | None = None, config: Config | None = None) -> None:
+        raise AssertionError(f'conflicting call reached the constructor: {registry!r}, {config!r}')
+
+    wrapped = reject_registry_options(init)
+
+    with pytest.raises(ValueError, match='config'):
+        wrapped(registry=Registry(), config=None)
+
+
+def test__resolve_registry__injected_registry__returns_non_owner() -> None:
+    registry = Registry()
+
+    effective, owns_registry = resolve_registry(
+        registry=registry,
+        config=None,
+        clock=None,
+        initial_state=State.CLOSED,
+        classifier=None,
+        listener=None,
+        default_classifier=_Classifier(),
+    )
+
+    assert effective is registry
+    assert not owns_registry

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -9,7 +9,7 @@ from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
 from tests.conftest import FakeClock
 
-from interlock import CircuitOpenError, Config, State
+from interlock import CircuitOpenError, Config, Registry, State
 from interlock.integrations.requests import CircuitBreakerAdapter, HttpStatusClassifier
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
@@ -130,6 +130,51 @@ def test__adapter__close__releases_pools_and_registry(mocker: MockerFixture) -> 
 
     parent_close.assert_called_once_with(adapter)
     close_all.assert_called_once_with()
+
+
+def test__adapters__shared_registry__merge_window(
+    mocker: MockerFixture,
+    fake_clock: FakeClock,
+) -> None:
+    transport = _patch_transport(mocker, [_response(503), _response(503)])
+    registry = Registry(
+        config=_TRIP_FAST,
+        clock=fake_clock,
+        classifier=HttpStatusClassifier(),
+    )
+    first = CircuitBreakerAdapter(registry=registry)
+    second = CircuitBreakerAdapter(registry=registry)
+
+    first.send(_prepared('https://api.a/x'))
+    second.send(_prepared('https://api.a/x'))
+    breaker = registry.get_existing('api.a')
+
+    assert first.registry is registry
+    assert second.registry is registry
+    assert breaker is not None
+    assert breaker.snapshot().failed_calls == 2
+    with pytest.raises(CircuitOpenError):
+        second.send(_prepared('https://api.a/x'))
+    assert transport.call_count == 2
+
+
+def test__adapter__injected_registry__closes_only_connection_pools(
+    mocker: MockerFixture,
+) -> None:
+    parent_close = mocker.patch.object(HTTPAdapter, 'close', autospec=True)
+    registry = Registry()
+    adapter = CircuitBreakerAdapter(registry=registry)
+    close_all = mocker.spy(registry, 'close_all')
+
+    adapter.close()
+
+    close_all.assert_not_called()
+    parent_close.assert_called_once_with(adapter)
+
+
+def test__adapter__registry_with_initial_state__raises_conflict() -> None:
+    with pytest.raises(ValueError, match='initial_state'):
+        CircuitBreakerAdapter(registry=Registry(), initial_state=State.CLOSED)
 
 
 def test__adapter__transport_exception__counts_as_failure(


### PR DESCRIPTION
## Summary

- allow httpx2/httpx transports, aiohttp middleware, and requests adapters to use one caller-owned `Registry`
- fail fast when `registry` is combined with integration-owned configuration, while preserving existing public defaults
- keep injected registries alive when individual clients close, and document classifier ownership and shutdown

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Added
- Added `registry=` to `CircuitBreakerTransport` and `AsyncCircuitBreakerTransport` in the `httpx` and `httpx2` integrations.
- Added `registry=` to `CircuitBreakerMiddleware` in the `aiohttp` integration.
- Added `registry=` to `CircuitBreakerAdapter` in the `requests` integration.
- Added shared per-host breaker state across clients, sessions, middleware instances, transports, and adapters.
- Added `resolve_registry` and `reject_registry_options` integration utilities.

### Fixed
- Prevented integrations from closing caller-owned `Registry` instances.
- Preserved wrapped transport and connection-pool cleanup when clients close.
- Rejected `registry` with conflicting builder options.
- Preserved existing defaults when no registry is supplied.

### Changed
- Updated the public APIs for the `aiohttp`, `httpx`, `httpx2`, and `requests` extras.
- Documented caller ownership of registry configuration, classifier requirements, and explicit registry shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->