### PR TITLE
feat: split event listener protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `CoreEventListener`, `StorageEventListener` and `PipelineEventListener` let a
   breaker-only, coordination-only or strategy-only sink pass strict type
   checking without inheriting unrelated hooks. The existing `EventListener`
-  remains the complete ten-hook contract, and listener documentation now makes
-  the `name` namespace explicit: breaker for core/storage events, strategy for
-  pipeline events.
+  remains the complete ten-hook contract and continues to satisfy every narrowed
+  annotation, so existing listeners require no migration. Listener documentation
+  now makes the `name` namespace explicit: breaker for core/storage events,
+  strategy for pipeline events.
 
 - **Partial `EventListener` implementations now pass strict type checking.** A
   listener that only needs one hook previously had to stub all ten before mypy,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Listener contracts now match the events a component actually emits.**
+  `CoreEventListener`, `StorageEventListener` and `PipelineEventListener` let a
+  breaker-only, coordination-only or strategy-only sink pass strict type
+  checking without inheriting unrelated hooks. The existing `EventListener`
+  remains the complete ten-hook contract, and listener documentation now makes
+  the `name` namespace explicit: breaker for core/storage events, strategy for
+  pipeline events.
+
 - **Partial `EventListener` implementations now pass strict type checking.** A
   listener that only needs one hook previously had to stub all ten before mypy,
   pyright and pyrefly would accept it, despite runtime dispatch already treating

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -6,28 +6,50 @@ hooks back logging, metrics, and any custom sink.
 ## The hooks
 
 ```python
-class EventListener(Protocol):
+class CoreEventListener(Protocol):
     def on_state_change(self, *, name: str, old: State, new: State) -> None: ...
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
     def on_rejected(self, *, name: str) -> None: ...
     def on_reset(self, *, name: str) -> None: ...
+
+
+class StorageEventListener(Protocol):
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
     def on_storage_recovered(self, *, name: str) -> None: ...
     def on_storage_write_dropped(self, *, name: str) -> None: ...
+
+
+class PipelineEventListener(Protocol):
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None: ...
     def on_bulkhead_rejected(self, *, name: str) -> None: ...
     def on_fallback(self, *, name: str, error: BaseException) -> None: ...
+
+
+class EventListener(
+    CoreEventListener,
+    StorageEventListener,
+    PipelineEventListener,
+    Protocol,
+): ...
 ```
 
 Listeners are called **outside** the breaker's lock, after the protected call
 returns, so a slow listener never serialises throughput.
 
-The three storage hooks fire only for breakers coordinated through a shared
-[storage](../integrations/redis.md); the three pipeline hooks fire from
-[pipeline strategies](pipeline.md) given a `listener=`. Every hook is dispatched
-only if present, and the protocol supplies no-op implementations for subclasses.
-A listener can therefore override just the hooks it cares about and keeps
-working when a later interlock version adds a new hook.
+The protocols follow the owner of each event. `CoreEventListener` observes the
+breaker itself, `StorageEventListener` observes breakers coordinated through a
+shared [storage](../integrations/redis.md), and `PipelineEventListener` observes
+[pipeline strategies](pipeline.md) given a `listener=`. `EventListener` combines
+all three for sinks that observe the complete library.
+
+The `name` namespace follows the same boundary: core and storage hooks receive
+the **breaker name**, while pipeline hooks receive the **strategy name**. A
+listener can therefore use `name` directly as its breaker or strategy label
+without rediscovering the distinction from the call site.
+
+Every hook is dispatched only if present, and each protocol supplies no-op
+implementations for subclasses. A listener can override just the hooks it cares
+about and keeps working when a later interlock version adds a new hook.
 
 ## Listener failures are isolated
 
@@ -120,15 +142,15 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 
 ## Custom listeners
 
