### PR TITLE
docs: warn about registry-owned classification in the transport docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with no error anywhere. The warning existed only in the integration guides; the
   `registry` argument docstrings now carry it too, where the reader is when they
   make the choice.
+- **The opposite trap is documented as well.** A registry configured with
+  `HttpStatusClassifier` reads the status off every result it records, so
+  borrowing a breaker from it for non-HTTP work raised `AttributeError` on the
+  first returned value. The four shared-registry guides now say to keep such a
+  registry for HTTP clients only.
+- **Rejecting an option the injected registry already owns explains itself.** The
+  `ValueError` used to name the conflicting options and stop; it now says the
+  registry owns them and to configure them there.
 
 ## [2.5.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The classifier trap behind an injected registry is now visible in the editor.**
+  A caller-owned `Registry` owns the failure policy, so a bare one silently
+  downgrades the httpx2/httpx transports, the aiohttp middleware and the requests
+  adapter to exception-only classification — a returned `503` counts as a success
+  with no error anywhere. The warning existed only in the integration guides; the
+  `registry` argument docstrings now carry it too, where the reader is when they
+  make the choice.
+
 ## [2.5.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **The classifier trap behind an injected registry is now visible in the editor.**
-  A caller-owned `Registry` owns the failure policy, so a bare one silently
-  downgrades the httpx2/httpx transports, the aiohttp middleware and the requests
-  adapter to exception-only classification — a returned `503` counts as a success
-  with no error anywhere. The warning existed only in the integration guides; the
-  `registry` argument docstrings now carry it too, where the reader is when they
-  make the choice.
+- **A caller-owned `Registry` needs its own HTTP classifier.** Handing one to the
+  httpx2/httpx transports, the aiohttp middleware or the requests adapter moves
+  the failure policy to the registry, so a returned `503` counts as a success
+  unless the registry is built with `classifier=HttpStatusClassifier()`. The
+  `registry` argument now states that where the registry is configured.
 - **The opposite trap is documented as well.** A registry configured with
   `HttpStatusClassifier` reads the status off every result it records, so
   borrowing a breaker from it for non-HTTP work raised `AttributeError` on the

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -99,6 +99,11 @@ as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; passing any of them to the middleware together
 with `registry` raises `ValueError`.
 
+Share such a registry with HTTP sessions only. `HttpStatusClassifier` reads
+`.status` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
+
 Calling `aclose()` automatically closes the breakers only when the middleware
 owns the registry. An injected registry remains open until the application
 explicitly calls `await registry.aclose_all()` during shutdown.

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -146,6 +146,11 @@ supplied registry also owns `config`, `clock`, `initial_state`, `classifier`,
 and `listener`; combining `registry` with any of those transport options raises
 `ValueError` instead of silently ignoring one source of configuration.
 
+Share such a registry with HTTP clients only. `HttpStatusClassifier` reads
+`.status_code` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
+
 Closing a client automatically closes its breakers only when the transport
 owns the registry. An injected registry remains open while the wrapped
 connection pool closes; the application must explicitly call

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -152,6 +152,11 @@ status policy; otherwise a returned `503` counts as a success. The supplied
 registry owns `config`, `clock`, `initial_state`, `classifier`, and `listener`,
 so none of those options may also be passed to the transport.
 
+Share such a registry with HTTP clients only. `HttpStatusClassifier` reads
+`.status_code` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
+
 Closing a client automatically closes its breakers only when the transport
 owns the registry. An injected registry remains open while the wrapped
 connection pool closes; the application must explicitly call

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -102,6 +102,11 @@ as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; combining `registry` with any of those adapter
 options raises `ValueError`.
 
+Share such a registry with HTTP sessions only. `HttpStatusClassifier` reads
+`.status_code` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
+
 Closing a session automatically closes its breakers only when the adapter owns
 the registry. An injected registry remains open while its connection pools
 close; the application must explicitly call `registry.close_all()` during

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2871,6 +2871,11 @@ status policy; otherwise a returned `503` counts as a success. The supplied
 registry owns `config`, `clock`, `initial_state`, `classifier`, and `listener`,
 so none of those options may also be passed to the transport.
 
+Share such a registry with HTTP clients only. `HttpStatusClassifier` reads
+`.status_code` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
+
 Closing a client automatically closes its breakers only when the transport
 owns the registry. An injected registry remains open while the wrapped
 connection pool closes; the application must explicitly call
@@ -3060,6 +3065,11 @@ supplied registry also owns `config`, `clock`, `initial_state`, `classifier`,
 and `listener`; combining `registry` with any of those transport options raises
 `ValueError` instead of silently ignoring one source of configuration.
 
