### PR TITLE
ci: add Windows and macOS compatibility smoke jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,51 @@ jobs:
       - name: Tests
         run: uv run pytest --cov
 
+  platform-smoke:
+    name: Platform smoke (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+        python-version: ['3.11', '3.14']
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      # Service containers are unavailable on Windows and macOS hosted runners,
+      # so Redis tests stay in the full Ubuntu matrix. Static quality checks also
+      # stay there; this job targets platform-sensitive runtime behaviour only.
+      - name: Platform-sensitive runtime tests
+        run: >-
+          uv run pytest
+          tests/test_breaker.py
+          tests/test_concurrency.py
+          tests/test_engine.py
+          tests/test_shutdown.py
+          tests/test_windows.py
+          tests/test_timeout.py
+          tests/test_pipeline.py
+          tests/test_state_machine.py
+          tests/test_state_machine_model.py
+          tests/test_state_machine_properties.py
+          tests/test_typing.py
+          tests/test_e2e.py
+          tests/test_httpx_e2e.py
+          tests/test_httpx2_e2e.py
+          tests/test_aiohttp.py
+
   extras-min:
     name: Extras (minimum versions)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Windows and macOS regressions are now caught before release.** A lightweight CI
+  matrix exercises the platform-sensitive runtime paths on the oldest and newest
+  supported Python versions while the full quality, coverage and Redis matrix stays
+  on Ubuntu.
+
 - **Transport integrations can key breakers by logical dependency instead of
   raw host.** Service-discovery suffixes and shared gateway hosts previously
   made the httpx2/httpx transports, aiohttp middleware, and requests adapter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,21 @@ The pre-commit hooks run the fast subset automatically:
 uv run prek install           # one-time, installs the git hook
 ```
 
+### Supported platforms
+
+interlock supports Python 3.11–3.14 on Linux, Windows and macOS. The full test,
+coverage, static-analysis and Redis matrix runs on Ubuntu. A smaller runtime matrix
+runs on Windows and macOS with the oldest and newest supported Python versions. It
+covers the core breaker, concurrency and shutdown paths, timeouts, the resilience
+pipeline, state-machine invariants, the runtime typing surface and loopback HTTP
+integrations.
+
+Redis tests are the only platform-smoke exclusion tied to an operating-system
+constraint: GitHub-hosted Windows and macOS runners do not support service
+containers. They remain covered against a real Redis server in every Python version
+of the Ubuntu matrix. Ruff and the static type checkers also stay in that full matrix
+because their results are platform-independent.
+
 ### Public API compatibility
 
 `.github/workflows/api-compatibility.yml` runs [`griffe check`](https://mkdocstrings.github.io/griffe/)


### PR DESCRIPTION
## Summary

- add a lightweight Windows and macOS runtime matrix for Python 3.11 and 3.14
- cover core, concurrency, shutdown, timeout, pipeline, state-machine, typing-surface, and loopback integration behavior
- keep Redis and platform-independent quality gates in the full Ubuntu matrix and document the tested-platform policy

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

Closes #86