### PR TITLE
fix: stop counting caller-side HTTP errors as dependency failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   holding connections open) when the local pool is sized below your own burst.
   aiohttp excludes nothing by default, since it rejects malformed URLs before
   the middleware chain runs; the knob is there for the exceptions of
-  middlewares of your own.
+  middlewares of your own. The set is validated at construction — an entry that
+  is not an `Exception` subclass raises `TypeError` there instead of crashing
+  the classifier mid-incident, when the first real failure arrives.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A bug in your own code no longer opens the circuit of a healthy
+  dependency.** The HTTP integrations counted every exception raised inside the
+  guarded call as the dependency failing, including the ones the client library
+  raises for the *caller's* mistake: a scheme-less URL (`UnsupportedProtocol`)
+  or a local protocol violation (`LocalProtocolError`) in httpx2/httpx, a URL
+  or proxy URL with no host (`InvalidURL`) in requests. A burst of them was
+  enough to trip the breaker and start rejecting real traffic to a host that
+  was answering fine — and in `METRICS_ONLY` they polluted the very
+  baseline used to pick thresholds. Those exceptions now count as successes and
+  still propagate unchanged. `HttpStatusClassifier(excluded_exceptions=...)`
+  replaces the set: pass `()` for the old behaviour, or add `PoolTimeout` (kept
+  a failure by default — an exhausted pool usually means the dependency is
+  holding connections open) when the local pool is sized below your own burst.
+  aiohttp excludes nothing by default, since it rejects malformed URLs before
+  the middleware chain runs; the knob is there for the exceptions of
+  middlewares of your own.
+
 ### Changed
 
+- **`FailureClassifier.is_failure` now declares `exception: Exception | None`.**
+  The engine never passed a `BaseException` — cancellation and shutdown are
+  released without being classified — so the wider annotation invited
+  classifier authors to write cancellation handling that could never run. A
+  classifier still annotated `BaseException | None` keeps type-checking.
 - **A caller-owned `Registry` needs its own HTTP classifier.** Handing one to the
   httpx2/httpx transports, the aiohttp middleware or the requests adapter moves
   the failure policy to the registry, so a returned `503` counts as a success

--- a/docs/guides/failure-classification.md
+++ b/docs/guides/failure-classification.md
@@ -68,11 +68,23 @@ For HTTP clients, you do not need to write this yourself — the
 [httpx2](../integrations/httpx2.md), [httpx](../integrations/httpx.md),
 [aiohttp](../integrations/aiohttp.md), and
 [requests](../integrations/requests.md) integrations ship
-`HttpStatusClassifier`, which treats transport exceptions and the canonical
-retryable statuses (`429, 500, 502, 503, 504`) as failures.
+`HttpStatusClassifier`, which treats the canonical retryable statuses
+(`429, 500, 502, 503, 504`) and every non-excluded transport exception as
+failures.
 
-Errors the *caller* caused are excluded there for the same reason: a
+Errors the *caller* caused are excluded for the same reason as a `404`: a
 scheme-less URL or a local protocol violation is a bug in your code, not
 evidence that the dependency is unhealthy, and counting it would open the
-circuit of a host that is answering fine. Each integration excludes its own
-library's types and takes `excluded_exceptions=(...)` to replace that set.
+circuit of a host that is answering fine. The default set differs per
+integration, because each client library raises different things inside the
+guarded call:
+
+| Integration | Excluded by default |
+|---|---|
+| [httpx2](../integrations/httpx2.md), [httpx](../integrations/httpx.md) | `UnsupportedProtocol`, `LocalProtocolError` |
+| [requests](../integrations/requests.md) | `InvalidURL` (and its `InvalidProxyURL` subclass) |
+| [aiohttp](../integrations/aiohttp.md) | nothing — it rejects malformed URLs before the middleware chain runs, so every handler exception counts unless you exclude it |
+
+All four take `excluded_exceptions=(...)` to replace that set — `()` counts
+every exception as a failure. Entries must be `Exception` subclasses;
+anything else raises `TypeError` at construction.

--- a/docs/guides/failure-classification.md
+++ b/docs/guides/failure-classification.md
@@ -22,14 +22,16 @@ whose `503` status means the dependency is unhealthy.
 
 A classifier implements one method. The `result`/`exception` pair is mutually
 exclusive: when `exception` is not `None` the call raised; otherwise `result`
-holds the return value.
+holds the return value. `exception` is always an `Exception` — a
+`BaseException` such as `CancelledError` says nothing about the dependency, so
+the breaker releases the call without classifying it.
 
 ```python
 from interlock import CircuitBreaker
 
 
 class StatusClassifier:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if exception is not None:
             return True
         return getattr(result, 'status_code', 200) >= 500
@@ -50,11 +52,15 @@ Encode that by treating only the exceptions you care about as failures:
 
 ```python
 class IgnoreNotFound:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if isinstance(exception, NotFoundError):
             return False  # expected, not a dependency problem
         return exception is not None
 ```
+
+An ignored exception is recorded as a **success** — the sliding window has only
+two outcomes — and still propagates to the caller. It therefore dilutes the
+failure rate rather than being invisible to it.
 
 ## HTTP out of the box
 
@@ -64,3 +70,9 @@ For HTTP clients, you do not need to write this yourself — the
 [requests](../integrations/requests.md) integrations ship
 `HttpStatusClassifier`, which treats transport exceptions and the canonical
 retryable statuses (`429, 500, 502, 503, 504`) as failures.
+
+Errors the *caller* caused are excluded there for the same reason: a
+scheme-less URL or a local protocol violation is a bug in your code, not
+evidence that the dependency is unhealthy, and counting it would open the
+circuit of a host that is answering fine. Each integration excludes its own
+library's types and takes `excluded_exceptions=(...)` to replace that set.

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -133,7 +133,18 @@ state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout)
 By default a response counts as a failure when its status is in the canonical
 retryable set (`429, 500, 502, 503, 504`) and any exception raised while
 sending (connect/read errors) is a failure; `4xx` client mistakes like `404`
-are successes. Change the statuses, or the whole policy:
+are successes.
+
+Nothing is excluded by default: aiohttp rejects a malformed or non-HTTP URL
+before the middleware chain runs, so no caller-side error of its own reaches
+the classifier. Middlewares of your own that sit inside this one are the
+exception — an auth middleware refusing to sign a request is your bug, not the
+dependency's, so exclude what it raises with
+`excluded_exceptions=(MissingCredentials,)`. An excluded exception is recorded
+as a *success*, since the sliding window has no third outcome, and still
+propagates to the caller.
+
+Change the statuses, or the whole policy:
 
 ```python
 from interlock import Config

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -165,8 +165,31 @@ The default `HttpStatusClassifier` counts these as failures:
 - response statuses `429, 500, 502, 503, 504`.
 
 Other responses, including caller errors such as `404`, count as successes.
+So are the transport exceptions httpx raises for the *caller's* own bug —
+`UnsupportedProtocol` (a scheme-less or unsupported URL) and
+`LocalProtocolError` (the local side violating HTTP). They are deterministic
+and say nothing about the dependency, so a burst of them must not open the
+circuit of a healthy host. They still propagate to the caller unchanged.
+
+`PoolTimeout` is *not* excluded: an exhausted pool is usually the dependency
+holding connections open, and shedding load then is the point. Exclude it
+explicitly when your pool is sized below your own burst:
+
+```python
+import httpx
+from interlock.integrations.httpx import HttpStatusClassifier
+
+classifier = HttpStatusClassifier(
+    excluded_exceptions=(httpx.LocalProtocolError, httpx.UnsupportedProtocol, httpx.PoolTimeout),
+)
+```
+
+`excluded_exceptions` replaces the default set — pass `()` to count every
+exception as a failure. An excluded exception is recorded as a *success*: the
+sliding window has no third outcome.
+
 Pass `HttpStatusClassifier(failure_statuses={...})` or another
-`FailureClassifier` to change the policy.
+`FailureClassifier` to change the status side of the policy.
 
 ## Streaming responses
 

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -167,13 +167,40 @@ when all guarded clients are synchronous).
 
 By default the transport uses `HttpStatusClassifier`:
 