+Share such a registry with HTTP clients only. `HttpStatusClassifier` reads
+`.status_code` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
+
 Closing a client automatically closes its breakers only when the transport
 owns the registry. An injected registry remains open while the wrapped
 connection pool closes; the application must explicitly call
@@ -3212,6 +3222,11 @@ bare `Registry` uses exception-only classification, so a returned `503` counts
 as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; passing any of them to the middleware together
 with `registry` raises `ValueError`.
+
+Share such a registry with HTTP sessions only. `HttpStatusClassifier` reads
+`.status` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
 
 Calling `aclose()` automatically closes the breakers only when the middleware
 owns the registry. An injected registry remains open until the application
@@ -3373,6 +3388,11 @@ it, a bare `Registry` classifies exceptions only and a returned `503` counts
 as a success. The registry owns `config`, `clock`, `initial_state`,
 `classifier`, and `listener`; combining `registry` with any of those adapter
 options raises `ValueError`.
+
+Share such a registry with HTTP sessions only. `HttpStatusClassifier` reads
+`.status_code` off every result it records, so a breaker taken from the same
+registry for non-HTTP work — `registry.get('db')` — raises `AttributeError` the
+first time that call returns. Keep a separate registry for those.
 
 Closing a session automatically closes its breakers only when the adapter owns
 the registry. An injected registry remains open while its connection pools

--- a/interlock/integrations/_registry.py
+++ b/interlock/integrations/_registry.py
@@ -27,7 +27,10 @@ def reject_registry_options(init: Callable[_P, None]) -> Callable[_P, None]:
             conflicts = [name for name in _REGISTRY_OPTIONS if name in kwargs]
             if conflicts:
                 joined = ', '.join(conflicts)
-                raise ValueError(f'registry cannot be combined with: {joined}')
+                raise ValueError(
+                    f'The injected registry already owns these options: {joined}. '
+                    'Configure them on the registry instead.'
+                )
         init(*args, **kwargs)
 
     return wrapped

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -121,7 +121,10 @@ class CircuitBreakerMiddleware:
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every breaker.
         registry: Caller-owned registry shared with other clients. Mutually
-            exclusive with all breaker-construction options above.
+            exclusive with all breaker-construction options above; it owns the
+            failure policy too, so pass ``classifier=HttpStatusClassifier()``
+            when creating it — a bare ``Registry`` counts only exceptions, and
+            a returned ``503`` is a success.
         name_resolver: Maps each request to its breaker name. Defaults to the
             request host.
 

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -119,7 +119,10 @@ class CircuitBreakerTransport(BaseTransport):
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every breaker.
         registry: Caller-owned registry shared with other clients. Mutually
-            exclusive with all breaker-construction options above.
+            exclusive with all breaker-construction options above; it owns the
+            failure policy too, so pass ``classifier=HttpStatusClassifier()``
+            when creating it — a bare ``Registry`` counts only exceptions, and
+            a returned ``503`` is a success.
         name_resolver: Maps each request to its breaker name. Defaults to the
             request host.
 
@@ -210,7 +213,10 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every breaker.
         registry: Caller-owned registry shared with other clients. Mutually
-            exclusive with all breaker-construction options above.
+            exclusive with all breaker-construction options above; it owns the
+            failure policy too, so pass ``classifier=HttpStatusClassifier()``
+            when creating it — a bare ``Registry`` counts only exceptions, and
+            a returned ``503`` is a success.
         name_resolver: Maps each request to its breaker name. Defaults to the
             request host.
 

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -119,7 +119,10 @@ class CircuitBreakerTransport(BaseTransport):
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every breaker.
         registry: Caller-owned registry shared with other clients. Mutually
-            exclusive with all breaker-construction options above.
+            exclusive with all breaker-construction options above; it owns the
+            failure policy too, so pass ``classifier=HttpStatusClassifier()``
+            when creating it — a bare ``Registry`` counts only exceptions, and
+            a returned ``503`` is a success.
         name_resolver: Maps each request to its breaker name. Defaults to the
             request host.
 
@@ -211,7 +214,10 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every breaker.
         registry: Caller-owned registry shared with other clients. Mutually
-            exclusive with all breaker-construction options above.
+            exclusive with all breaker-construction options above; it owns the
+            failure policy too, so pass ``classifier=HttpStatusClassifier()``
+            when creating it — a bare ``Registry`` counts only exceptions, and
+            a returned ``503`` is a success.
         name_resolver: Maps each request to its breaker name. Defaults to the
             request host.
 

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -127,7 +127,10 @@ class CircuitBreakerAdapter(HTTPAdapter):
         classifier: Failure policy. Defaults to ``HttpStatusClassifier``.
         listener: Observability hooks shared by every breaker.
         registry: Caller-owned registry shared with other clients. Mutually