-For a partial listener that strict type checkers can verify, inherit
-`EventListener` and override only the hooks you need. Every inherited hook is a
-no-op:
+For a partial listener that strict type checkers can verify, inherit the narrowest
+protocol for its owner and override only the hooks you need. Every inherited hook
+is a no-op:
 
 ```python
-from interlock import EventListener
+from interlock import CoreEventListener
 
 
-class RejectionCounter(EventListener):
+class RejectionCounter(CoreEventListener):
     def __init__(self) -> None:
         self.rejected = 0
 
@@ -136,7 +158,8 @@ class RejectionCounter(EventListener):
         self.rejected += 1
 ```
 
-Inheritance is optional for a listener that implements the complete protocol:
-structural typing continues to accept it. At runtime, dispatch is still by name
-and skips any missing hook, including on older listener objects that do not
-inherit `EventListener`.
+Use `StorageEventListener` for storage-only sinks, `PipelineEventListener` for
+strategy-only sinks, or `EventListener` when one object handles every group.
+Inheritance is optional for a listener that structurally implements the relevant
+protocol. At runtime, dispatch is still by name and skips any missing hook,
+including on older listener objects that inherit none of them.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -6,6 +6,11 @@ hooks back logging, metrics, and any custom sink.
 ## The hooks
 
 ```python
+from typing import Protocol
+
+from interlock import Outcome, State
+
+
 class CoreEventListener(Protocol):
     def on_state_change(self, *, name: str, old: State, new: State) -> None: ...
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
@@ -33,8 +38,14 @@ class EventListener(
 ): ...
 ```
 
-Listeners are called **outside** the breaker's lock, after the protected call
-returns, so a slow listener never serialises throughput.
+Core listeners are called **outside** the breaker's lock, so a slow listener
+never serialises throughput. `on_call` runs after the protected call completes;
+transition, rejection, and reset hooks run immediately after their corresponding
+breaker operation. Storage hooks run from the coordinated breaker's background
+lane when its backend degrades, recovers, or drops a queued write.
+
+Pipeline hooks run inside their strategy's execution path: before retry backoff,
+when bulkhead admission fails, or before a fallback returns its substitute.
 
 The protocols follow the owner of each event. `CoreEventListener` observes the
 breaker itself, `StorageEventListener` observes breakers coordinated through a

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1778,28 +1778,50 @@ hooks back logging, metrics, and any custom sink.
 ## The hooks
 
 ```python
-class EventListener(Protocol):
+class CoreEventListener(Protocol):
     def on_state_change(self, *, name: str, old: State, new: State) -> None: ...
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
     def on_rejected(self, *, name: str) -> None: ...
     def on_reset(self, *, name: str) -> None: ...
+
+
+class StorageEventListener(Protocol):
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None: ...
     def on_storage_recovered(self, *, name: str) -> None: ...
     def on_storage_write_dropped(self, *, name: str) -> None: ...
+
+
+class PipelineEventListener(Protocol):
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None: ...
     def on_bulkhead_rejected(self, *, name: str) -> None: ...
     def on_fallback(self, *, name: str, error: BaseException) -> None: ...
+
+
+class EventListener(
+    CoreEventListener,
+    StorageEventListener,
+    PipelineEventListener,
+    Protocol,
+): ...
 ```
 
 Listeners are called **outside** the breaker's lock, after the protected call
 returns, so a slow listener never serialises throughput.
 
-The three storage hooks fire only for breakers coordinated through a shared
-[storage](../integrations/redis.md); the three pipeline hooks fire from
-[pipeline strategies](pipeline.md) given a `listener=`. Every hook is dispatched
-only if present, and the protocol supplies no-op implementations for subclasses.
-A listener can therefore override just the hooks it cares about and keeps
-working when a later interlock version adds a new hook.
+The protocols follow the owner of each event. `CoreEventListener` observes the
+breaker itself, `StorageEventListener` observes breakers coordinated through a
+shared [storage](../integrations/redis.md), and `PipelineEventListener` observes
+[pipeline strategies](pipeline.md) given a `listener=`. `EventListener` combines
+all three for sinks that observe the complete library.
+
+The `name` namespace follows the same boundary: core and storage hooks receive
+the **breaker name**, while pipeline hooks receive the **strategy name**. A
+listener can therefore use `name` directly as its breaker or strategy label
+without rediscovering the distinction from the call site.
+
+Every hook is dispatched only if present, and each protocol supplies no-op
+implementations for subclasses. A listener can override just the hooks it cares
+about and keeps working when a later interlock version adds a new hook.
 
 ## Listener failures are isolated
 