-- any transport exception (connect/read errors) → failure;
+- a transport exception (connect/read errors) → failure;
 - a response with status `429, 500, 502, 503, 504` → failure;
-- everything else, including `4xx` client errors like `404`, → success.
+- everything else, including `4xx` client errors like `404`, → success;
+- `UnsupportedProtocol` and `LocalProtocolError` → success.
 
 This mirrors the retryable set used by urllib3, AWS and Google clients.
 Permanent `5xx` (`501`, `505`) are deliberately excluded — retrying or tripping
 the breaker cannot fix a contract or protocol error.
+
+The two excluded exceptions are the caller's own bug — a scheme-less or
+unsupported URL, and the local side violating HTTP. They are deterministic and
+say nothing about the dependency, so a burst of them must not open the circuit
+of a healthy host; they still propagate to the caller unchanged.
+
+`PoolTimeout` is *not* excluded: an exhausted pool is usually the dependency
+holding connections open, and shedding load then is the point. Exclude it
+explicitly when your pool is sized below your own burst:
+
+```python
+import httpx2
+from interlock.integrations.httpx2 import HttpStatusClassifier
+
+classifier = HttpStatusClassifier(
+    excluded_exceptions=(
+        httpx2.LocalProtocolError,
+        httpx2.UnsupportedProtocol,
+        httpx2.PoolTimeout,
+    ),
+)
+```
+
+`excluded_exceptions` replaces the default set — pass `()` to count every
+exception as a failure. An excluded exception is recorded as a *success*: the
+sliding window has no third outcome.
 
 ## Tuning
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -36,10 +36,13 @@ Every integration follows the same rules, so learning one means knowing all:
   deploy a new integration with `CLOSED` after tuning thresholds.
 - **One classification model.** Responses are classified by an
   `HttpStatusClassifier` — by default the canonical retryable set
-  (`429, 500, 502, 503, 504`) plus any transport exception counts as a
-  failure, while `4xx` client mistakes do not. Pass
-  `HttpStatusClassifier(failure_statuses={...})` or your own
-  `FailureClassifier` to change the policy.
+  (`429, 500, 502, 503, 504`) plus a transport exception counts as a
+  failure, while `4xx` client mistakes do not. Exceptions the *caller* caused
+  (a malformed URL, a local protocol violation) are excluded wherever the
+  client library raises them inside the guarded call: they say nothing about
+  the dependency's health. Pass
+  `HttpStatusClassifier(failure_statuses={...}, excluded_exceptions=(...))` or
+  your own `FailureClassifier` to change the policy.
 - **One rejection signal.** An open circuit always raises
   [`CircuitOpenError`](../reference.md) — carrying the breaker name, a
   `retry_after` estimate and the last recorded failure — *before* a

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -36,11 +36,13 @@ Every integration follows the same rules, so learning one means knowing all:
   deploy a new integration with `CLOSED` after tuning thresholds.
 - **One classification model.** Responses are classified by an
   `HttpStatusClassifier` — by default the canonical retryable set
-  (`429, 500, 502, 503, 504`) plus a transport exception counts as a
-  failure, while `4xx` client mistakes do not. Exceptions the *caller* caused
-  (a malformed URL, a local protocol violation) are excluded wherever the
-  client library raises them inside the guarded call: they say nothing about
-  the dependency's health. Pass
+  (`429, 500, 502, 503, 504`) plus every non-excluded transport exception
+  counts as a failure, while `4xx` client mistakes do not. Exceptions the
+  *caller* caused say nothing about the dependency's health, so each
+  integration excludes the ones its own library raises inside the guarded
+  call: `UnsupportedProtocol` / `LocalProtocolError` for httpx2 and httpx,
+  `InvalidURL` for requests, nothing for aiohttp (it rejects malformed URLs
+  before the middleware chain runs). Pass
   `HttpStatusClassifier(failure_statuses={...}, excluded_exceptions=(...))` or
   your own `FailureClassifier` to change the policy.
 - **One rejection signal.** An open circuit always raises

--- a/docs/integrations/llm.md
+++ b/docs/integrations/llm.md
@@ -25,7 +25,7 @@ class LLMFailureClassifier:
 
     _FAILURE_STATUSES = frozenset({429, 500, 502, 503, 504, 529})
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if exception is None:
             return False
         if isinstance(exception, anthropic.APIStatusError):

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -135,9 +135,19 @@ to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 ## Failure policy
 
 By default a response counts as a failure when its status is in the canonical
-retryable set (`429, 500, 502, 503, 504`) and any transport exception
+retryable set (`429, 500, 502, 503, 504`) and a transport exception
 (connect/read errors) is a failure; `4xx` client mistakes like `404` are
-successes. Change the statuses, or the whole policy:
+successes.
+
+`InvalidURL` — raised by the adapter when the request or proxy URL carries no
+host, and the parent of `InvalidProxyURL` — is a success too. It is the
+caller's own bug: deterministic, and no evidence about the dependency, so a
+burst of them must not open the circuit of a healthy host. The exception still
+propagates to the caller. Replace that set with `excluded_exceptions=(...)`,
+or pass `()` to count every exception as a failure; an excluded exception is
+recorded as a *success*, since the sliding window has no third outcome.
+
+Change the statuses, or the whole policy:
 
 ```python
 from interlock import Config

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -931,7 +931,7 @@ breaker = pybreaker.CircuitBreaker(exclude=[ValueError])
 ```python
 # after — interlock
 class IgnoreValueError:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if isinstance(exception, ValueError):
             return False  # business error, not a dependency problem
         return exception is not None
@@ -1084,7 +1084,7 @@ circuitbreaker's `expected_exception` is the *inverse* of pybreaker's
 
 ```python
 class OnlyConnectionError:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         return isinstance(exception, ConnectionError)
 ```
 
@@ -1723,14 +1723,16 @@ whose `503` status means the dependency is unhealthy.
 
 A classifier implements one method. The `result`/`exception` pair is mutually
 exclusive: when `exception` is not `None` the call raised; otherwise `result`
