### PR TITLE
perf: stop rebuilding the guarded wrapper on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`CircuitBreaker.call_sync()` and `call_async()` protect a call without
+  deciding what it is.** `call()` inspects every callable it is handed —
+  unwrapping `functools.partial`, probing `__call__` — and the decorator copies
+  metadata onto a freshly allocated closure. A caller that already knows its own
+  nature paid for a decision it could not change. The two new methods run the
+  same protected path with the dispatch removed; `call()` keeps dispatching and
+  stays the default. `call_async` awaits whatever the callable returns, so a
+  callable that is not a coroutine *function* (a middleware handler, say) works
+  too; `call_sync` never awaits, so a coroutine function passed to it is
+  recorded as an immediate success.
+
 ### Fixed
 
 - **A bug in your own code no longer opens the circuit of a healthy
@@ -29,6 +42,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The HTTP integrations no longer rebuild their guarded wrapper on every
+  request.** Each request through the httpx2/httpx transports, the requests
+  adapter and the aiohttp middleware re-ran the breaker's sync/async detection
+  and built a fresh `functools.wraps` closure before the request could start —
+  per-request overhead with no behavioural value, paid exactly when a service is
+  busiest. They now call the breaker directly (`call_sync` / `call_async`), and
+  the aiohttp middleware no longer needs its per-request coroutine wrapper.
+  Against a stubbed transport that answers from memory, an httpx request through
+  the wrapper falls from ~10.5 µs to ~7.5 µs (sync) and from ~9.9 µs to ~8.0 µs
+  (async); ~3.5 µs of that is the stub itself, so the integration's own overhead
+  drops by roughly 40%. Behaviour is unchanged.
+- **The pipeline's breaker step stopped rebuilding its wrapper as well.**
+  `CircuitBreakerStrategy` decorated the next layer on every call for the same
+  reason, although it statically knows whether that layer is sync or async. It
+  now routes through `call_sync` / `call_async`: the same protected path, one
+  detection and one closure fewer per pipeline call.
+- **A `Registry` cache hit no longer takes the registry lock.** Because the
+  transport integrations create one breaker per host lazily, every request paid
+  a lock acquisition to find a breaker that was already there. The lookup now
+  reads the cache first and falls back to the locked, double-checked creation
+  path only for a name it has not seen — one name still yields exactly one
+  breaker, and a lost creation race returns the winner.
 - **`FailureClassifier.is_failure` now declares `exception: Exception | None`.**
   The engine never passed a `BaseException` — cancellation and shutdown are
   released without being classified — so the wider annotation invited