@@ -1892,15 +1914,15 @@ It records five instruments on the `interlock` meter (or a meter you pass in):
 
 ## Custom listeners
 
-For a partial listener that strict type checkers can verify, inherit
-`EventListener` and override only the hooks you need. Every inherited hook is a
-no-op:
+For a partial listener that strict type checkers can verify, inherit the narrowest
+protocol for its owner and override only the hooks you need. Every inherited hook
+is a no-op:
 
 ```python
-from interlock import EventListener
+from interlock import CoreEventListener
 
 
-class RejectionCounter(EventListener):
+class RejectionCounter(CoreEventListener):
     def __init__(self) -> None:
         self.rejected = 0
 
@@ -1908,10 +1930,11 @@ class RejectionCounter(EventListener):
         self.rejected += 1
 ```
 
-Inheritance is optional for a listener that implements the complete protocol:
-structural typing continues to accept it. At runtime, dispatch is still by name
-and skips any missing hook, including on older listener objects that do not
-inherit `EventListener`.
+Use `StorageEventListener` for storage-only sinks, `PipelineEventListener` for
+strategy-only sinks, or `EventListener` when one object handles every group.
+Inheritance is optional for a listener that structurally implements the relevant
+protocol. At runtime, dispatch is still by name and skips any missing hook,
+including on older listener objects that inherit none of them.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1778,6 +1778,11 @@ hooks back logging, metrics, and any custom sink.
 ## The hooks
 
 ```python
+from typing import Protocol
+
+from interlock import Outcome, State
+
+
 class CoreEventListener(Protocol):
     def on_state_change(self, *, name: str, old: State, new: State) -> None: ...
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None: ...
@@ -1805,8 +1810,14 @@ class EventListener(
 ): ...
 ```
 
-Listeners are called **outside** the breaker's lock, after the protected call
-returns, so a slow listener never serialises throughput.
+Core listeners are called **outside** the breaker's lock, so a slow listener
+never serialises throughput. `on_call` runs after the protected call completes;
+transition, rejection, and reset hooks run immediately after their corresponding
+breaker operation. Storage hooks run from the coordinated breaker's background
+lane when its backend degrades, recovers, or drops a queued write.
+
+Pipeline hooks run inside their strategy's execution path: before retry backoff,
+when bulkhead admission fails, or before a fallback returns its substitute.
 
 The protocols follow the owner of each event. `CoreEventListener` observes the
 breaker itself, `StorageEventListener` observes breakers coordinated through a