-holds the return value.
+holds the return value. `exception` is always an `Exception` — a
+`BaseException` such as `CancelledError` says nothing about the dependency, so
+the breaker releases the call without classifying it.
 
 ```python
 from interlock import CircuitBreaker
 
 
 class StatusClassifier:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if exception is not None:
             return True
         return getattr(result, 'status_code', 200) >= 500
@@ -1751,11 +1753,15 @@ Encode that by treating only the exceptions you care about as failures:
 
 ```python
 class IgnoreNotFound:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if isinstance(exception, NotFoundError):
             return False  # expected, not a dependency problem
         return exception is not None
 ```
+
+An ignored exception is recorded as a **success** — the sliding window has only
+two outcomes — and still propagates to the caller. It therefore dilutes the
+failure rate rather than being invisible to it.
 
 ## HTTP out of the box
 
@@ -1765,6 +1771,12 @@ For HTTP clients, you do not need to write this yourself — the
 [requests](../integrations/requests.md) integrations ship
 `HttpStatusClassifier`, which treats transport exceptions and the canonical
 retryable statuses (`429, 500, 502, 503, 504`) as failures.
+
+Errors the *caller* caused are excluded there for the same reason: a
+scheme-less URL or a local protocol violation is a bug in your code, not
+evidence that the dependency is unhealthy, and counting it would open the
+circuit of a host that is answering fine. Each integration excludes its own
+library's types and takes `excluded_exceptions=(...)` to replace that set.
 
 ---
 
@@ -2457,10 +2469,13 @@ Every integration follows the same rules, so learning one means knowing all:
   deploy a new integration with `CLOSED` after tuning thresholds.
 - **One classification model.** Responses are classified by an
   `HttpStatusClassifier` — by default the canonical retryable set
-  (`429, 500, 502, 503, 504`) plus any transport exception counts as a
-  failure, while `4xx` client mistakes do not. Pass
-  `HttpStatusClassifier(failure_statuses={...})` or your own
-  `FailureClassifier` to change the policy.
+  (`429, 500, 502, 503, 504`) plus a transport exception counts as a
+  failure, while `4xx` client mistakes do not. Exceptions the *caller* caused
+  (a malformed URL, a local protocol violation) are excluded wherever the
+  client library raises them inside the guarded call: they say nothing about
+  the dependency's health. Pass
+  `HttpStatusClassifier(failure_statuses={...}, excluded_exceptions=(...))` or
+  your own `FailureClassifier` to change the policy.
 - **One rejection signal.** An open circuit always raises
   [`CircuitOpenError`](../reference.md) — carrying the breaker name, a
   `retry_after` estimate and the last recorded failure — *before* a
@@ -2886,13 +2901,40 @@ when all guarded clients are synchronous).
 
 By default the transport uses `HttpStatusClassifier`:
 
-- any transport exception (connect/read errors) → failure;
+- a transport exception (connect/read errors) → failure;
 - a response with status `429, 500, 502, 503, 504` → failure;
-- everything else, including `4xx` client errors like `404`, → success.
+- everything else, including `4xx` client errors like `404`, → success;
+- `UnsupportedProtocol` and `LocalProtocolError` → success.
 
 This mirrors the retryable set used by urllib3, AWS and Google clients.
 Permanent `5xx` (`501`, `505`) are deliberately excluded — retrying or tripping
 the breaker cannot fix a contract or protocol error.
+
+The two excluded exceptions are the caller's own bug — a scheme-less or
+unsupported URL, and the local side violating HTTP. They are deterministic and
+say nothing about the dependency, so a burst of them must not open the circuit
+of a healthy host; they still propagate to the caller unchanged.
+
+`PoolTimeout` is *not* excluded: an exhausted pool is usually the dependency
+holding connections open, and shedding load then is the point. Exclude it
+explicitly when your pool is sized below your own burst:
+
+```python
+import httpx2
+from interlock.integrations.httpx2 import HttpStatusClassifier
+
+classifier = HttpStatusClassifier(
+    excluded_exceptions=(
+        httpx2.LocalProtocolError,
+        httpx2.UnsupportedProtocol,
+        httpx2.PoolTimeout,
+    ),
+)
+```
+
+`excluded_exceptions` replaces the default set — pass `()` to count every
+exception as a failure. An excluded exception is recorded as a *success*: the
+sliding window has no third outcome.
 
 ## Tuning
 
@@ -3084,8 +3126,31 @@ The default `HttpStatusClassifier` counts these as failures:
 - response statuses `429, 500, 502, 503, 504`.
 
 Other responses, including caller errors such as `404`, count as successes.
+So are the transport exceptions httpx raises for the *caller's* own bug —
+`UnsupportedProtocol` (a scheme-less or unsupported URL) and
+`LocalProtocolError` (the local side violating HTTP). They are deterministic
+and say nothing about the dependency, so a burst of them must not open the
+circuit of a healthy host. They still propagate to the caller unchanged.
+
+`PoolTimeout` is *not* excluded: an exhausted pool is usually the dependency
+holding connections open, and shedding load then is the point. Exclude it
+explicitly when your pool is sized below your own burst:
+
+```python
+import httpx
+from interlock.integrations.httpx import HttpStatusClassifier
+
+classifier = HttpStatusClassifier(
+    excluded_exceptions=(httpx.LocalProtocolError, httpx.UnsupportedProtocol, httpx.PoolTimeout),
+)
+```
+
+`excluded_exceptions` replaces the default set — pass `()` to count every
+exception as a failure. An excluded exception is recorded as a *success*: the
+sliding window has no third outcome.
+
 Pass `HttpStatusClassifier(failure_statuses={...})` or another
-`FailureClassifier` to change the policy.
+`FailureClassifier` to change the status side of the policy.
 
 ## Streaming responses
 
@@ -3257,7 +3322,18 @@ state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout)
 By default a response counts as a failure when its status is in the canonical
 retryable set (`429, 500, 502, 503, 504`) and any exception raised while
 sending (connect/read errors) is a failure; `4xx` client mistakes like `404`
-are successes. Change the statuses, or the whole policy:
+are successes.
+
+Nothing is excluded by default: aiohttp rejects a malformed or non-HTTP URL
+before the middleware chain runs, so no caller-side error of its own reaches
+the classifier. Middlewares of your own that sit inside this one are the
+exception — an auth middleware refusing to sign a request is your bug, not the
+dependency's, so exclude what it raises with
+`excluded_exceptions=(MissingCredentials,)`. An excluded exception is recorded
+as a *success*, since the sliding window has no third outcome, and still
+propagates to the caller.
+
+Change the statuses, or the whole policy:
 
 ```python
 from interlock import Config
@@ -3422,9 +3498,19 @@ to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 ## Failure policy
 
 By default a response counts as a failure when its status is in the canonical
-retryable set (`429, 500, 502, 503, 504`) and any transport exception
+retryable set (`429, 500, 502, 503, 504`) and a transport exception
 (connect/read errors) is a failure; `4xx` client mistakes like `404` are
-successes. Change the statuses, or the whole policy:
+successes.
+
+`InvalidURL` — raised by the adapter when the request or proxy URL carries no
+host, and the parent of `InvalidProxyURL` — is a success too. It is the
+caller's own bug: deterministic, and no evidence about the dependency, so a
+burst of them must not open the circuit of a healthy host. The exception still
+propagates to the caller. Replace that set with `excluded_exceptions=(...)`,
+or pass `()` to count every exception as a failure; an excluded exception is
+recorded as a *success*, since the sliding window has no third outcome.
+
+Change the statuses, or the whole policy:
 
 ```python
 from interlock import Config
@@ -3480,7 +3566,7 @@ class LLMFailureClassifier:
 
     _FAILURE_STATUSES = frozenset({429, 500, 502, 503, 504, 529})
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if exception is None:
             return False
         if isinstance(exception, anthropic.APIStatusError):
@@ -4282,7 +4368,9 @@ Implement any of these to swap a core behaviour:
   `expected_version` (version-fenced CAS); every write carries a `ttl`.
   Mechanism only — threshold policy stays in the core. `AsyncStorage` is the
   awaitable mirror. See the [Redis integration](integrations/redis.md).
-- **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`. See
+- **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`, where
+  `exception` is an `Exception` or `None` — cancellation and shutdown are
+  released without being classified. See
   [Failure classification](guides/failure-classification.md).
 - **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`,
   plus `on_storage_degraded` / `on_storage_recovered` /
@@ -4313,9 +4401,11 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
-  exceptions and statuses `429, 500, 502, 503, 504` (override the set via
-  `failure_statuses`).
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  fails on transport exceptions and statuses `429, 500, 502, 503, 504`
+  (override the set via `failure_statuses`). `UnsupportedProtocol` and
+  `LocalProtocolError` are caller-side and count as successes; replace that set
+  via `excluded_exceptions`.
 
 Both transports expose their per-host `registry`; `close()` / `aclose()` release
 the wrapped transport and every breaker in that registry. See the
@@ -4329,8 +4419,9 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
-  exceptions and statuses `429, 500, 502, 503, 504`.
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  same policy, including the caller-side `UnsupportedProtocol` /
+  `LocalProtocolError` exclusions.
 
 Both transports expose their per-host `registry`, preserve streaming responses,
 and release the wrapped transport and every breaker on `close()` / `aclose()`.
@@ -4344,8 +4435,9 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
   initial_state=State.CLOSED, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
-- **`HttpStatusClassifier(failure_statuses=None)`** — same canonical HTTP
-  policy, reading `ClientResponse.status`.
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  same canonical HTTP policy, reading `ClientResponse.status`; nothing is
+  excluded by default (aiohttp rejects bad URLs before the middleware runs).
 
 It exposes its `registry`; call `await middleware.aclose()` during application
 shutdown. See the [aiohttp integration](integrations/aiohttp.md).
@@ -4358,8 +4450,9 @@ Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
   initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