--- a/benchmarks/test_transport.py
+++ b/benchmarks/test_transport.py
@@ -1,0 +1,84 @@
+"""Benchmarks for the transport-integration hot path.
+
+Every outgoing request of a wrapped client pays the integration's own overhead:
+resolving the breaker name, looking the breaker up in the registry and running
+the request under it. The wrapped transport here answers from memory, so what is
+measured is that per-request wrapper rather than a socket.
+"""
+
+import asyncio
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from pytest_codspeed import BenchmarkFixture
+
+from interlock import Config
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport, CircuitBreakerTransport
+
+_CONFIG = Config(window_size=100, minimum_number_of_calls=10)
+_REQUEST = httpx.Request('GET', 'https://api.example.com/orders')
+_OK = 200
+
+
+class _StubTransport(httpx.BaseTransport):
+    """The wrapped dependency: cheap enough to expose the wrapper's own cost."""
+
+    def handle_request(self, _request: httpx.Request) -> httpx.Response:
+        """Answer from memory, the way a healthy dependency would."""
+        return httpx.Response(_OK)
+
+
+class _AsyncStubTransport(httpx.AsyncBaseTransport):
+    """The async twin of :class:`_StubTransport`."""
+
+    async def handle_async_request(self, _request: httpx.Request) -> httpx.Response:
+        """Answer from memory, the way a healthy dependency would."""
+        return httpx.Response(_OK)
+
+
+@pytest.fixture
+def runner() -> Iterator[asyncio.Runner]:
+    """An event-loop runner reused across iterations, so loop setup is excluded."""
+    with asyncio.Runner() as loop_runner:
+        yield loop_runner
+
+
+def test_baseline_unwrapped_transport(benchmark: BenchmarkFixture) -> None:
+    """The bare transport: the denominator for the wrapper's overhead ratio."""
+    transport = _StubTransport()
+
+    benchmark(lambda: transport.handle_request(_REQUEST))
+
+
+def test_transport_request(benchmark: BenchmarkFixture) -> None:
+    """A guarded request on a closed breaker: name, registry lookup, protected call."""
+    transport = CircuitBreakerTransport(_StubTransport(), config=_CONFIG)
+
+    response = benchmark(lambda: transport.handle_request(_REQUEST))
+
+    assert response.status_code == _OK
+
+
+def test_baseline_unwrapped_transport_async(
+    benchmark: BenchmarkFixture, runner: asyncio.Runner
+) -> None:
+    """The bare async transport, behind the same coroutine frame the guarded path pays."""
+    transport = _AsyncStubTransport()
+
+    async def bare() -> httpx.Response:
+        return await transport.handle_async_request(_REQUEST)
+
+    benchmark(lambda: runner.run(bare()))
+
+
+def test_transport_request_async(benchmark: BenchmarkFixture, runner: asyncio.Runner) -> None:
+    """The async twin of :func:`test_transport_request`."""
+    transport = AsyncCircuitBreakerTransport(_AsyncStubTransport(), config=_CONFIG)
+
+    async def guarded() -> httpx.Response:
+        return await transport.handle_async_request(_REQUEST)
+
+    response = benchmark(lambda: runner.run(guarded()))
+
+    assert response.status_code == _OK

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,19 @@ checkers still see `charge` as `(int) -> str`.
 result = breaker.call(gateway.charge, 100)
 ```
 
+`call` inspects the callable to pick the sync or the async path. Where that is
+already known — a synchronous client, an awaited handler — `call_sync` and
+`call_async` skip the inspection:
+
+```python
+result = breaker.call_sync(gateway.charge, 100)
+result = await breaker.call_async(client.get, url)
+```
+
+`call_sync` never awaits, so passing a coroutine function to it records the
+coroutine's creation rather than its outcome. Reach for these on a hot path that
+calls the same shape every time; `call` is the right default everywhere else.
+
 ### Context manager
 
 ```python

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -97,6 +97,19 @@ checkers still see `charge` as `(int) -> str`.
 result = breaker.call(gateway.charge, 100)
 ```
 
+`call` inspects the callable to pick the sync or the async path. Where that is
+already known — a synchronous client, an awaited handler — `call_sync` and
+`call_async` skip the inspection:
+
+```python
+result = breaker.call_sync(gateway.charge, 100)
+result = await breaker.call_async(client.get, url)
+```
+
+`call_sync` never awaits, so passing a coroutine function to it records the
+coroutine's creation rather than its outcome. Reach for these on a hot path that
+calls the same shape every time; `call` is the right default everywhere else.
+
 ### Context manager
 
 ```python
@@ -4260,6 +4273,12 @@ A named breaker for sync and async callables.
 
 - **Use as** a decorator (`@breaker`), a sync/async context manager
   (`with` / `async with`), or `breaker.call(fn, *args, **kwargs)`.
+- **`call_sync(fn, ...)` / `call_async(fn, ...)`** — the same protection with the
+  sync/async dispatch skipped, for callers that already know their own nature
+  (the transport integrations use them per request). `call_sync` never awaits: a
+  coroutine function passed to it is recorded as an immediate success.
+  `call_async` awaits whatever `fn` returns, so it accepts any
+  awaitable-returning callable, not only a coroutine function.
 - **Properties:** `name: str`, `state: State`.
 - **`initial_state`** — one of `CLOSED`, `FORCED_OPEN`, `DISABLED` or
   `METRICS_ONLY`; transitional `OPEN` / `HALF_OPEN` raise `ValueError`.
@@ -4293,7 +4312,9 @@ registry.close_all() / await registry.aclose_all()
 ```
 
 Creates and caches named breakers. The same name always returns the same
-instance; the per-call `config` override applies only at creation. A `storage`
+instance; the per-call `config` override applies only at creation. A cache hit
+is served without taking the registry lock, so a registry shared by every
+request of a service does not serialise on lookups. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
 name. `initial_state` is assigned before a lazy breaker is published;
 `get_existing()` inspects the cache without creating a missing name.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,6 +15,12 @@ A named breaker for sync and async callables.
 
 - **Use as** a decorator (`@breaker`), a sync/async context manager
   (`with` / `async with`), or `breaker.call(fn, *args, **kwargs)`.
+- **`call_sync(fn, ...)` / `call_async(fn, ...)`** — the same protection with the
+  sync/async dispatch skipped, for callers that already know their own nature
+  (the transport integrations use them per request). `call_sync` never awaits: a
+  coroutine function passed to it is recorded as an immediate success.
+  `call_async` awaits whatever `fn` returns, so it accepts any
+  awaitable-returning callable, not only a coroutine function.
 - **Properties:** `name: str`, `state: State`.
 - **`initial_state`** — one of `CLOSED`, `FORCED_OPEN`, `DISABLED` or
   `METRICS_ONLY`; transitional `OPEN` / `HALF_OPEN` raise `ValueError`.
@@ -48,7 +54,9 @@ registry.close_all() / await registry.aclose_all()
 ```
 
 Creates and caches named breakers. The same name always returns the same