--- a/interlock/__init__.py
+++ b/interlock/__init__.py
@@ -24,10 +24,13 @@ from interlock.pipeline import (
 from interlock.protocols import (
     AsyncStorage,
     Clock,
+    CoreEventListener,
     EventListener,
     FailureClassifier,
+    PipelineEventListener,
     SlidingWindow,
     Storage,
+    StorageEventListener,
 )
 from interlock.registry import Registry
 from interlock.shared import ProbeLease, SharedState
@@ -51,6 +54,7 @@ __all__ = (
     'CircuitOpenError',
     'Clock',
     'Config',
+    'CoreEventListener',
     'EventListener',
     'FailureClassifier',
     'FallbackStrategy',
@@ -60,12 +64,14 @@ __all__ = (
     'Outcome',
     'Pipeline',
     'PipelineBuilder',
+    'PipelineEventListener',
     'ProbeLease',
     'Registry',
     'SharedState',
     'SlidingWindow',
     'State',
     'Storage',
+    'StorageEventListener',
     'Strategy',
     'SyncCallable',
     'TimeoutStrategy',

--- a/interlock/_engine.py
+++ b/interlock/_engine.py
@@ -28,7 +28,14 @@ from interlock._typing import AsyncCallable, P, R, SyncCallable
 from interlock.config import Config
 from interlock.errors import CircuitOpenError, InterlockError
 from interlock.outcome import Outcome
-from interlock.protocols import AsyncStorage, Clock, EventListener, FailureClassifier, Storage
+from interlock.protocols import (
+    AsyncStorage,
+    Clock,
+    CoreEventListener,
+    FailureClassifier,
+    Storage,
+    StorageEventListener,
+)
 from interlock.shared import SharedState
 from interlock.state import State
 from interlock.window import WindowSnapshot
@@ -82,7 +89,7 @@ class Engine:
         clock: Clock,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         storage: Storage | AsyncStorage | None = None,
     ) -> None:
         self._name = name

--- a/interlock/_notify.py
+++ b/interlock/_notify.py
@@ -24,14 +24,21 @@ part of the call's behaviour, not observations of it, and keep raising.
 import logging
 from typing import Final
 
-from interlock.protocols import EventListener
+from interlock.protocols import CoreEventListener, PipelineEventListener, StorageEventListener
 
 __all__ = ('notify',)
 
 _logger: Final = logging.getLogger('interlock')
 
 
-def notify(listener: EventListener | None, hook: str, /, *, name: str, **kwargs: object) -> None:
+def notify(
+    listener: CoreEventListener | StorageEventListener | PipelineEventListener | None,
+    hook: str,
+    /,
+    *,
+    name: str,
+    **kwargs: object,
+) -> None:
     """Invoke one listener hook, isolating its failure from the caller.
 
     Args:

--- a/interlock/breaker.py
+++ b/interlock/breaker.py
@@ -26,7 +26,14 @@ from interlock._detect import is_async_callable
 from interlock._engine import Admission, Engine
 from interlock._typing import AsyncCallable, P, R, SyncCallable
 from interlock.config import Config
-from interlock.protocols import AsyncStorage, Clock, EventListener, FailureClassifier, Storage
+from interlock.protocols import (
+    AsyncStorage,
+    Clock,
+    CoreEventListener,
+    FailureClassifier,
+    Storage,
+    StorageEventListener,
+)
 from interlock.state import State
 from interlock.window import WindowSnapshot
 
@@ -67,7 +74,7 @@ class CircuitBreaker:
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         storage: Storage | AsyncStorage | None = None,
     ) -> None:
         self._name = name

--- a/interlock/integrations/_registry.py
+++ b/interlock/integrations/_registry.py
@@ -5,7 +5,12 @@ from functools import wraps
 from typing import ParamSpec
 
 from interlock.config import Config
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import (
+    Clock,
+    CoreEventListener,
+    FailureClassifier,
+    StorageEventListener,
+)
 from interlock.registry import Registry
 from interlock.state import State
 
@@ -35,7 +40,7 @@ def resolve_registry(  # noqa: PLR0913 - mirrors the integration constructors
     clock: Clock | None,
     initial_state: State,
     classifier: FailureClassifier | None,
-    listener: EventListener | None,
+    listener: CoreEventListener | StorageEventListener | None,
     default_classifier: FailureClassifier,
 ) -> tuple[Registry, bool]:
     """Return the effective registry and whether the integration owns it."""

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -33,7 +33,7 @@ from aiohttp import ClientHandlerType, ClientRequest, ClientResponse
 
 from interlock.config import Config
 from interlock.integrations._registry import reject_registry_options, resolve_registry
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
 from interlock.state import State
 
@@ -108,7 +108,7 @@ class CircuitBreakerMiddleware:
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         registry: Registry | None = None,
     ) -> None:
         self._registry, self._owns_registry = resolve_registry(

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -31,7 +31,7 @@ from httpx import AsyncBaseTransport, BaseTransport, Request, Response
 
 from interlock.config import Config
 from interlock.integrations._registry import reject_registry_options, resolve_registry
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
 from interlock.state import State
 
@@ -120,7 +120,7 @@ class CircuitBreakerTransport(BaseTransport):
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         registry: Registry | None = None,
     ) -> None:
         self._transport = transport
@@ -205,7 +205,7 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         registry: Registry | None = None,
     ) -> None:
         self._transport = transport

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -30,7 +30,7 @@ from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
 
 from interlock.config import Config
 from interlock.integrations._registry import reject_registry_options, resolve_registry
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
 from interlock.state import State
 
@@ -120,7 +120,7 @@ class CircuitBreakerTransport(BaseTransport):
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         registry: Registry | None = None,
     ) -> None:
         self._transport = transport
@@ -206,7 +206,7 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         registry: Registry | None = None,
     ) -> None:
         self._transport = transport

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -32,7 +32,7 @@ from requests.adapters import HTTPAdapter
 
 from interlock.config import Config
 from interlock.integrations._registry import reject_registry_options, resolve_registry
-from interlock.protocols import Clock, EventListener, FailureClassifier
+from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
 from interlock.state import State
 
@@ -112,7 +112,7 @@ class CircuitBreakerAdapter(HTTPAdapter):
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         registry: Registry | None = None,
         **adapter_kwargs: object,
     ) -> None:

--- a/interlock/integrations/tenacity.py
+++ b/interlock/integrations/tenacity.py
@@ -69,7 +69,7 @@ except ImportError as exc:
 
 from interlock._notify import notify
 from interlock.errors import CircuitOpenError
-from interlock.protocols import EventListener
+from interlock.protocols import PipelineEventListener
 
 __all__ = ('RetryStrategy', 'retry_unless_open', 'wait_probe')
 
@@ -195,7 +195,7 @@ class RetryStrategy:
         async_sleep: Callable[[float], Awaitable[None]] | None = None,
         before_sleep: Callable[[RetryCallState], None] | None = None,
         name: str = 'retry',
-        listener: EventListener | None = None,
+        listener: PipelineEventListener | None = None,
     ) -> None:
         if attempts < 1:
             raise ValueError(f'attempts must be >= 1, got {attempts!r}')

--- a/interlock/pipeline.py
+++ b/interlock/pipeline.py
@@ -37,7 +37,7 @@ from interlock._notify import notify
 from interlock._typing import AsyncCallable, P, R, SyncCallable
 from interlock.breaker import CircuitBreaker
 from interlock.errors import BulkheadFullError
-from interlock.protocols import EventListener
+from interlock.protocols import PipelineEventListener
 from interlock.timeout import sync_timeout, timeout
 
 if TYPE_CHECKING:
@@ -289,7 +289,7 @@ class BulkheadStrategy:
         *,
         max_wait: float = 0.0,
         name: str = 'bulkhead',
-        listener: EventListener | None = None,
+        listener: PipelineEventListener | None = None,
     ) -> None:
         if max_concurrent < 1:
             raise ValueError(f'max_concurrent must be >= 1, got {max_concurrent!r}')
@@ -378,7 +378,7 @@ class FallbackStrategy(Generic[F_co]):
         *,
         on: tuple[type[Exception], ...] = (Exception,),
         name: str = 'fallback',
-        listener: EventListener | None = None,
+        listener: PipelineEventListener | None = None,
     ) -> None:
         if not on:
             raise ValueError('on must name at least one exception type')
@@ -447,7 +447,7 @@ class PipelineBuilder:
         *,
         on: tuple[type[Exception], ...] = (Exception,),
         name: str = 'fallback',
-        listener: EventListener | None = None,
+        listener: PipelineEventListener | None = None,
     ) -> Self:
         """Append a :class:`FallbackStrategy` substituting failures listed in ``on``."""
         return self.add(FallbackStrategy(fallback, on=on, name=name, listener=listener))
@@ -462,7 +462,7 @@ class PipelineBuilder:
         async_sleep: Callable[[float], Awaitable[None]] | None = None,
         before_sleep: 'Callable[[RetryCallState], None] | None' = None,
         name: str = 'retry',
-        listener: EventListener | None = None,
+        listener: PipelineEventListener | None = None,
     ) -> Self:
         """Append a ``RetryStrategy`` (requires the ``tenacity`` extra).
 
@@ -498,7 +498,7 @@ class PipelineBuilder:
         *,
         max_wait: float = 0.0,
         name: str = 'bulkhead',
-        listener: EventListener | None = None,
+        listener: PipelineEventListener | None = None,
     ) -> Self:
         """Append a :class:`BulkheadStrategy` capping concurrency."""
         return self.add(

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -18,10 +18,13 @@ from interlock.window import WindowSnapshot
 __all__ = (
     'AsyncStorage',
     'Clock',
+    'CoreEventListener',
     'EventListener',
     'FailureClassifier',
+    'PipelineEventListener',
     'SlidingWindow',
     'Storage',
+    'StorageEventListener',
 )
 
 
@@ -185,14 +188,13 @@ class FailureClassifier(Protocol):
 
 
 @runtime_checkable
-class EventListener(Protocol):
-    """Hooks for observability, isolated from the paths they observe.
+class CoreEventListener(Protocol):
+    """Observes circuit-breaker calls, rejections, resets and transitions.
 
     A hook that raises an ``Exception`` is logged to the ``interlock`` logger
     and ignored: the protected call keeps its result, a failing call keeps its
-    own exception, transition bookkeeping completes, and a coordinated
-    breaker's background lane keeps running. ``BaseException`` — cancellation,
-    shutdown — still propagates.
+    own exception, and transition bookkeeping completes. ``BaseException`` —
+    cancellation, shutdown — still propagates.
 
     Every hook is dispatched by name and only if defined, so a listener may
     implement just the ones it needs and one written before a hook existed
@@ -202,23 +204,33 @@ class EventListener(Protocol):
     """
 
     def on_state_change(self, *, name: str, old: State, new: State) -> None:
-        """Called after the breaker transitions between states."""
+        """Called after breaker ``name`` transitions between states."""
         return None
 
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
-        """Called after a protected call completes, success or failure."""
+        """Called after a call protected by breaker ``name`` completes."""
         return None
 
     def on_rejected(self, *, name: str) -> None:
-        """Called when a call is rejected because the circuit is open."""
+        """Called when breaker ``name`` rejects a call because its circuit is open."""
         return None
 
     def on_reset(self, *, name: str) -> None:
-        """Called when the breaker is manually reset."""
+        """Called when breaker ``name`` is manually reset."""
         return None
 
+
+@runtime_checkable
+class StorageEventListener(Protocol):
+    """Observes the shared-storage path of a coordinated circuit breaker.
+
+    ``name`` always identifies the breaker whose storage path emitted the
+    event. Hooks inherit the same failure isolation and optional-dispatch
+    policy as ``CoreEventListener``.
+    """
+
     def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
-        """Called when the shared storage backend becomes unavailable.
+        """Called when breaker ``name`` loses its shared storage backend.
 
         The breaker keeps working on local state; this event makes the
         degradation observable instead of silent. It reports storage failures
@@ -228,11 +240,11 @@ class EventListener(Protocol):
         return None
 
     def on_storage_recovered(self, *, name: str) -> None:
-        """Called when the shared storage backend becomes reachable again."""
+        """Called when breaker ``name`` reaches its shared storage backend again."""
         return None
 
     def on_storage_write_dropped(self, *, name: str) -> None:
-        """Called when a coordinated write is dropped by a full write queue.
+        """Called when breaker ``name`` drops a write from its full storage queue.
 
         The queue only fills when the background lane stops draining it, so
         this is the signal that shared writes are being lost while the breaker
@@ -241,8 +253,18 @@ class EventListener(Protocol):
         """
         return None
 
+
+@runtime_checkable
+class PipelineEventListener(Protocol):
+    """Observes retry, bulkhead and fallback pipeline strategies.
+
+    ``name`` always identifies the strategy that emitted the event. Hooks
+    inherit the same failure isolation and optional-dispatch policy as
+    ``CoreEventListener``.
+    """
+
     def on_retry(self, *, name: str, attempt: int, delay: float) -> None:
-        """Called by a pipeline retry layer before it sleeps between attempts.
+        """Called before retry strategy ``name`` sleeps between attempts.
 
         ``attempt`` is the number of the attempt that just failed; ``delay``
         is the upcoming backoff in seconds.
@@ -250,9 +272,19 @@ class EventListener(Protocol):
         return None
 
     def on_bulkhead_rejected(self, *, name: str) -> None:
-        """Called when a pipeline bulkhead rejects a call (no free slot)."""
+        """Called when bulkhead strategy ``name`` rejects a call (no free slot)."""
         return None
 
     def on_fallback(self, *, name: str, error: BaseException) -> None:
-        """Called when a pipeline fallback substitutes a value for ``error``."""
+        """Called when fallback strategy ``name`` substitutes a value for ``error``."""
         return None
+
+
+@runtime_checkable
+class EventListener(
+    CoreEventListener,
+    StorageEventListener,
+    PipelineEventListener,
+    Protocol,
+):
+    """Complete listener contract combining core, storage and pipeline hooks."""

--- a/interlock/registry.py
+++ b/interlock/registry.py
@@ -12,7 +12,14 @@ from interlock._clock import SystemClock
 from interlock._initial_state import validate_initial_state
 from interlock.breaker import CircuitBreaker
 from interlock.config import Config
-from interlock.protocols import AsyncStorage, Clock, EventListener, FailureClassifier, Storage
+from interlock.protocols import (
+    AsyncStorage,
+    Clock,
+    CoreEventListener,
+    FailureClassifier,
+    Storage,
+    StorageEventListener,
+)
 from interlock.state import State
 
 __all__ = ('Registry',)
@@ -46,7 +53,7 @@ class Registry:
         clock: Clock | None = None,
         initial_state: State = State.CLOSED,
         classifier: FailureClassifier | None = None,
-        listener: EventListener | None = None,
+        listener: CoreEventListener | StorageEventListener | None = None,
         storage: Storage | AsyncStorage | None = None,
     ) -> None:
         validate_initial_state(initial_state)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -53,6 +53,18 @@ class _RejectionListener(EventListener):
         self.names.append(name)
 
 
+class _CoreOnlyListener(CoreEventListener):
+    pass
+
+
+class _StorageOnlyListener(StorageEventListener):
+    pass
+
+
+class _PipelineOnlyListener(PipelineEventListener):
+    pass
+
+
 def _notify_inherited_hooks(listener: EventListener) -> None:
     hooks: tuple[tuple[str, dict[str, object]], ...] = (
         ('on_state_change', {'old': State.CLOSED, 'new': State.OPEN}),
@@ -142,7 +154,23 @@ def test__partial_listeners__own_hooks_and_inherited_hooks__only_own_hooks_have_
     assert rejection_listener.names == [NAME]
 
 
-def test__listener_protocols__complete_listener__satisfies_every_narrow_contract() -> None:
+def test__listener_protocols__narrow_listeners__satisfy_only_their_event_group() -> None:
+    core_listener = _CoreOnlyListener()
+    storage_listener = _StorageOnlyListener()
+    pipeline_listener = _PipelineOnlyListener()
+
+    assert isinstance(core_listener, CoreEventListener)
+    assert not isinstance(core_listener, StorageEventListener)
+    assert not isinstance(core_listener, PipelineEventListener)
+    assert isinstance(storage_listener, StorageEventListener)
+    assert not isinstance(storage_listener, CoreEventListener)
+    assert not isinstance(storage_listener, PipelineEventListener)
+    assert isinstance(pipeline_listener, PipelineEventListener)
+    assert not isinstance(pipeline_listener, CoreEventListener)
+    assert not isinstance(pipeline_listener, StorageEventListener)
+
+
+def test__event_listener__complete_listener__satisfies_every_event_group() -> None:
     listener = _CallListener()
 
     assert isinstance(listener, CoreEventListener)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -23,7 +23,14 @@ from interlock._coordination import (
     _sync_lane_tick,
 )
 from interlock._notify import notify
-from interlock.protocols import AsyncStorage, EventListener, Storage
+from interlock.protocols import (
+    AsyncStorage,
+    CoreEventListener,
+    EventListener,
+    PipelineEventListener,
+    Storage,
+    StorageEventListener,
+)
 from interlock.shared import SharedState
 
 NAME = 'svc'
@@ -133,6 +140,14 @@ def test__partial_listeners__own_hooks_and_inherited_hooks__only_own_hooks_have_
 
     assert call_listener.calls == [(NAME, Outcome.SUCCESS)]
     assert rejection_listener.names == [NAME]
+
+
+def test__listener_protocols__complete_listener__satisfies_every_narrow_contract() -> None:
+    listener = _CallListener()
+
+    assert isinstance(listener, CoreEventListener)
+    assert isinstance(listener, StorageEventListener)
+    assert isinstance(listener, PipelineEventListener)
 
 
 def test__notify__raising_hook__is_logged_with_context(

--- a/tests/typing_surface.py
+++ b/tests/typing_surface.py
@@ -13,19 +13,37 @@ from typing import assert_type
 from interlock import (
     BulkheadStrategy,
     CircuitBreaker,
+    CoreEventListener,
     EventListener,
     FallbackStrategy,
     LoggingEventListener,
     Outcome,
     Pipeline,
+    PipelineEventListener,
     Registry,
     State,
+    StorageEventListener,
 )
 from interlock.integrations.tenacity import RetryStrategy
 
 
 class _CallListener(EventListener):
     def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
+        return None
+
+
+class _CoreCallListener(CoreEventListener):
+    def on_call(self, *, name: str, outcome: Outcome, duration: float) -> None:
+        return None
+
+
+class _StorageDegradedListener(StorageEventListener):
+    def on_storage_degraded(self, *, name: str, error: BaseException) -> None:
+        return None
+
+
+class _RetryListener(PipelineEventListener):
+    def on_retry(self, *, name: str, attempt: int, delay: float) -> None:
         return None
 
 
@@ -38,6 +56,16 @@ partial_retry = RetryStrategy(listener=partial_listener)
 complete_listener_breaker = CircuitBreaker(
     name='complete-listener', listener=LoggingEventListener()
 )
+core_listener = _CoreCallListener()
+core_breaker = CircuitBreaker(name='core-listener', listener=core_listener)
+core_registry = Registry(listener=core_listener)
+storage_listener = _StorageDegradedListener()
+storage_breaker = CircuitBreaker(name='storage-listener', listener=storage_listener)
+storage_registry = Registry(listener=storage_listener)
+pipeline_listener = _RetryListener()
+pipeline_bulkhead = BulkheadStrategy(1, listener=pipeline_listener)
+pipeline_fallback = FallbackStrategy(lambda _error: None, listener=pipeline_listener)
+pipeline_retry = RetryStrategy(listener=pipeline_listener)
 
 breaker = CircuitBreaker(name='typing-surface')
 shadow_breaker = CircuitBreaker(name='shadow', initial_state=State.METRICS_ONLY)


### PR DESCRIPTION
## Summary

- split listener hooks into narrow core, storage, and pipeline protocols while preserving the complete `EventListener` contract
- narrow breaker/coordination and pipeline strategy annotations so focused listeners pass strict type checking
- document the breaker-versus-strategy `name` namespace and regenerate the LLM documentation mirror

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Added
- Added `CoreEventListener`, `StorageEventListener`, and `PipelineEventListener` to the public API.
- Added typing support for core-only, storage-only, pipeline-only, and complete listeners.

### Changed
- Updated breaker, registry, engine, and HTTP integration APIs to accept `CoreEventListener` or `StorageEventListener`.
- Updated pipeline and Tenacity APIs to accept `PipelineEventListener`.
- Preserved the complete `EventListener` contract as a composite of the narrow protocols.
- Clarified breaker and strategy name namespaces in listener documentation.
- Regenerated `docs/llms-full.txt` and updated observability documentation.

### Public API
- Expanded the public listener protocol surface without changing `EventListener` members or `notify` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->