-- **`HttpStatusClassifier(failure_statuses=None)`** — same policy, reading
-  `Response.status_code`.
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  same policy, reading `Response.status_code`; the caller-side `InvalidURL`
+  counts as a success.
 
 It exposes its `registry`; closing the adapter or owning session releases both
 the connection pools and breaker resources. See the

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1769,14 +1769,26 @@ For HTTP clients, you do not need to write this yourself — the
 [httpx2](../integrations/httpx2.md), [httpx](../integrations/httpx.md),
 [aiohttp](../integrations/aiohttp.md), and
 [requests](../integrations/requests.md) integrations ship
-`HttpStatusClassifier`, which treats transport exceptions and the canonical
-retryable statuses (`429, 500, 502, 503, 504`) as failures.
+`HttpStatusClassifier`, which treats the canonical retryable statuses
+(`429, 500, 502, 503, 504`) and every non-excluded transport exception as
+failures.
 
-Errors the *caller* caused are excluded there for the same reason: a
+Errors the *caller* caused are excluded for the same reason as a `404`: a
 scheme-less URL or a local protocol violation is a bug in your code, not
 evidence that the dependency is unhealthy, and counting it would open the
-circuit of a host that is answering fine. Each integration excludes its own
-library's types and takes `excluded_exceptions=(...)` to replace that set.
+circuit of a host that is answering fine. The default set differs per
+integration, because each client library raises different things inside the
+guarded call:
+
+| Integration | Excluded by default |
+|---|---|
+| [httpx2](../integrations/httpx2.md), [httpx](../integrations/httpx.md) | `UnsupportedProtocol`, `LocalProtocolError` |
+| [requests](../integrations/requests.md) | `InvalidURL` (and its `InvalidProxyURL` subclass) |
+| [aiohttp](../integrations/aiohttp.md) | nothing — it rejects malformed URLs before the middleware chain runs, so every handler exception counts unless you exclude it |
+
+All four take `excluded_exceptions=(...)` to replace that set — `()` counts
+every exception as a failure. Entries must be `Exception` subclasses;
+anything else raises `TypeError` at construction.
 
 ---
 
@@ -2469,11 +2481,13 @@ Every integration follows the same rules, so learning one means knowing all:
   deploy a new integration with `CLOSED` after tuning thresholds.
 - **One classification model.** Responses are classified by an
   `HttpStatusClassifier` — by default the canonical retryable set
-  (`429, 500, 502, 503, 504`) plus a transport exception counts as a
-  failure, while `4xx` client mistakes do not. Exceptions the *caller* caused
-  (a malformed URL, a local protocol violation) are excluded wherever the
-  client library raises them inside the guarded call: they say nothing about
-  the dependency's health. Pass
+  (`429, 500, 502, 503, 504`) plus every non-excluded transport exception
+  counts as a failure, while `4xx` client mistakes do not. Exceptions the
+  *caller* caused say nothing about the dependency's health, so each
+  integration excludes the ones its own library raises inside the guarded
+  call: `UnsupportedProtocol` / `LocalProtocolError` for httpx2 and httpx,
+  `InvalidURL` for requests, nothing for aiohttp (it rejects malformed URLs
+  before the middleware chain runs). Pass
   `HttpStatusClassifier(failure_statuses={...}, excluded_exceptions=(...))` or
   your own `FailureClassifier` to change the policy.
 - **One rejection signal.** An open circuit always raises
@@ -4401,7 +4415,7 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   fails on transport exceptions and statuses `429, 500, 502, 503, 504`
   (override the set via `failure_statuses`). `UnsupportedProtocol` and
   `LocalProtocolError` are caller-side and count as successes; replace that set
@@ -4419,7 +4433,7 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, including the caller-side `UnsupportedProtocol` /
   `LocalProtocolError` exclusions.
 
@@ -4435,7 +4449,7 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
   initial_state=State.CLOSED, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same canonical HTTP policy, reading `ClientResponse.status`; nothing is
   excluded by default (aiohttp rejects bad URLs before the middleware runs).
 
@@ -4450,7 +4464,7 @@ Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
   initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, reading `Response.status_code`; the caller-side `InvalidURL`
   counts as a success.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -108,7 +108,7 @@ breaker = pybreaker.CircuitBreaker(exclude=[ValueError])
 ```python
 # after — interlock
 class IgnoreValueError:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         if isinstance(exception, ValueError):
             return False  # business error, not a dependency problem
         return exception is not None
@@ -261,7 +261,7 @@ circuitbreaker's `expected_exception` is the *inverse* of pybreaker's
 
 ```python
 class OnlyConnectionError:
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         return isinstance(exception, ConnectionError)
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -137,7 +137,9 @@ Implement any of these to swap a core behaviour:
   `expected_version` (version-fenced CAS); every write carries a `ttl`.
   Mechanism only — threshold policy stays in the core. `AsyncStorage` is the
   awaitable mirror. See the [Redis integration](integrations/redis.md).
-- **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`. See
+- **`FailureClassifier`** — `is_failure(*, result, exception) -> bool`, where
+  `exception` is an `Exception` or `None` — cancellation and shutdown are
+  released without being classified. See
   [Failure classification](guides/failure-classification.md).
 - **`EventListener`** — `on_state_change`, `on_call`, `on_rejected`, `on_reset`,
   plus `on_storage_degraded` / `on_storage_recovered` /
@@ -168,9 +170,11 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
-  exceptions and statuses `429, 500, 502, 503, 504` (override the set via
-  `failure_statuses`).
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  fails on transport exceptions and statuses `429, 500, 502, 503, 504`
+  (override the set via `failure_statuses`). `UnsupportedProtocol` and
+  `LocalProtocolError` are caller-side and count as successes; replace that set
+  via `excluded_exceptions`.
 
 Both transports expose their per-host `registry`; `close()` / `aclose()` release
 the wrapped transport and every breaker in that registry. See the
@@ -184,8 +188,9 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None)`** — fails on transport
-  exceptions and statuses `429, 500, 502, 503, 504`.
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  same policy, including the caller-side `UnsupportedProtocol` /
+  `LocalProtocolError` exclusions.
 
 Both transports expose their per-host `registry`, preserve streaming responses,
 and release the wrapped transport and every breaker on `close()` / `aclose()`.
@@ -199,8 +204,9 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
   initial_state=State.CLOSED, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
-- **`HttpStatusClassifier(failure_statuses=None)`** — same canonical HTTP
-  policy, reading `ClientResponse.status`.
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  same canonical HTTP policy, reading `ClientResponse.status`; nothing is
+  excluded by default (aiohttp rejects bad URLs before the middleware runs).
 
 It exposes its `registry`; call `await middleware.aclose()` during application
 shutdown. See the [aiohttp integration](integrations/aiohttp.md).
@@ -213,8 +219,9 @@ Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
   initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
-- **`HttpStatusClassifier(failure_statuses=None)`** — same policy, reading
-  `Response.status_code`.
+- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+  same policy, reading `Response.status_code`; the caller-side `InvalidURL`
+  counts as a success.
 
 It exposes its `registry`; closing the adapter or owning session releases both
 the connection pools and breaker resources. See the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -170,7 +170,7 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   fails on transport exceptions and statuses `429, 500, 502, 503, 504`
   (override the set via `failure_statuses`). `UnsupportedProtocol` and
   `LocalProtocolError` are caller-side and count as successes; replace that set
@@ -188,7 +188,7 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
   initial_state=State.CLOSED, classifier=None, listener=None)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, including the caller-side `UnsupportedProtocol` /
   `LocalProtocolError` exclusions.
 
@@ -204,7 +204,7 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
   initial_state=State.CLOSED, classifier=None, listener=None)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same canonical HTTP policy, reading `ClientResponse.status`; nothing is
   excluded by default (aiohttp rejects bad URLs before the middleware runs).
 
@@ -219,7 +219,7 @@ Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
   initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
-- **`HttpStatusClassifier(failure_statuses=None, excluded_exceptions=None)`** —
+- **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, reading `Response.status_code`; the caller-side `InvalidURL`
   counts as a success.
 