-instance; the per-call `config` override applies only at creation. A `storage`
+instance; the per-call `config` override applies only at creation. A cache hit
+is served without taking the registry lock, so a registry shared by every
+request of a service does not serialise on lookups. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
 name. `initial_state` is assigned before a lazy breaker is published;
 `get_existing()` inspects the cache without creating a missing name.

--- a/interlock/breaker.py
+++ b/interlock/breaker.py
@@ -178,6 +178,34 @@ class CircuitBreaker:
         """
         return self._engine.call(fn, *args, **kwargs)
 
+    def call_sync(self, fn: SyncCallable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Execute a synchronous ``fn`` under protection, without dispatching.
+
+        The caller states the callable's nature, so nothing is detected and
+        nothing is decorated — the shape a per-request integration path wants.
+        A coroutine function passed here is *not* awaited: its coroutine is
+        recorded as an immediate success. Use ``call_async`` for those, or
+        ``call`` to dispatch on the callable.
+
+        Raises:
+            CircuitOpenError: If the breaker rejects the call.
+        """
+        return self._engine.call_sync(fn, *args, **kwargs)
+
+    def call_async(
+        self, fn: AsyncCallable[P, R], /, *args: P.args, **kwargs: P.kwargs
+    ) -> Awaitable[R]:
+        """Execute an awaitable-returning ``fn`` under protection; ``call_sync``'s mirror.
+
+        ``fn`` need not be a coroutine *function*: any callable returning an
+        awaitable is awaited, which is the shape middleware chains hand over.
+
+        Raises:
+            CircuitOpenError: If the breaker rejects the call.
+            InterlockError: If the breaker is coordinated through a sync storage.
+        """
+        return self._engine.call_async(fn, *args, **kwargs)
+
     @overload
     def __call__(self, fn: AsyncCallable[P, R]) -> AsyncCallable[P, R]: ...
 

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -225,10 +225,6 @@ class CircuitBreakerMiddleware:
 
         # The composed handler is not guaranteed to be a coroutine *function*
         # (middleware chains may hand over plain callables returning
-        # awaitables), so don't rely on the breaker's sync/async detection —
-        # wrap the send in an explicit coroutine function.
-        async def _send() -> ClientResponse:
-            return await handler(request)
-
-        guarded = breaker(_send)
-        return await guarded()
+        # awaitables), so the breaker's sync/async detection must not decide
+        # here: call_async awaits whatever the handler returns.
+        return await breaker.call_async(handler, request)

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -231,8 +231,7 @@ class CircuitBreakerTransport(BaseTransport):
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        guarded = breaker(self._transport.handle_request)
-        return guarded(request)
+        return breaker.call_sync(self._transport.handle_request, request)
 
     def __enter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""
@@ -325,8 +324,7 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        guarded = breaker(self._transport.handle_async_request)
-        return await guarded(request)
+        return await breaker.call_async(self._transport.handle_async_request, request)
 
     async def __aenter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -231,8 +231,7 @@ class CircuitBreakerTransport(BaseTransport):
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        guarded = breaker(self._transport.handle_request)
-        return guarded(request)
+        return breaker.call_sync(self._transport.handle_request, request)
 
     def __enter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""