-            exclusive with all breaker-construction options above.
+            exclusive with all breaker-construction options above; it owns the
+            failure policy too, so pass ``classifier=HttpStatusClassifier()``
+            when creating it — a bare ``Registry`` counts only exceptions, and
+            a returned ``503`` is a success.
         name_resolver: Maps each request to its breaker name. Defaults to the
             request host.
         adapter_kwargs: Passed through to ``HTTPAdapter`` (pool sizes,

--- a/tests/test_integration_registry.py
+++ b/tests/test_integration_registry.py
@@ -34,6 +34,20 @@ def test__reject_registry_options__explicit_builder_option__raises_conflict() ->
         wrapped(registry=Registry(), config=None)
 
 
+def test__reject_registry_options__conflicting_option__names_option_and_registry_fix() -> None:
+    def init(*, registry: Registry | None = None, config: Config | None = None) -> None:
+        raise AssertionError(f'conflicting call reached the constructor: {registry!r}, {config!r}')
+
+    wrapped = reject_registry_options(init)
+
+    with pytest.raises(ValueError) as exc_info:
+        wrapped(registry=Registry(), config=None)
+
+    error_message = str(exc_info.value)
+    assert 'config' in error_message
+    assert 'Configure them on the registry instead' in error_message
+
+
 def test__resolve_registry__injected_registry__returns_non_owner() -> None:
     registry = Registry()
 

--- a/tests/test_integration_registry.py
+++ b/tests/test_integration_registry.py
@@ -30,22 +30,8 @@ def test__reject_registry_options__explicit_builder_option__raises_conflict() ->
 
     wrapped = reject_registry_options(init)
 
-    with pytest.raises(ValueError, match='config'):
+    with pytest.raises(ValueError, match=r'config\. Configure them on the registry instead'):
         wrapped(registry=Registry(), config=None)
-
-
-def test__reject_registry_options__conflicting_option__names_option_and_registry_fix() -> None:
-    def init(*, registry: Registry | None = None, config: Config | None = None) -> None:
-        raise AssertionError(f'conflicting call reached the constructor: {registry!r}, {config!r}')
-
-    wrapped = reject_registry_options(init)
-
-    with pytest.raises(ValueError) as exc_info:
-        wrapped(registry=Registry(), config=None)
-
-    error_message = str(exc_info.value)
-    assert 'config' in error_message
-    assert 'Configure them on the registry instead' in error_message
 
 
 def test__resolve_registry__injected_registry__returns_non_owner() -> None:


### PR DESCRIPTION
## Summary

A caller-owned `Registry` owns the failure policy for every breaker it creates. Passing a bare
`Registry()` to the httpx2/httpx transports, the aiohttp middleware or the requests adapter
therefore downgrades them to exception-only classification: a returned `503` counts as a success,
and nothing anywhere reports it. The integration guides already carry that warning, but the
`registry` argument docstring — what the reader actually sees in the editor while writing the call
— did not. This adds it to all six `registry` arguments.

Docstrings only; no behaviour change, no signature change.

Two neighbouring sharp edges were considered and deliberately left alone:

- **Validating the injected registry's classifier at construction.** Rejected: it would require
  reading `Registry._classifier` (or growing a public property for it), and exception-only
  classification is a legitimate choice for a caller who raises on status upstream. An
  unsuppressable warning on a legitimate configuration is noise.
- **`reject_registry_options` rejecting on key presence rather than on a non-default value.**
  Kept as is: "you passed both" is predictable and value-independent, whereas comparing against
  defaults would make `initial_state=State.CLOSED` pass and `State.METRICS_ONLY` fail, and would
  need `classifier=None` to be distinguishable from "not passed".

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — docstring-only change, no new
      behaviour to cover; `uv run pytest --cov` stays at 100.00% (714 passed, 2 skipped)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes — `docs/integrations/*.md` already document
      this; no page changed, so `llms-full.txt` needs no regeneration
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Changed

- `httpx` and `httpx2` transports: Document bare caller-owned `Registry` behavior. Returned `503` responses count as successes.
- `aiohttp` `CircuitBreakerMiddleware`: Document that an explicit classifier is required to classify response statuses such as `503` as failures.
- `requests` `CircuitBreakerAdapter`: Document the failure policy of a caller-owned `Registry`.
- Shared registries using `HttpStatusClassifier`: Document that they are limited to HTTP clients. Non-HTTP results can raise `AttributeError`.
- Injected `Registry` options: Clarify that conflicting options raise `ValueError` and must be configured on the `Registry`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->