--- a/interlock/_classify.py
+++ b/interlock/_classify.py
@@ -11,7 +11,7 @@ __all__ = ('DefaultFailureClassifier',)
 class DefaultFailureClassifier:
     """Counts a call as a failure exactly when it raised."""
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:  # noqa: ARG002
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:  # noqa: ARG002
         """Return whether a completed call counts as a failure.
 
         Args:

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -54,30 +54,52 @@ _FAILURE_STATUSES = frozenset(
     }
 )
 
+# Empty on purpose: aiohttp raises its caller-side errors — a malformed or
+# non-HTTP URL — before the middleware chain runs, so none of them can reach
+# the classifier and be misread as the dependency failing.
+_EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = ()
+
 
 class HttpStatusClassifier:
     """Counts handler exceptions and unhealthy-status responses as failures.
 
     A returned response is a failure when its status is in ``failure_statuses``
-    — by default the canonical retryable set (``429, 500, 502, 503, 504``);
-    any raised exception is a failure. Other responses — including ``4xx``
-    client mistakes like ``404`` — are successes, so they never trip the
-    breaker.
+    — by default the canonical retryable set (``429, 500, 502, 503, 504``); a
+    raised exception is a failure unless it is one of ``excluded_exceptions``,
+    which is empty by default. Other responses — including ``4xx`` client
+    mistakes like ``404`` — are successes, so they never trip the breaker.
+
+    aiohttp rejects a malformed or non-HTTP URL before the middleware chain
+    runs, so no caller-side error of its own reaches this classifier — hence
+    the empty default. Exclude the exceptions raised by middlewares of your
+    own that sit inside this one: they are the caller's, not the dependency's.
+
+    An excluded exception still propagates to the caller; it is recorded as a
+    success, since the window has no third outcome.
 
     Args:
         failure_statuses: Statuses to count as failures instead of the
             canonical set.
+        excluded_exceptions: Exception types to count as successes.
     """
 
-    def __init__(self, *, failure_statuses: Iterable[int] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        failure_statuses: Iterable[int] | None = None,
+        excluded_exceptions: Iterable[type[Exception]] | None = None,
+    ) -> None:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
+        self._excluded_exceptions = (
+            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
+        )
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""
         if exception is not None:
-            return True
+            return not isinstance(exception, self._excluded_exceptions)
 
         return cast('ClientResponse', result).status in self._failure_statuses
 

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -60,6 +60,28 @@ _FAILURE_STATUSES = frozenset(
 _EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = ()
 
 
+def _exception_types(
+    excluded: Iterable[type[Exception]] | None,
+) -> tuple[type[Exception], ...]:
+    """Freeze the exclusion set, rejecting entries that can never be classified.
+
+    Raises:
+        TypeError: If an entry is not an ``Exception`` subclass.
+    """
+    if excluded is None:
+        return _EXCLUDED_EXCEPTIONS
+
+    types = tuple(excluded)
+    # The annotation is a promise, not a guarantee: an untyped caller can still
+    # pass a string. Checking now beats an ``isinstance`` TypeError raised from
+    # inside the guarded call, on the first real failure.
+    for entry in cast('tuple[object, ...]', types):
+        if not (isinstance(entry, type) and issubclass(entry, Exception)):
+            raise TypeError(f'excluded_exceptions must hold Exception subclasses, got: {entry!r}')
+
+    return types
+
+
 class HttpStatusClassifier:
     """Counts handler exceptions and unhealthy-status responses as failures.
 
@@ -81,6 +103,10 @@ class HttpStatusClassifier:
         failure_statuses: Statuses to count as failures instead of the
             canonical set.
         excluded_exceptions: Exception types to count as successes.
+
+    Raises:
+        TypeError: If ``excluded_exceptions`` holds anything but ``Exception``
+            subclasses.
     """
 
     def __init__(
@@ -92,9 +118,7 @@ class HttpStatusClassifier:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
-        self._excluded_exceptions = (
-            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
-        )
+        self._excluded_exceptions = _exception_types(excluded_exceptions)
 
     def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -17,8 +17,9 @@ Responses are returned unchanged, preserving httpx's streaming semantics.
 
 By default a response counts as a failure when its status is one of
 ``HttpStatusClassifier``'s — the canonical retryable set ``429, 500, 502, 503,
-504`` — and any transport exception (connect/read errors) is a failure. Supply
-a custom ``classifier`` to change that policy.
+504`` — and a transport exception (connect/read errors) is a failure unless it
+is caller-side (a malformed URL, a local protocol violation). Supply a custom
+``classifier`` to change that policy.
 """
 
 import http
@@ -27,7 +28,14 @@ from contextlib import AsyncExitStack, ExitStack
 from types import TracebackType
 from typing import Self, cast
 
-from httpx import AsyncBaseTransport, BaseTransport, Request, Response
+from httpx import (
+    AsyncBaseTransport,
+    BaseTransport,
+    LocalProtocolError,
+    Request,
+    Response,
+    UnsupportedProtocol,
+)
 
 from interlock.config import Config
 from interlock.integrations._registry import reject_registry_options, resolve_registry
@@ -55,30 +63,58 @@ _FAILURE_STATUSES = frozenset(
     }
 )
 
+# httpx raises these from inside the transport, but they are the caller's own
+# fault: a scheme-less or unsupported URL, and a local violation of the HTTP
+# protocol. Both are deterministic — no retry and no open circuit can make them
+# succeed — and say nothing about the dependency, so counting them would trip
+# the breaker of a perfectly healthy host. ``PoolTimeout`` is deliberately not
+# here: an exhausted pool is usually the dependency holding connections open,
+# and shedding load then is the point.
+_EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = (
+    LocalProtocolError,
+    UnsupportedProtocol,
+)
+
 
 class HttpStatusClassifier:
     """Counts transport exceptions and unhealthy-status responses as failures.
 
     A returned response is a failure when its status is in ``failure_statuses``
-    — by default the canonical retryable set (``429, 500, 502, 503, 504``);
-    any raised exception is a failure. Other responses — including ``4xx``
-    client mistakes like ``404`` — are successes, so they never trip the
-    breaker.
+    — by default the canonical retryable set (``429, 500, 502, 503, 504``); a
+    raised exception is a failure unless it is one of ``excluded_exceptions``,
+    by default the caller-side errors ``LocalProtocolError`` and
+    ``UnsupportedProtocol``. Other responses — including ``4xx`` client
+    mistakes like ``404`` — are successes, so they never trip the breaker.
+
+    An excluded exception still propagates to the caller; it is recorded as a
+    success, since the window has no third outcome.
 
     Args:
         failure_statuses: Statuses to count as failures instead of the
             canonical set.
+        excluded_exceptions: Exception types to count as successes instead of
+            the caller-side default. Pass ``()`` to count every exception as a
+            failure, or add ``PoolTimeout`` when the local pool is sized below
+            the caller's own burst.
     """
 
-    def __init__(self, *, failure_statuses: Iterable[int] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        failure_statuses: Iterable[int] | None = None,
+        excluded_exceptions: Iterable[type[Exception]] | None = None,
+    ) -> None:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
+        self._excluded_exceptions = (
+            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
+        )
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""
         if exception is not None:
-            return True
+            return not isinstance(exception, self._excluded_exceptions)
 
         return cast('Response', result).status_code in self._failure_statuses
 

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -76,6 +76,28 @@ _EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = (
 )
 
 