@@ -326,8 +325,7 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        guarded = breaker(self._transport.handle_async_request)
-        return await guarded(request)
+        return await breaker.call_async(self._transport.handle_async_request, request)
 
     async def __aenter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -248,8 +248,8 @@ class CircuitBreakerAdapter(HTTPAdapter):
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        guarded = breaker(super().send)
-        return guarded(
+        return breaker.call_sync(
+            super().send,
             request,
             stream=stream,
             timeout=timeout,

--- a/interlock/pipeline.py
+++ b/interlock/pipeline.py
@@ -209,8 +209,7 @@ class CircuitBreakerStrategy:
         Raises:
             CircuitOpenError: If the breaker rejects the call.
         """
-        guarded: Callable[[], T] = self._breaker(call)
-        return guarded()
+        return self._breaker.call_sync(call)
 
     async def execute_async(self, call: Callable[[], Awaitable[T]]) -> T:
         """Run the next async layer under the breaker's protection.
@@ -218,8 +217,7 @@ class CircuitBreakerStrategy:
         Raises:
             CircuitOpenError: If the breaker rejects the call.
         """
-        guarded: Callable[[], Awaitable[T]] = self._breaker(call)
-        return await guarded()
+        return await self._breaker.call_async(call)
 
 
 class TimeoutStrategy:

--- a/interlock/registry.py
+++ b/interlock/registry.py
@@ -77,6 +77,14 @@ class Registry:
         Returns:
             The cached or newly created breaker.
         """
+        # A hit reads the dict without the lock: this is the per-request path of
+        # every transport integration, and a breaker is never replaced or
+        # removed once cached, so the worst a concurrent creation can do is send
+        # this reader down the locked path below.
+        cached = self._breakers.get(name)
+        if cached is not None:
+            return cached
+
         with self._lock:
             breaker = self._breakers.get(name)
             if breaker is None:

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,5 +1,6 @@
 """Tests for the aiohttp integration (``interlock.integrations.aiohttp``)."""
 
+from collections.abc import Awaitable
 from typing import cast
 
 import pytest
@@ -9,7 +10,7 @@ from pytest_mock import MockerFixture
 from tests.conftest import FakeClock
 from yarl import URL
 
-from interlock import CircuitOpenError, Config, Registry, State
+from interlock import CircuitBreaker, CircuitOpenError, Config, Registry, State
 from interlock.integrations.aiohttp import CircuitBreakerMiddleware, HttpStatusClassifier
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
@@ -103,6 +104,37 @@ async def test__middleware__failure_statuses__trip_breaker_and_reject(
     with pytest.raises(CircuitOpenError):
         await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
     assert handler.calls == 2
+
+
+@pytest.mark.asyncio
+async def test__middleware__cached_breaker__is_not_redecorated_per_request(
+    fake_clock: FakeClock, mocker: MockerFixture
+) -> None:
+    """The per-request path costs no decoration: no ``functools.wraps``, no detection."""
+    middleware = CircuitBreakerMiddleware(config=_TRIP_FAST, clock=fake_clock)
+    handler = _handler([200, 200])
+    await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+    mocker.patch.object(CircuitBreaker, '__call__', side_effect=AssertionError('decorated'))
+
+    response = await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+    assert response.status == 200
+
+
+@pytest.mark.asyncio
+async def test__middleware__handler_is_not_a_coroutine_function__still_awaited(
+    fake_clock: FakeClock,
+) -> None:
+    """Middleware chains may hand over plain callables that return an awaitable."""
+    middleware = CircuitBreakerMiddleware(config=_TRIP_FAST, clock=fake_clock)
+    inner = _handler([200])
+
+    def handler(request: ClientRequest) -> Awaitable[ClientResponse]:
+        return inner(request)
+
+    response = await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+    assert response.status == 200
 
 
 @pytest.mark.asyncio

--- a/tests/test_breaker.py
+++ b/tests/test_breaker.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import threading
+from collections.abc import Awaitable
 
 import pytest
 
@@ -146,6 +147,90 @@ async def test__call__async_callable__awaited(breaker: CircuitBreaker) -> None:
         return 'a'
 
     assert await breaker.call(ok) == 'a'
+
+
+def test__call_sync__success__returns_result(breaker: CircuitBreaker) -> None:
+    assert breaker.call_sync(lambda a, b: a + b, 2, 3) == 5
+
+
+def test__call_sync__failures_reach_threshold__opens(breaker: CircuitBreaker) -> None:
+    def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            breaker.call_sync(boom)
+
+    assert breaker.state is State.OPEN
+
+
+def test__call_sync__open_circuit__raises_circuit_open_error(breaker: CircuitBreaker) -> None:
+    _fail(breaker)
+
+    with pytest.raises(CircuitOpenError):
+        breaker.call_sync(lambda: 1)
+
+
+def test__call_sync__async_callable__is_never_detected(breaker: CircuitBreaker) -> None:
+    """The caller states the nature; a coroutine function is run, not awaited."""
+
+    async def never_awaited() -> str:
+        return 'a'
+
+    coroutine = breaker.call_sync(never_awaited)
+
+    assert breaker.snapshot() == WindowSnapshot(total_calls=1, failed_calls=0, slow_calls=0)
+    coroutine.close()
+
+
+@pytest.mark.asyncio
+async def test__call_async__success__returns_result(breaker: CircuitBreaker) -> None:
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    assert await breaker.call_async(add, 2, 3) == 5
+
+
+@pytest.mark.asyncio
+async def test__call_async__failures_reach_threshold__opens(breaker: CircuitBreaker) -> None:
+    async def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            await breaker.call_async(boom)
+
+    assert breaker.state is State.OPEN
+
+
+@pytest.mark.asyncio
+async def test__call_async__open_circuit__raises_circuit_open_error(
+    breaker: CircuitBreaker,
+) -> None:
+    async def boom() -> None:
+        raise ValueError('boom')
+
+    for _ in range(2):
+        with pytest.raises(ValueError, match='boom'):
+            await breaker.call_async(boom)
+
+    with pytest.raises(CircuitOpenError):
+        await breaker.call_async(boom)
+
+
+@pytest.mark.asyncio
+async def test__call_async__plain_callable_returning_awaitable__awaited(
+    breaker: CircuitBreaker,
+) -> None:
+    """Middleware chains hand over callables that are not coroutine functions."""
+
+    async def inner() -> str:
+        return 'a'
+
+    def handler() -> Awaitable[str]:
+        return inner()
+
+    assert await breaker.call_async(handler) == 'a'
 
 
 def test__decorator__sync__preserves_name_and_runs(breaker: CircuitBreaker) -> None:

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitOpenError, Config, Outcome, Registry, State
+from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, Registry, State
 from interlock.integrations.httpx import (
     AsyncCircuitBreakerTransport,
     CircuitBreakerTransport,
@@ -197,6 +197,18 @@ def test__sync_transport__success_response__passes_through(fake_clock: FakeClock
     response = transport.handle_request(_request())
 
     assert response.status_code == 200
+
+
+def test__sync_transport__cached_breaker__is_not_redecorated_per_request(
+    fake_clock: FakeClock, mocker: MockerFixture
+) -> None:
+    """The per-request path costs no decoration: no ``functools.wraps``, no detection."""
+    inner = _SyncStub(lambda _request: httpx.Response(200))
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+    transport.handle_request(_request())
+    mocker.patch.object(CircuitBreaker, '__call__', side_effect=AssertionError('decorated'))
+
+    assert transport.handle_request(_request()).status_code == 200
 
 
 def test__sync_transport__context_manager__delegates_wrapped_lifecycle() -> None:
@@ -504,6 +516,20 @@ def test__sync_transport__metrics_only_server_errors__records_without_rejecting(
 async def test__async_transport__success_response__passes_through(fake_clock: FakeClock) -> None:
     inner = _AsyncStub(lambda _request: httpx.Response(200))
     transport = AsyncCircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+
+    response = await transport.handle_async_request(_request())
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test__async_transport__cached_breaker__is_not_redecorated_per_request(
+    fake_clock: FakeClock, mocker: MockerFixture
+) -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(200))
+    transport = AsyncCircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+    await transport.handle_async_request(_request())
+    mocker.patch.object(CircuitBreaker, '__call__', side_effect=AssertionError('decorated'))
 
     response = await transport.handle_async_request(_request())
 

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -8,7 +8,7 @@ from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
 from pytest_mock import MockerFixture
 from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitOpenError, Config, Outcome, Registry, State
+from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, Registry, State
 from interlock.integrations.httpx2 import (
     AsyncCircuitBreakerTransport,
     CircuitBreakerTransport,
@@ -180,6 +180,18 @@ def test__sync_transport__success_response__passes_through(fake_clock: FakeClock
     response = transport.handle_request(_request())
 
     assert response.status_code == 200
+
+
+def test__sync_transport__cached_breaker__is_not_redecorated_per_request(
+    fake_clock: FakeClock, mocker: MockerFixture
+) -> None:
+    """The per-request path costs no decoration: no ``functools.wraps``, no detection."""
+    inner = _SyncStub(lambda _request: Response(200))
+    transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+    transport.handle_request(_request())
+    mocker.patch.object(CircuitBreaker, '__call__', side_effect=AssertionError('decorated'))
+
+    assert transport.handle_request(_request()).status_code == 200
 
 
 def test__sync_transport__context_manager__delegates_wrapped_lifecycle() -> None:
@@ -362,6 +374,20 @@ async def test__async_transport__name_resolver__uses_custom_breaker_key(
 
     assert transport.registry.get_existing('orders') is not None
     assert transport.registry.get_existing('gateway.example.com') is None
+
+
+@pytest.mark.asyncio
+async def test__async_transport__cached_breaker__is_not_redecorated_per_request(
+    fake_clock: FakeClock, mocker: MockerFixture
+) -> None:
+    inner = _AsyncStub(lambda _request: Response(200))
+    transport = AsyncCircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
+    await transport.handle_async_request(_request())
+    mocker.patch.object(CircuitBreaker, '__call__', side_effect=AssertionError('decorated'))
+
+    response = await transport.handle_async_request(_request())
+
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,8 +1,37 @@
+import threading
+
 import pytest
 from pytest_mock import MockerFixture
 
 from conftest import FakeClock
 from interlock import CircuitBreaker, Config, Registry, State
+
+
+class _CountingLock:
+    def __init__(self) -> None:
+        self.acquisitions = 0
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> None:
+        self.acquisitions += 1
+        self._lock.acquire()
+
+    def __exit__(self, *_args: object) -> None:
+        self._lock.release()
+
+
+class _RacingLock:
+    """Another thread wins the creation race while this one waits for the lock."""
+
+    def __init__(self, registry: Registry, winner: CircuitBreaker) -> None:
+        self._registry = registry
+        self._winner = winner
+
+    def __enter__(self) -> None:
+        self._registry._breakers.setdefault(self._winner.name, self._winner)
+
+    def __exit__(self, *_args: object) -> None:
+        return
 
 
 def _fail_twice(breaker: CircuitBreaker) -> None:
@@ -33,6 +62,38 @@ def test__get__different_names__returns_distinct_instances() -> None:
     registry = Registry()
 
     assert registry.get('a') is not registry.get('b')
+
+
+def test__get__cached_name__reads_without_taking_the_lock() -> None:
+    """The per-request path of every transport integration: a cache hit is lock-free."""
+    registry = Registry()
+    breaker = registry.get('payments')
+    lock = _CountingLock()
+    registry._lock = lock  # type: ignore[assignment]
+
+    assert registry.get('payments') is breaker
+    assert lock.acquisitions == 0
+
+
+def test__get__lost_creation_race__returns_the_winner_without_replacing_it() -> None:
+    """The lock-free miss is re-checked under the lock, so a name has one breaker."""
+    registry = Registry()
+    winner = CircuitBreaker(name='payments')
+    registry._lock = _RacingLock(registry, winner)  # type: ignore[assignment]
+
+    assert registry.get('payments') is winner
+    assert registry.get('payments') is winner
+
+
+def test__get__missing_name__creates_under_the_lock() -> None:
+    registry = Registry()
+    lock = _CountingLock()
+    registry._lock = lock  # type: ignore[assignment]
+
+    breaker = registry.get('payments')
+
+    assert breaker.name == 'payments'
+    assert lock.acquisitions == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -10,7 +10,7 @@ from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
 from tests.conftest import FakeClock
 
-from interlock import CircuitOpenError, Config, Registry, State
+from interlock import CircuitBreaker, CircuitOpenError, Config, Registry, State
 from interlock.integrations.requests import CircuitBreakerAdapter, HttpStatusClassifier
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
@@ -107,6 +107,18 @@ def test__adapter__failure_statuses__trip_breaker_and_reject(
     with pytest.raises(CircuitOpenError):
         adapter.send(_prepared('https://api.a/x'))
     assert transport.call_count == 2
+
+
+def test__adapter__cached_breaker__is_not_redecorated_per_request(
+    mocker: MockerFixture, fake_clock: FakeClock
+) -> None:
+    """The per-request path costs no decoration: no ``functools.wraps``, no detection."""
+    _patch_transport(mocker, [_response(200), _response(200)])
+    adapter = CircuitBreakerAdapter(config=_TRIP_FAST, clock=fake_clock)
+    adapter.send(_prepared('https://api.a/x'))
+    mocker.patch.object(CircuitBreaker, '__call__', side_effect=AssertionError('decorated'))
+
+    assert adapter.send(_prepared('https://api.a/x')).status_code == 200
 
 
 def test__adapter__open_host__other_host_unaffected(

--- a/tests/typing_surface.py
+++ b/tests/typing_surface.py
@@ -109,6 +109,14 @@ def _breaker_call_infers_sync_result() -> None:
     assert_type(breaker.call(_fetch_sync, 1), str)
 
 
+def _breaker_call_sync_infers_result() -> None:
+    assert_type(breaker.call_sync(_fetch_sync, 1), str)
+
+
+async def _breaker_call_async_infers_result() -> None:
+    assert_type(await breaker.call_async(_fetch, 1), str)
+
+
 async def _breaker_decorator_preserves_async_signature() -> None:
     assert_type(await _decorated_async(1), str)
 


### PR DESCRIPTION
## Summary

Every guarded request through an HTTP integration rebuilt the same wrapper from scratch: `breaker(fn)` re-ran the coroutine-function detection, allocated a `functools.wraps` closure, and threw it away one call later — on the hottest path a fault-tolerance library has. `Registry.get` then took the registry lock even for a plain cache hit, serialising readers that had nothing to create.

Two additions remove the work instead of caching its result (the issue's option 1 would have added a second cache to invalidate — a new entity for a problem that disappears once the caller states what it already knows):

- **`CircuitBreaker.call_sync` / `call_async`** — the same protected path, no dispatch, no decoration. The caller declares the callable's nature, so nothing is detected and nothing is wrapped. `call_sync` never awaits (a coroutine function passed there is recorded as an immediate success — documented); `call_async` awaits *whatever the callable returns*, so it also fits handlers that are not coroutine functions, which is exactly the shape an aiohttp middleware chain hands over. `call` is unchanged and stays the dispatching front door.
- **Lock-free cache hit in `Registry.get`** — a hit reads the dict without the lock; a miss falls through to the existing locked create, now with a double-check. A breaker is never replaced or removed once cached, so a reader that races a creation can at worst take the slow path. One name still yields exactly one breaker; there is a test that loses the race deliberately and asserts the winner is returned, not replaced.

All four transports (`httpx`, `httpx2`, `requests`, `aiohttp`) now call through the new methods. aiohttp additionally loses its per-request `async def _send()` closure — the handler goes straight to `call_async`.

**Beyond the issue's scope**, the same defect lives in the core: `CircuitBreakerStrategy` in `pipeline.py` decorated the next strategy on every execution although it statically knows whether it is on the sync or the async path. Fixed in the same way; noted separately in `CHANGELOG.md`.

### Measurements

Stub transport answering from memory, three passes, same venv (a temporary worktree at `main` for the baseline):

| Path | Before | After | Stub floor |
|---|---|---|---|
| sync request | ~10.5 µs | ~7.5 µs | ~3.55 µs |
| async request | ~9.9 µs | ~8.0 µs | ~3.55 µs |

Discounting the stub itself, the integration's own overhead drops roughly 40%. `benchmarks/test_transport.py` is new so CodSpeed guards the wrapped-transport path from now on (wrapped and unwrapped, sync and async).

Semantics are untouched: same classification, same exception propagation, same cancellation handling in the engine, same lock scope. `griffe check` is clean — the two methods are purely additive, so no `breaking-change` label.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

Tests first: each integration got a test that fails on the old code by making re-decoration observable (`CircuitBreaker.__call__` patched to raise), plus the behavioural cases for the new methods — `call_sync` not awaiting a coroutine function, `call_async` accepting a non-coroutine callable returning an awaitable, both respecting `CircuitOpenError` and the sync-storage guard. `tests/typing_surface.py` pins the inferred return types of both. The registry got the lock-free-hit assertion (a counting lock double) and the lost-race test.

## Related issues

Closes #155


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Added
- Added `CircuitBreaker.call_sync()` and `CircuitBreaker.call_async()` to the `interlock` API.
- Added transport benchmarks for the `httpx` extra.
- Added tests for explicit call paths, registry races, and transport breaker reuse.

### Fixed
- Reduced per-request overhead in the `httpx`, `httpx2`, `requests`, and `aiohttp` extras.
- Preserved awaiting of awaitable handler results in the `aiohttp` extra.
- Preserved stable breaker identity during concurrent registry creation.

### Changed
- `Registry.get()` now returns cache hits without acquiring the registry lock.
- Updated documentation and typing coverage for the new call methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->