### PR TITLE
feat: let the registry enumerate the breakers it created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`Registry` can now be enumerated: `names()` and `items()`.** The registry
+  could only be asked about a name you already knew, which is exactly the case
+  that does not hold where it matters most: every HTTP integration creates its
+  breakers lazily, one per host, so the set of names is only known at runtime.
+  Listing them for a diagnostics endpoint during a `METRICS_ONLY` rollout, or
+  applying an operator override to all of them before a maintenance window,
+  meant reaching into the private `registry._breakers`. Both methods take a
+  point-in-time copy under the registry lock — a breaker created afterwards is
+  not in it, and the returned tuple never changes.
+
 ### Fixed
 
 - **A bug in your own code no longer opens the circuit of a healthy

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ transport = AsyncCircuitBreakerTransport(
 Use an `EventListener` for production metrics. For local diagnostics,
 `transport.registry.get_existing(host)` returns an already-created breaker
 without creating one, so its `state` and `snapshot()` can be inspected safely.
+Hosts are only known at runtime, so `transport.registry.items()` lists every
+breaker created so far — a point-in-time copy, name and breaker together.
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`; the enforcing instance starts with a fresh window.
 See [States and manual control](docs/guides/states.md#safe-rollout).

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -115,6 +115,16 @@ For local diagnosis, `registry.get_existing(name)` returns a cached breaker or
 `None` without creating one. Inspect its `state` and `snapshot()`; use listeners
 rather than polling snapshots for production metrics.
 
+When the names are not known in advance — the HTTP transports create one
+breaker per host, lazily — `registry.items()` lists every breaker created so
+far, and `registry.names()` just their names. Both return a point-in-time copy,
+so they also drive bulk operator actions:
+
+```python
+for _, breaker in registry.items():
+    breaker.metrics_only()
+```
+
 ## Coordinated state (optional)
 
 With a shared [storage](../integrations/redis.md), `OPEN` and `HALF_OPEN` can

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -125,7 +125,7 @@ middleware = CircuitBreakerMiddleware(
 
 The public `middleware.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
-the hosts created so far — point-in-time copies, without the hosts first seen
+the breakers created so far — point-in-time copies, without the ones created
 afterwards. Use an `EventListener` for
 production metrics, then deploy a new middleware with the default `CLOSED`
 state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -124,7 +124,8 @@ middleware = CircuitBreakerMiddleware(
 ```
 
 The public `middleware.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
+created so far. Use an `EventListener` for
 production metrics, then deploy a new middleware with the default `CLOSED`
 state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -124,8 +124,9 @@ middleware = CircuitBreakerMiddleware(
 ```
 
 The public `middleware.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
-created so far. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
+the hosts created so far — point-in-time copies, without the hosts first seen
+afterwards. Use an `EventListener` for
 production metrics, then deploy a new middleware with the default `CLOSED`
 state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -73,8 +73,8 @@ production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and
-`names()` just their hosts. Both are point-in-time copies: a host first seen
-afterwards is not in them.
+`names()` just the names they were created under. Both are point-in-time copies:
+a breaker created afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -72,7 +72,9 @@ records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
-runtime, so `transport.registry.items()` lists the breakers created so far.
+runtime, so `transport.registry.items()` lists the breakers created so far and
+`names()` just their hosts. Both are point-in-time copies: a host first seen
+afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -71,7 +71,8 @@ Every host created later starts in `METRICS_ONLY` before its first request: it
 records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
-creating one; inspect its `state` and `snapshot()`.
+creating one; inspect its `state` and `snapshot()`. Hosts are only known at
+runtime, so `transport.registry.items()` lists the breakers created so far.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -77,8 +77,8 @@ production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and
-`names()` just their hosts. Both are point-in-time copies: a host first seen
-afterwards is not in them.
+`names()` just the names they were created under. Both are point-in-time copies:
+a breaker created afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -75,7 +75,8 @@ Every host created later starts in `METRICS_ONLY` before its first request: it
 records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
-creating one; inspect its `state` and `snapshot()`.
+creating one; inspect its `state` and `snapshot()`. Hosts are only known at
+runtime, so `transport.registry.items()` lists the breakers created so far.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -76,7 +76,9 @@ records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
-runtime, so `transport.registry.items()` lists the breakers created so far.
+runtime, so `transport.registry.items()` lists the breakers created so far and
+`names()` just their hosts. Both are point-in-time copies: a host first seen
+afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -128,8 +128,9 @@ adapter = CircuitBreakerAdapter(
 ```
 
 The public `adapter.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
-created so far. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
+the hosts created so far — point-in-time copies, without the hosts first seen
+afterwards. Use an `EventListener` for
 production metrics, then deploy a new adapter with the default `CLOSED` state
 to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -129,7 +129,7 @@ adapter = CircuitBreakerAdapter(
 
 The public `adapter.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
-the hosts created so far — point-in-time copies, without the hosts first seen
+the breakers created so far — point-in-time copies, without the ones created
 afterwards. Use an `EventListener` for
 production metrics, then deploy a new adapter with the default `CLOSED` state
 to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -128,7 +128,8 @@ adapter = CircuitBreakerAdapter(
 ```
 
 The public `adapter.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
+created so far. Use an `EventListener` for
 production metrics, then deploy a new adapter with the default `CLOSED` state
 to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2847,7 +2847,9 @@ records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
-runtime, so `transport.registry.items()` lists the breakers created so far.
+runtime, so `transport.registry.items()` lists the breakers created so far and
+`names()` just their hosts. Both are point-in-time copies: a host first seen
+afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
@@ -3071,7 +3073,9 @@ records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
-runtime, so `transport.registry.items()` lists the breakers created so far.
+runtime, so `transport.registry.items()` lists the breakers created so far and
+`names()` just their hosts. Both are point-in-time copies: a host first seen
+afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
@@ -3352,8 +3356,9 @@ middleware = CircuitBreakerMiddleware(
 ```
 
 The public `middleware.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
-created so far. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
+the hosts created so far — point-in-time copies, without the hosts first seen
+afterwards. Use an `EventListener` for
 production metrics, then deploy a new middleware with the default `CLOSED`
 state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 
@@ -3531,8 +3536,9 @@ adapter = CircuitBreakerAdapter(
 ```
 
 The public `adapter.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
-created so far. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
+the hosts created so far — point-in-time copies, without the hosts first seen
+afterwards. Use an `EventListener` for
 production metrics, then deploy a new adapter with the default `CLOSED` state
 to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1674,6 +1674,16 @@ For local diagnosis, `registry.get_existing(name)` returns a cached breaker or
 `None` without creating one. Inspect its `state` and `snapshot()`; use listeners
 rather than polling snapshots for production metrics.
 
+When the names are not known in advance — the HTTP transports create one
+breaker per host, lazily — `registry.items()` lists every breaker created so
+far, and `registry.names()` just their names. Both return a point-in-time copy,
+so they also drive bulk operator actions:
+
+```python
+for _, breaker in registry.items():
+    breaker.metrics_only()
+```
+
 ## Coordinated state (optional)
 
 With a shared [storage](../integrations/redis.md), `OPEN` and `HALF_OPEN` can
@@ -2823,7 +2833,8 @@ Every host created later starts in `METRICS_ONLY` before its first request: it
 records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
-creating one; inspect its `state` and `snapshot()`.
+creating one; inspect its `state` and `snapshot()`. Hosts are only known at
+runtime, so `transport.registry.items()` lists the breakers created so far.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
@@ -3046,7 +3057,8 @@ Every host created later starts in `METRICS_ONLY` before its first request: it
 records outcomes but never raises `CircuitOpenError`. Use the listener for
 production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
-creating one; inspect its `state` and `snapshot()`.
+creating one; inspect its `state` and `snapshot()`. Hosts are only known at
+runtime, so `transport.registry.items()` lists the breakers created so far.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
@@ -3327,7 +3339,8 @@ middleware = CircuitBreakerMiddleware(
 ```
 
 The public `middleware.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
+created so far. Use an `EventListener` for
 production metrics, then deploy a new middleware with the default `CLOSED`
 state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 
@@ -3505,7 +3518,8 @@ adapter = CircuitBreakerAdapter(
 ```
 
 The public `adapter.registry` supports local diagnosis with
-`get_existing(host)`, `state` and `snapshot()`. Use an `EventListener` for
+`get_existing(host)`, `state` and `snapshot()`, and `items()` for the hosts
+created so far. Use an `EventListener` for
 production metrics, then deploy a new adapter with the default `CLOSED` state
 to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
 
@@ -4289,6 +4303,8 @@ Registry(*, config=None, clock=None, initial_state=State.CLOSED,
          classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
 registry.get_existing(name) -> CircuitBreaker | None
+registry.names() -> tuple[str, ...]
+registry.items() -> tuple[tuple[str, CircuitBreaker], ...]
 registry.close_all() / await registry.aclose_all()
 ```
 
@@ -4297,6 +4313,16 @@ instance; the per-call `config` override applies only at creation. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
 name. `initial_state` is assigned before a lazy breaker is published;
 `get_existing()` inspects the cache without creating a missing name.
+
+`names()` and `items()` enumerate the breakers created so far — the only way to
+see the ones the HTTP transports create lazily, one per host. Both take a
+point-in-time copy under the registry lock: a breaker created afterwards is not
+in it, and the returned tuple never changes.
+
+```python
+for name, breaker in registry.items():
+    print(name, breaker.state, breaker.snapshot())
+```
 
 `close_all()` / `aclose_all()` close every breaker created so far. The cache is
 kept, so `get()` keeps returning the same, torn-down instances instead of

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2848,8 +2848,8 @@ production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and
-`names()` just their hosts. Both are point-in-time copies: a host first seen
-afterwards is not in them.
+`names()` just the names they were created under. Both are point-in-time copies:
+a breaker created afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
@@ -3074,8 +3074,8 @@ production metrics. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and
-`names()` just their hosts. Both are point-in-time copies: a host first seen
-afterwards is not in them.
+`names()` just the names they were created under. Both are point-in-time copies:
+a breaker created afterwards is not in them.
 
 After tuning thresholds, deploy a new transport with the default
 `initial_state=State.CLOSED`. Do not reset only the currently known hosts: a
@@ -3357,7 +3357,7 @@ middleware = CircuitBreakerMiddleware(
 
 The public `middleware.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
-the hosts created so far — point-in-time copies, without the hosts first seen
+the breakers created so far — point-in-time copies, without the ones created
 afterwards. Use an `EventListener` for
 production metrics, then deploy a new middleware with the default `CLOSED`
 state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
@@ -3537,7 +3537,7 @@ adapter = CircuitBreakerAdapter(
 
 The public `adapter.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
-the hosts created so far — point-in-time copies, without the hosts first seen
+the breakers created so far — point-in-time copies, without the ones created
 afterwards. Use an `EventListener` for
 production metrics, then deploy a new adapter with the default `CLOSED` state
 to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,6 +44,8 @@ Registry(*, config=None, clock=None, initial_state=State.CLOSED,
          classifier=None, listener=None, storage=None)
 registry.get(name, *, config=None) -> CircuitBreaker
 registry.get_existing(name) -> CircuitBreaker | None
+registry.names() -> tuple[str, ...]
+registry.items() -> tuple[tuple[str, CircuitBreaker], ...]
 registry.close_all() / await registry.aclose_all()
 ```
 
@@ -52,6 +54,16 @@ instance; the per-call `config` override applies only at creation. A `storage`
 is handed to every breaker the registry creates; each coordinates under its own
 name. `initial_state` is assigned before a lazy breaker is published;
 `get_existing()` inspects the cache without creating a missing name.
+
+`names()` and `items()` enumerate the breakers created so far — the only way to
+see the ones the HTTP transports create lazily, one per host. Both take a
+point-in-time copy under the registry lock: a breaker created afterwards is not
+in it, and the returned tuple never changes.
+
+```python
+for name, breaker in registry.items():
+    print(name, breaker.state, breaker.snapshot())
+```
 
 `close_all()` / `aclose_all()` close every breaker created so far. The cache is
 kept, so `get()` keeps returning the same, torn-down instances instead of

--- a/interlock/registry.py
+++ b/interlock/registry.py
@@ -98,6 +98,30 @@ class Registry:
         with self._lock:
             return self._breakers.get(name)
 
+    def names(self) -> tuple[str, ...]:
+        """Return the names of the breakers created so far.
+
+        Returns:
+            A point-in-time copy taken under the registry lock: a breaker
+            created afterwards is not in it, and the returned tuple never
+            changes.
+        """
+        with self._lock:
+            return tuple(self._breakers)
+
+    def items(self) -> tuple[tuple[str, CircuitBreaker], ...]:
+        """Return every breaker created so far, paired with its name.
+
+        For listing states and snapshots in a diagnostics endpoint, or applying
+        an operator override to every breaker before a maintenance window.
+
+        Returns:
+            A point-in-time copy taken under the registry lock, with the same
+            snapshot semantics as ``names``.
+        """
+        with self._lock:
+            return tuple(self._breakers.items())
+
     def close_all(self) -> None:
         """Release the background resources of every breaker created so far.
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -67,6 +67,54 @@ def test__get_existing__created_name__returns_cached_breaker() -> None:
     assert registry.get_existing('payments') is breaker
 
 
+def test__names__no_breaker_created__returns_empty_tuple() -> None:
+    registry = Registry()
+
+    assert registry.names() == ()
+
+
+def test__names__created_breakers__returns_every_name() -> None:
+    registry = Registry()
+    registry.get('payments')
+    registry.get('search')
+
+    assert set(registry.names()) == {'payments', 'search'}
+
+
+def test__names__breaker_created_after_the_call__is_absent_from_the_snapshot() -> None:
+    registry = Registry()
+    registry.get('payments')
+
+    names = registry.names()
+    registry.get('search')
+
+    assert names == ('payments',)
+
+
+def test__items__no_breaker_created__returns_empty_tuple() -> None:
+    registry = Registry()
+
+    assert registry.items() == ()
+
+
+def test__items__created_breakers__pairs_each_name_with_its_breaker() -> None:
+    registry = Registry()
+    payments = registry.get('payments')
+    search = registry.get('search')
+
+    assert set(registry.items()) == {('payments', payments), ('search', search)}
+
+
+def test__items__breaker_created_after_the_call__is_absent_from_the_snapshot() -> None:
+    registry = Registry()
+    payments = registry.get('payments')
+
+    items = registry.items()
+    registry.get('search')
+
+    assert items == (('payments', payments),)
+
+
 def test__close_all__one_breaker_raises__still_closes_the_rest(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

`Registry` could only be asked about a name you already knew — `get`,
`get_existing`, `close_all`, `aclose_all`. That is exactly the case that does
not hold where the registry matters most: every HTTP integration creates its
breakers lazily, one per host, so the set of names only exists at runtime.
Listing them for a diagnostics endpoint during a `METRICS_ONLY` rollout, or
applying an operator override to all of them before a maintenance window, meant
reaching into the private `_breakers` dict.

```python
def names(self) -> tuple[str, ...]: ...
def items(self) -> tuple[tuple[str, CircuitBreaker], ...]: ...
```

Both return an immutable point-in-time copy taken under the registry lock,
mirroring what `_snapshot()` already does for teardown: a breaker created
afterwards is not in it, and the returned tuple never changes. `names()` covers
the "which hosts exist" question on its own; `items()` pairs each breaker with
its name, which `_snapshot()` cannot — it returns breakers only, enough for
teardown but not for a diagnostics listing.

No `__iter__` / `__len__`: a live view over a dict mutated under a lock is the
wrong shape here, and explicit copy-returning methods make the snapshot
semantics obvious at the call site.

Docs: reference, the safe-rollout section of the states guide (bulk operator
action), the four transport integration pages and the README diagnostics
paragraph, plus the regenerated `llms-full.txt`.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

`uv run griffe check interlock --search .` is clean — the change is purely
additive. `_state_machine.py` / `_engine.py` are untouched, so no mutmut run.

## Related issues

Closes #157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Added
- Added `Registry.names()` to return an immutable snapshot of cached breaker names.
- Added `Registry.items()` to return an immutable snapshot of `(name, CircuitBreaker)` pairs.
- Added enumeration support for breakers created lazily by transport integrations.

### Changed
- Documented point-in-time snapshot semantics for `Registry.names()` and `Registry.items()`.
- Documented bulk operations and runtime-created breaker inspection across registry and transport integration guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->