+def _exception_types(
+    excluded: Iterable[type[Exception]] | None,
+) -> tuple[type[Exception], ...]:
+    """Freeze the exclusion set, rejecting entries that can never be classified.
+
+    Raises:
+        TypeError: If an entry is not an ``Exception`` subclass.
+    """
+    if excluded is None:
+        return _EXCLUDED_EXCEPTIONS
+
+    types = tuple(excluded)
+    # The annotation is a promise, not a guarantee: an untyped caller can still
+    # pass a string. Checking now beats an ``isinstance`` TypeError raised from
+    # inside the guarded call, on the first real failure.
+    for entry in cast('tuple[object, ...]', types):
+        if not (isinstance(entry, type) and issubclass(entry, Exception)):
+            raise TypeError(f'excluded_exceptions must hold Exception subclasses, got: {entry!r}')
+
+    return types
+
+
 class HttpStatusClassifier:
     """Counts transport exceptions and unhealthy-status responses as failures.
 
@@ -96,6 +118,10 @@ class HttpStatusClassifier:
             the caller-side default. Pass ``()`` to count every exception as a
             failure, or add ``PoolTimeout`` when the local pool is sized below
             the caller's own burst.
+
+    Raises:
+        TypeError: If ``excluded_exceptions`` holds anything but ``Exception``
+            subclasses.
     """
 
     def __init__(
@@ -107,9 +133,7 @@ class HttpStatusClassifier:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
-        self._excluded_exceptions = (
-            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
-        )
+        self._excluded_exceptions = _exception_types(excluded_exceptions)
 
     def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -16,8 +16,9 @@ no decorators in user code. Each host gets its own breaker (a slow or failing
 
 By default a response counts as a failure when its status is one of
 ``HttpStatusClassifier``'s — the canonical retryable set ``429, 500, 502, 503,
-504`` — and any transport exception (connect/read errors) is a failure. Supply
-a custom ``classifier`` to change that policy.
+504`` — and a transport exception (connect/read errors) is a failure unless it
+is caller-side (a malformed URL, a local protocol violation). Supply a custom
+``classifier`` to change that policy.
 """
 
 import http
@@ -26,7 +27,14 @@ from contextlib import AsyncExitStack, ExitStack
 from types import TracebackType
 from typing import Self, cast
 
-from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
+from httpx2 import (
+    AsyncBaseTransport,
+    BaseTransport,
+    LocalProtocolError,
+    Request,
+    Response,
+    UnsupportedProtocol,
+)
 
 from interlock.config import Config
 from interlock.integrations._registry import reject_registry_options, resolve_registry
@@ -54,30 +62,58 @@ _FAILURE_STATUSES = frozenset(
     }
 )
 
+# httpx2 raises these from inside the transport, but they are the caller's own
+# fault: a scheme-less or unsupported URL, and a local violation of the HTTP
+# protocol. Both are deterministic — no retry and no open circuit can make them
+# succeed — and say nothing about the dependency, so counting them would trip
+# the breaker of a perfectly healthy host. ``PoolTimeout`` is deliberately not
+# here: an exhausted pool is usually the dependency holding connections open,
+# and shedding load then is the point.
+_EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = (
+    LocalProtocolError,
+    UnsupportedProtocol,
+)
+
 
 class HttpStatusClassifier:
     """Counts transport exceptions and unhealthy-status responses as failures.
 
     A returned response is a failure when its status is in ``failure_statuses``
-    — by default the canonical retryable set (``429, 500, 502, 503, 504``);
-    any raised exception is a failure. Other responses — including ``4xx``
-    client mistakes like ``404`` — are successes, so they never trip the
-    breaker.
+    — by default the canonical retryable set (``429, 500, 502, 503, 504``); a
+    raised exception is a failure unless it is one of ``excluded_exceptions``,
+    by default the caller-side errors ``LocalProtocolError`` and
+    ``UnsupportedProtocol``. Other responses — including ``4xx`` client
+    mistakes like ``404`` — are successes, so they never trip the breaker.
+
+    An excluded exception still propagates to the caller; it is recorded as a
+    success, since the window has no third outcome.
 
     Args:
         failure_statuses: Statuses to count as failures instead of the
             canonical set.
+        excluded_exceptions: Exception types to count as successes instead of
+            the caller-side default. Pass ``()`` to count every exception as a
+            failure, or add ``PoolTimeout`` when the local pool is sized below
+            the caller's own burst.
     """
 
-    def __init__(self, *, failure_statuses: Iterable[int] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        failure_statuses: Iterable[int] | None = None,
+        excluded_exceptions: Iterable[type[Exception]] | None = None,
+    ) -> None:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
+        self._excluded_exceptions = (
+            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
+        )
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""
         if exception is not None:
-            return True
+            return not isinstance(exception, self._excluded_exceptions)
 
         return cast('Response', result).status_code in self._failure_statuses
 

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -75,6 +75,28 @@ _EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = (
 )
 
 
+def _exception_types(
+    excluded: Iterable[type[Exception]] | None,
+) -> tuple[type[Exception], ...]:
+    """Freeze the exclusion set, rejecting entries that can never be classified.
+
+    Raises:
+        TypeError: If an entry is not an ``Exception`` subclass.
+    """
+    if excluded is None:
+        return _EXCLUDED_EXCEPTIONS
+
+    types = tuple(excluded)
+    # The annotation is a promise, not a guarantee: an untyped caller can still
+    # pass a string. Checking now beats an ``isinstance`` TypeError raised from
+    # inside the guarded call, on the first real failure.
+    for entry in cast('tuple[object, ...]', types):
+        if not (isinstance(entry, type) and issubclass(entry, Exception)):
+            raise TypeError(f'excluded_exceptions must hold Exception subclasses, got: {entry!r}')
+
+    return types
+
+
 class HttpStatusClassifier:
     """Counts transport exceptions and unhealthy-status responses as failures.
 
@@ -95,6 +117,10 @@ class HttpStatusClassifier:
             the caller-side default. Pass ``()`` to count every exception as a
             failure, or add ``PoolTimeout`` when the local pool is sized below
             the caller's own burst.
+
+    Raises:
+        TypeError: If ``excluded_exceptions`` holds anything but ``Exception``
+            subclasses.
     """
 
     def __init__(
@@ -106,9 +132,7 @@ class HttpStatusClassifier:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
-        self._excluded_exceptions = (
-            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
-        )
+        self._excluded_exceptions = _exception_types(excluded_exceptions)
 
     def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -17,9 +17,10 @@ created lazily and shared across requests. When a host's circuit is open the
 request is rejected with ``CircuitOpenError`` before a connection is made.
 
 By default a response counts as a failure when its status is in the canonical
-retryable set (``429, 500, 502, 503, 504``) and any transport exception
-(connect/read errors) is a failure; ``4xx`` client mistakes like ``404`` are
-successes. Supply a custom ``classifier`` to change that policy.
+retryable set (``429, 500, 502, 503, 504``) and a transport exception
+(connect/read errors) is a failure unless it is caller-side (a URL with no
+host); ``4xx`` client mistakes like ``404`` are successes. Supply a custom
+``classifier`` to change that policy.
 """
 
 import http
@@ -30,6 +31,7 @@ from urllib.parse import urlsplit
 
 from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
+from requests.exceptions import InvalidURL
 
 from interlock.config import Config
 from interlock.integrations._registry import reject_registry_options, resolve_registry
@@ -56,30 +58,53 @@ _FAILURE_STATUSES = frozenset(
 _Timeout = float | tuple[float, float] | tuple[float, None] | None
 _Cert = bytes | str | tuple[bytes | str, bytes | str] | None
 
+# The adapter raises ``InvalidURL`` (and its ``InvalidProxyURL`` subclass) when
+# the request or proxy URL carries no host — the caller's own bug. It is
+# deterministic, so no retry and no open circuit can make it succeed, and it
+# says nothing about the dependency: counting it would trip the breaker of a
+# perfectly healthy host. ``InvalidHeader`` is *not* here — urllib3 raises it
+# for a malformed header sent by the *server*.
+_EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = (InvalidURL,)
+
 
 class HttpStatusClassifier:
     """Counts transport exceptions and unhealthy-status responses as failures.
 
     A returned response is a failure when its status is in ``failure_statuses``
-    — by default the canonical retryable set (``429, 500, 502, 503, 504``);
-    any raised exception is a failure. Other responses — including ``4xx``
-    client mistakes like ``404`` — are successes, so they never trip the
-    breaker.
+    — by default the canonical retryable set (``429, 500, 502, 503, 504``); a
+    raised exception is a failure unless it is one of ``excluded_exceptions``,
+    by default the caller-side ``InvalidURL``. Other responses — including
+    ``4xx`` client mistakes like ``404`` — are successes, so they never trip
+    the breaker.
+
+    An excluded exception still propagates to the caller; it is recorded as a
+    success, since the window has no third outcome.
 
     Args:
         failure_statuses: Statuses to count as failures instead of the
             canonical set.
+        excluded_exceptions: Exception types to count as successes instead of
+            the caller-side default. Pass ``()`` to count every exception as a
+            failure.
     """
 
-    def __init__(self, *, failure_statuses: Iterable[int] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        failure_statuses: Iterable[int] | None = None,
+        excluded_exceptions: Iterable[type[Exception]] | None = None,
+    ) -> None:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
+        self._excluded_exceptions = (
+            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
+        )
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""
         if exception is not None:
-            return True
+            return not isinstance(exception, self._excluded_exceptions)
 
         return cast('Response', result).status_code in self._failure_statuses
 

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -67,6 +67,28 @@ _Cert = bytes | str | tuple[bytes | str, bytes | str] | None
 _EXCLUDED_EXCEPTIONS: tuple[type[Exception], ...] = (InvalidURL,)
 
 
+def _exception_types(
+    excluded: Iterable[type[Exception]] | None,
+) -> tuple[type[Exception], ...]:
+    """Freeze the exclusion set, rejecting entries that can never be classified.
+
+    Raises:
+        TypeError: If an entry is not an ``Exception`` subclass.
+    """
+    if excluded is None:
+        return _EXCLUDED_EXCEPTIONS
+
+    types = tuple(excluded)
+    # The annotation is a promise, not a guarantee: an untyped caller can still
+    # pass a string. Checking now beats an ``isinstance`` TypeError raised from
+    # inside the guarded call, on the first real failure.
+    for entry in cast('tuple[object, ...]', types):
+        if not (isinstance(entry, type) and issubclass(entry, Exception)):
+            raise TypeError(f'excluded_exceptions must hold Exception subclasses, got: {entry!r}')
+
+    return types
+
+
 class HttpStatusClassifier:
     """Counts transport exceptions and unhealthy-status responses as failures.
 
@@ -86,6 +108,10 @@ class HttpStatusClassifier:
         excluded_exceptions: Exception types to count as successes instead of
             the caller-side default. Pass ``()`` to count every exception as a
             failure.
+
+    Raises:
+        TypeError: If ``excluded_exceptions`` holds anything but ``Exception``
+            subclasses.
     """
 
     def __init__(
@@ -97,9 +123,7 @@ class HttpStatusClassifier:
         self._failure_statuses = (
             frozenset(failure_statuses) if failure_statuses is not None else _FAILURE_STATUSES
         )
-        self._excluded_exceptions = (
-            tuple(excluded_exceptions) if excluded_exceptions is not None else _EXCLUDED_EXCEPTIONS
-        )
+        self._excluded_exceptions = _exception_types(excluded_exceptions)
 
     def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed request counts as a failure."""

--- a/interlock/protocols.py
+++ b/interlock/protocols.py
@@ -178,11 +178,16 @@ class AsyncStorage(Protocol):
 class FailureClassifier(Protocol):
     """Decides what counts as a failure, by exception and by result."""
 
-    def is_failure(self, *, result: object, exception: BaseException | None) -> bool:
+    def is_failure(self, *, result: object, exception: Exception | None) -> bool:
         """Return whether a completed call counts as a failure.
 
         Exactly one dimension is meaningful per call: when ``exception`` is not
         ``None`` the call raised; otherwise ``result`` is its return value.
+
+        Only an ``Exception`` is ever passed: a ``BaseException`` — cancellation,
+        shutdown — says nothing about the dependency, so the engine releases the
+        call without classifying it. A classifier that handles cancellation here
+        is writing code that can never run.
         """
         ...
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -81,6 +81,12 @@ def test__http_status_classifier__excluded_exception__is_success() -> None:
     assert classifier.is_failure(result=None, exception=ConnectionError('boom')) is True
 
 
+@pytest.mark.parametrize('entry', ['ConnectionError', str, KeyboardInterrupt])
+def test__http_status_classifier__non_exception_exclusion__raises(entry: object) -> None:
+    with pytest.raises(TypeError, match='Exception subclasses'):
+        HttpStatusClassifier(excluded_exceptions=[cast('type[Exception]', entry)])
+
+
 # --- CircuitBreakerMiddleware (unit, stubbed handler) -------------------------
 
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -71,6 +71,16 @@ def test__http_status_classifier__exception__is_failure() -> None:
     assert classifier.is_failure(result=None, exception=ConnectionError('boom')) is True
 
 
+def test__http_status_classifier__excluded_exception__is_success() -> None:
+    class _MissingCredentials(Exception):
+        pass
+
+    classifier = HttpStatusClassifier(excluded_exceptions=(_MissingCredentials,))
+
+    assert classifier.is_failure(result=None, exception=_MissingCredentials()) is False
+    assert classifier.is_failure(result=None, exception=ConnectionError('boom')) is True
+
+
 # --- CircuitBreakerMiddleware (unit, stubbed handler) -------------------------
 
 

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -137,6 +137,53 @@ def test__http_status_classifier__custom_statuses__override_default_set() -> Non
     assert not classifier.is_failure(result=httpx.Response(500), exception=None)
 
 
+@pytest.mark.parametrize(
+    'exception',
+    [httpx.UnsupportedProtocol('no scheme'), httpx.LocalProtocolError('bad request')],
+)
+def test__http_status_classifier__caller_side_exception__is_success(
+    exception: httpx.TransportError,
+) -> None:
+    classifier = HttpStatusClassifier()
+
+    assert not classifier.is_failure(result=None, exception=exception)
+
+
+def test__http_status_classifier__pool_timeout__is_failure() -> None:
+    classifier = HttpStatusClassifier()
+
+    assert classifier.is_failure(result=None, exception=httpx.PoolTimeout('exhausted'))
+
+
+def test__http_status_classifier__custom_exclusions__override_default_set() -> None:
+    classifier = HttpStatusClassifier(excluded_exceptions=(httpx.PoolTimeout,))
+
+    assert not classifier.is_failure(result=None, exception=httpx.PoolTimeout('exhausted'))
+    assert classifier.is_failure(result=None, exception=httpx.UnsupportedProtocol('no scheme'))
+
+
+def test__http_status_classifier__empty_exclusions__counts_every_exception() -> None:
+    classifier = HttpStatusClassifier(excluded_exceptions=())
+
+    assert classifier.is_failure(result=None, exception=httpx.UnsupportedProtocol('no scheme'))
+
+
+def test__sync_transport__caller_side_exceptions__keep_circuit_closed(
+    fake_clock: FakeClock,
+) -> None:
+    def unsupported(_request: httpx.Request) -> httpx.Response:
+        raise httpx.UnsupportedProtocol('no scheme')
+
+    inner = _SyncStub(unsupported)
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    for _ in range(4):
+        with pytest.raises(httpx.UnsupportedProtocol):
+            transport.handle_request(_request())
+
+    assert transport.registry.get('api.example.com').state is State.CLOSED
+
+
 def test__sync_transport__success_response__passes_through(fake_clock: FakeClock) -> None:
     inner = _SyncStub(lambda _request: httpx.Response(200))
     transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -168,6 +168,12 @@ def test__http_status_classifier__empty_exclusions__counts_every_exception() -> 
     assert classifier.is_failure(result=None, exception=httpx.UnsupportedProtocol('no scheme'))
 
 
+@pytest.mark.parametrize('entry', ['httpx.PoolTimeout', str, KeyboardInterrupt])
+def test__http_status_classifier__non_exception_exclusion__raises(entry: object) -> None:
+    with pytest.raises(TypeError, match='Exception subclasses'):
+        HttpStatusClassifier(excluded_exceptions=[cast('type[Exception]', entry)])
+
+
 def test__sync_transport__caller_side_exceptions__keep_circuit_closed(
     fake_clock: FakeClock,
 ) -> None:

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -120,6 +120,53 @@ def test__http_status_classifier__healthy_or_permanent_status__is_success(status
     assert not classifier.is_failure(result=Response(status), exception=None)
 
 
+@pytest.mark.parametrize(
+    'exception',
+    [httpx2.UnsupportedProtocol('no scheme'), httpx2.LocalProtocolError('bad request')],
+)
+def test__http_status_classifier__caller_side_exception__is_success(
+    exception: httpx2.TransportError,
+) -> None:
+    classifier = HttpStatusClassifier()
+
+    assert not classifier.is_failure(result=None, exception=exception)
+
+
+def test__http_status_classifier__pool_timeout__is_failure() -> None:
+    classifier = HttpStatusClassifier()
+
+    assert classifier.is_failure(result=None, exception=httpx2.PoolTimeout('exhausted'))
+
+
+def test__http_status_classifier__custom_exclusions__override_default_set() -> None:
+    classifier = HttpStatusClassifier(excluded_exceptions=(httpx2.PoolTimeout,))
+
+    assert not classifier.is_failure(result=None, exception=httpx2.PoolTimeout('exhausted'))
+    assert classifier.is_failure(result=None, exception=httpx2.UnsupportedProtocol('no scheme'))
+
+
+def test__http_status_classifier__empty_exclusions__counts_every_exception() -> None:
+    classifier = HttpStatusClassifier(excluded_exceptions=())
+
+    assert classifier.is_failure(result=None, exception=httpx2.UnsupportedProtocol('no scheme'))
+
+
+def test__sync_transport__caller_side_exceptions__keep_circuit_closed(
+    fake_clock: FakeClock,
+) -> None:
+    def unsupported(_request: Request) -> Response:
+        raise httpx2.UnsupportedProtocol('no scheme')
+
+    inner = _SyncStub(unsupported)
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    for _ in range(4):
+        with pytest.raises(httpx2.UnsupportedProtocol):
+            transport.handle_request(_request())
+
+    assert transport.registry.get('api.example.com').state is State.CLOSED
+
+
 def test__sync_transport__success_response__passes_through(fake_clock: FakeClock) -> None:
     inner = _SyncStub(lambda _request: Response(200))
     transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -151,6 +151,12 @@ def test__http_status_classifier__empty_exclusions__counts_every_exception() -> 
     assert classifier.is_failure(result=None, exception=httpx2.UnsupportedProtocol('no scheme'))
 
 
+@pytest.mark.parametrize('entry', ['httpx2.PoolTimeout', str, KeyboardInterrupt])
+def test__http_status_classifier__non_exception_exclusion__raises(entry: object) -> None:
+    with pytest.raises(TypeError, match='Exception subclasses'):
+        HttpStatusClassifier(excluded_exceptions=[cast('type[Exception]', entry)])
+
+
 def test__sync_transport__caller_side_exceptions__keep_circuit_closed(
     fake_clock: FakeClock,
 ) -> None:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -57,6 +57,35 @@ def test__http_status_classifier__exception__is_failure() -> None:
     assert classifier.is_failure(result=None, exception=exc) is True
 
 
+@pytest.mark.parametrize(
+    'exception',
+    [
+        requests.exceptions.InvalidURL('no host'),
+        requests.exceptions.InvalidProxyURL('proxy has no host'),
+    ],
+)
+def test__http_status_classifier__caller_side_exception__is_success(
+    exception: requests.RequestException,
+) -> None:
+    classifier = HttpStatusClassifier()
+
+    assert classifier.is_failure(result=None, exception=exception) is False
+
+
+def test__http_status_classifier__custom_exclusions__override_default_set() -> None:
+    classifier = HttpStatusClassifier(excluded_exceptions=(requests.exceptions.InvalidHeader,))
+
+    excluded = requests.exceptions.InvalidHeader('bad Retry-After')
+    assert classifier.is_failure(result=None, exception=excluded) is False
+    assert classifier.is_failure(result=None, exception=requests.exceptions.InvalidURL()) is True
+
+
+def test__http_status_classifier__empty_exclusions__counts_every_exception() -> None:
+    classifier = HttpStatusClassifier(excluded_exceptions=())
+
+    assert classifier.is_failure(result=None, exception=requests.exceptions.InvalidURL()) is True
+
+
 # --- CircuitBreakerAdapter ----------------------------------------------------
 
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -86,6 +86,12 @@ def test__http_status_classifier__empty_exclusions__counts_every_exception() -> 
     assert classifier.is_failure(result=None, exception=requests.exceptions.InvalidURL()) is True
 
 
+@pytest.mark.parametrize('entry', ['requests.ConnectionError', str, KeyboardInterrupt])
+def test__http_status_classifier__non_exception_exclusion__raises(entry: object) -> None:
+    with pytest.raises(TypeError, match='Exception subclasses'):
+        HttpStatusClassifier(excluded_exceptions=[cast('type[Exception]', entry)])
+
+
 # --- CircuitBreakerAdapter ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

`HttpStatusClassifier` counted *any* exception raised inside the guarded call as the dependency failing — including the ones the client library raises for the **caller's** own bug. A burst of them tripped the breaker of a host that was answering fine (rejecting real traffic in blocking mode, polluting the threshold-picking baseline in `METRICS_ONLY`).

Each copy of the classifier now excludes its own library's caller-side exceptions and takes `excluded_exceptions=(...)` to replace that set (`()` restores the old behaviour). Excluded exceptions propagate unchanged; they are recorded as successes, since the window has no third outcome.

| Integration | Excluded by default | Why |
|---|---|---|
| httpx2 / httpx | `UnsupportedProtocol`, `LocalProtocolError` | Unsupported URL scheme, local protocol violation — deterministic, no evidence about the dependency |
| requests | `InvalidURL` (parent of `InvalidProxyURL`) | Request or proxy URL with no host |
| aiohttp | — (empty) | aiohttp rejects malformed/non-HTTP URLs *before* the middleware chain runs, so none reach the classifier; the knob is there for the caller's own middlewares |

Two judgement calls worth reviewing:

- **`PoolTimeout` stays a failure.** Pool exhaustion is most often the dependency holding connections open, and shedding load then is the point. Documented, with the one-liner to exclude it when the pool is sized below the caller's own burst.
- **`InvalidHeader` is *not* excluded** for requests: urllib3 raises it for a malformed header sent by the *server* (a bad `Retry-After`, multiple `Content-Length`), so it is dependency-side.

The typing nit from the issue is fixed too: `FailureClassifier.is_failure` now declares `exception: Exception | None`. The engine releases cancellation and shutdown without classifying them (`_engine.exit_block`, `_settle`), so the wider annotation only invited classifier authors to write handling that could never run. A classifier still annotated `BaseException | None` keeps type-checking (contravariance), and `griffe check` reports no public-API breakage.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

Tests first: the four classifier suites got failing cases for the caller-side exceptions, the custom/empty exclusion sets, and — for both httpx copies — a transport-level regression test reproducing the issue (a burst of `UnsupportedProtocol` leaves the breaker `CLOSED`). `griffe check` is clean, so no `breaking-change` label is needed.

## Related issues

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Added

- Added configurable `excluded_exceptions` to `HttpStatusClassifier` for the `httpx`, `httpx2`, `requests`, and `aiohttp` extras.
- Added default exclusions for `UnsupportedProtocol` and `LocalProtocolError` in the `httpx` and `httpx2` extras.
- Added a default `InvalidURL` exclusion in the `requests` extra.

### Fixed

- Excluded exceptions now propagate unchanged and count as successes.
- `PoolTimeout` remains a failure in the `httpx` and `httpx2` extras.
- `requests.InvalidHeader` remains a failure.
- Cancellation and shutdown exceptions are no longer classified by the engine.

### Changed

- Changed `FailureClassifier.is_failure` to accept `Exception | None` instead of `BaseException | None`.
- Made `excluded_exceptions` replace integration defaults. An empty tuple counts all exceptions as failures.
- Updated the public `HttpStatusClassifier` constructor API for the `httpx`, `httpx2`, `requests`, and `aiohttp` extras.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->