### PR TITLE
feat: expose the wrapped transport as a public read-only property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The guarded transport is reachable without private attributes.** The
+  httpx2/httpx transports kept the transport they wrap in `self._transport`,
+  so checking what a wrapper was actually built around — the pool limits, the
+  TLS context, the proxy — meant reading privates through two libraries, and
+  tests ended up asserting constructor kwargs instead of the object. Both the
+  synchronous and asynchronous transports now expose a read-only `wrapped`
+  property alongside `registry`.
+
 ### Fixed
 
 - **A bug in your own code no longer opens the circuit of a healthy

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -157,6 +157,27 @@ connection pool closes; the application must explicitly call
 `await registry.aclose_all()` during async shutdown, or `registry.close_all()`
 when every guarded client is synchronous.
 
+## Reach the wrapped transport
+
+`transport.wrapped` returns the transport being guarded, so a composed object
+can be unwrapped without touching private attributes — verifying the pool
+limits, TLS context or proxy the inner transport was built with, inspecting it
+in a REPL, or walking a chain of wrappers:
+
+```python
+import httpx
+
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport
+
+inner = httpx.AsyncHTTPTransport(limits=httpx.Limits(max_connections=20))
+transport = AsyncCircuitBreakerTransport(inner)
+
+assert transport.wrapped is inner
+```
+
+The property is read-only: the wrapped transport is fixed at construction. Both
+the synchronous and asynchronous classes expose it.
+
 ## What counts as a failure
 
 The default `HttpStatusClassifier` counts these as failures:

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -163,6 +163,27 @@ connection pool closes; the application must explicitly call
 `await registry.aclose_all()` during async shutdown (or `registry.close_all()`
 when all guarded clients are synchronous).
 
+## Reach the wrapped transport
+
+`transport.wrapped` returns the transport being guarded, so a composed object
+can be unwrapped without touching private attributes — verifying the pool
+limits, TLS context or proxy the inner transport was built with, inspecting it
+in a REPL, or walking a chain of wrappers:
+
+```python
+import httpx2
+
+from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
+
+inner = httpx2.AsyncHTTPTransport(limits=httpx2.Limits(max_connections=20))
+transport = AsyncCircuitBreakerTransport(inner)
+
+assert transport.wrapped is inner
+```
+
+The property is read-only: the wrapped transport is fixed at construction. Both
+the synchronous and asynchronous classes expose it.
+
 ## What counts as a failure
 
 By default the transport uses `HttpStatusClassifier`:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4517,8 +4517,9 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
   via `excluded_exceptions`.
 
 Both transports expose their per-host `registry` and the guarded transport as a
-read-only `wrapped`; `close()` / `aclose()` release the wrapped transport and
-every breaker in that registry. See the
+read-only `wrapped`. `close()` / `aclose()` release the wrapped transport and,
+when the transport owns the registry, every breaker in it; a caller-owned
+registry stays open and is closed by its owner. See the
 [httpx2 integration](integrations/httpx2.md).
 
 ## httpx adapters
@@ -4534,8 +4535,9 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
   `LocalProtocolError` exclusions.
 
 Both transports expose their per-host `registry` and the guarded transport as a
-read-only `wrapped`, preserve streaming responses, and release the wrapped
-transport and every breaker on `close()` / `aclose()`.
+read-only `wrapped`, and preserve streaming responses. `close()` / `aclose()`
+release the wrapped transport and, when the transport owns the registry, every
+breaker in it; a caller-owned registry stays open and is closed by its owner.
 See the [httpx integration](integrations/httpx.md).
 
 ## aiohttp adapters

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2911,6 +2911,27 @@ connection pool closes; the application must explicitly call
 `await registry.aclose_all()` during async shutdown (or `registry.close_all()`
 when all guarded clients are synchronous).
 
+## Reach the wrapped transport
+
+`transport.wrapped` returns the transport being guarded, so a composed object
+can be unwrapped without touching private attributes — verifying the pool
+limits, TLS context or proxy the inner transport was built with, inspecting it
+in a REPL, or walking a chain of wrappers:
+
+```python
+import httpx2
+
+from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
+
+inner = httpx2.AsyncHTTPTransport(limits=httpx2.Limits(max_connections=20))
+transport = AsyncCircuitBreakerTransport(inner)
+
+assert transport.wrapped is inner
+```
+
+The property is read-only: the wrapped transport is fixed at construction. Both
+the synchronous and asynchronous classes expose it.
+
 ## What counts as a failure
 
 By default the transport uses `HttpStatusClassifier`:
@@ -3131,6 +3152,27 @@ owns the registry. An injected registry remains open while the wrapped
 connection pool closes; the application must explicitly call
 `await registry.aclose_all()` during async shutdown, or `registry.close_all()`
 when every guarded client is synchronous.
+
+## Reach the wrapped transport
+
+`transport.wrapped` returns the transport being guarded, so a composed object
+can be unwrapped without touching private attributes — verifying the pool
+limits, TLS context or proxy the inner transport was built with, inspecting it
+in a REPL, or walking a chain of wrappers:
+
+```python
+import httpx
+
+from interlock.integrations.httpx import AsyncCircuitBreakerTransport
+
+inner = httpx.AsyncHTTPTransport(limits=httpx.Limits(max_connections=20))
+transport = AsyncCircuitBreakerTransport(inner)
+
+assert transport.wrapped is inner
+```
+
+The property is read-only: the wrapped transport is fixed at construction. Both
+the synchronous and asynchronous classes expose it.
 
 ## What counts as a failure
 
@@ -4421,8 +4463,9 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
   `LocalProtocolError` are caller-side and count as successes; replace that set
   via `excluded_exceptions`.
 
-Both transports expose their per-host `registry`; `close()` / `aclose()` release
-the wrapped transport and every breaker in that registry. See the
+Both transports expose their per-host `registry` and the guarded transport as a
+read-only `wrapped`; `close()` / `aclose()` release the wrapped transport and
+every breaker in that registry. See the
 [httpx2 integration](integrations/httpx2.md).
 
 ## httpx adapters
@@ -4437,8 +4480,9 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
   same policy, including the caller-side `UnsupportedProtocol` /
   `LocalProtocolError` exclusions.
 
-Both transports expose their per-host `registry`, preserve streaming responses,
-and release the wrapped transport and every breaker on `close()` / `aclose()`.
+Both transports expose their per-host `registry` and the guarded transport as a
+read-only `wrapped`, preserve streaming responses, and release the wrapped
+transport and every breaker on `close()` / `aclose()`.
 See the [httpx integration](integrations/httpx.md).
 
 ## aiohttp adapters

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -176,8 +176,9 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
   `LocalProtocolError` are caller-side and count as successes; replace that set
   via `excluded_exceptions`.
 
-Both transports expose their per-host `registry`; `close()` / `aclose()` release
-the wrapped transport and every breaker in that registry. See the
+Both transports expose their per-host `registry` and the guarded transport as a
+read-only `wrapped`; `close()` / `aclose()` release the wrapped transport and
+every breaker in that registry. See the
 [httpx2 integration](integrations/httpx2.md).
 
 ## httpx adapters
@@ -192,8 +193,9 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
   same policy, including the caller-side `UnsupportedProtocol` /
   `LocalProtocolError` exclusions.
 
-Both transports expose their per-host `registry`, preserve streaming responses,
-and release the wrapped transport and every breaker on `close()` / `aclose()`.
+Both transports expose their per-host `registry` and the guarded transport as a
+read-only `wrapped`, preserve streaming responses, and release the wrapped
+transport and every breaker on `close()` / `aclose()`.
 See the [httpx integration](integrations/httpx.md).
 
 ## aiohttp adapters

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -197,8 +197,9 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
   via `excluded_exceptions`.
 
 Both transports expose their per-host `registry` and the guarded transport as a
-read-only `wrapped`; `close()` / `aclose()` release the wrapped transport and
-every breaker in that registry. See the
+read-only `wrapped`. `close()` / `aclose()` release the wrapped transport and,
+when the transport owns the registry, every breaker in it; a caller-owned
+registry stays open and is closed by its owner. See the
 [httpx2 integration](integrations/httpx2.md).
 
 ## httpx adapters
@@ -214,8 +215,9 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
   `LocalProtocolError` exclusions.
 
 Both transports expose their per-host `registry` and the guarded transport as a
-read-only `wrapped`, preserve streaming responses, and release the wrapped
-transport and every breaker on `close()` / `aclose()`.
+read-only `wrapped`, and preserve streaming responses. `close()` / `aclose()`
+release the wrapped transport and, when the transport owns the registry, every
+breaker in it; a caller-owned registry stays open and is closed by its owner.
 See the [httpx integration](integrations/httpx.md).
 
 ## aiohttp adapters

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -221,6 +221,11 @@ class CircuitBreakerTransport(BaseTransport):
         """The breaker registry, exposed for diagnostics and operator control."""
         return self._registry
 
+    @property
+    def wrapped(self) -> BaseTransport:
+        """The transport this wrapper delegates to."""
+        return self._transport
+
     def handle_request(self, request: Request) -> Response:
         """Run a request under the breaker for its resolved dependency.
 
@@ -314,6 +319,11 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
     def registry(self) -> Registry:
         """The breaker registry, exposed for diagnostics and operator control."""
         return self._registry
+
+    @property
+    def wrapped(self) -> AsyncBaseTransport:
+        """The transport this wrapper delegates to."""
+        return self._transport
 
     async def handle_async_request(self, request: Request) -> Response:
         """Run a request under the breaker for its resolved dependency.

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -221,6 +221,11 @@ class CircuitBreakerTransport(BaseTransport):
         """The breaker registry, exposed for diagnostics and operator control."""
         return self._registry
 
+    @property
+    def wrapped(self) -> BaseTransport:
+        """The transport this wrapper delegates to."""
+        return self._transport
+
     def handle_request(self, request: Request) -> Response:
         """Run the request under its resolved dependency's breaker.
 
@@ -315,6 +320,11 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
     def registry(self) -> Registry:
         """The breaker registry, exposed for diagnostics and operator control."""
         return self._registry
+
+    @property
+    def wrapped(self) -> AsyncBaseTransport:
+        """The transport this wrapper delegates to."""
+        return self._transport
 
     async def handle_async_request(self, request: Request) -> Response:
         """Run the request under its resolved dependency's breaker.

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -212,6 +212,13 @@ def test__sync_transport__context_manager__delegates_wrapped_lifecycle() -> None
     assert inner.closed
 
 
+def test__sync_transport__wrapped__exposes_inner_transport() -> None:
+    inner = _SyncStub(lambda _request: httpx.Response(200))
+    transport = CircuitBreakerTransport(inner)
+
+    assert transport.wrapped is inner
+
+
 def test__sync_transport__streaming_response__preserves_stream(fake_clock: FakeClock) -> None:
     response = httpx.Response(200, stream=_SyncStream())
     inner = _SyncStub(lambda _request: response)
@@ -522,6 +529,13 @@ async def test__async_transport__context_manager__delegates_wrapped_lifecycle() 
     assert response.status_code == 200
     assert inner.exited
     assert inner.closed
+
+
+def test__async_transport__wrapped__exposes_inner_transport() -> None:
+    inner = _AsyncStub(lambda _request: httpx.Response(200))
+    transport = AsyncCircuitBreakerTransport(inner)
+
+    assert transport.wrapped is inner
 
 
 @pytest.mark.asyncio

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -195,6 +195,13 @@ def test__sync_transport__context_manager__delegates_wrapped_lifecycle() -> None
     assert inner.closed
 
 
+def test__sync_transport__wrapped__exposes_inner_transport() -> None:
+    inner = _SyncStub(lambda _request: Response(200))
+    transport = CircuitBreakerTransport(inner)
+
+    assert transport.wrapped is inner
+
+
 def test__sync_transport__server_errors__open_breaker_for_host(fake_clock: FakeClock) -> None:
     inner = _SyncStub(lambda _request: Response(503))
     transport = CircuitBreakerTransport(inner, config=_TRIP_FAST, clock=fake_clock)
@@ -376,6 +383,13 @@ async def test__async_transport__context_manager__delegates_wrapped_lifecycle() 
     assert response.status_code == 200
     assert inner.exited
     assert inner.closed
+
+
+def test__async_transport__wrapped__exposes_inner_transport() -> None:
+    inner = _AsyncStub(lambda _request: Response(200))
+    transport = AsyncCircuitBreakerTransport(inner)
+
+    assert transport.wrapped is inner
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Both httpx2/httpx transport wrappers kept the transport they wrap in a private
`self._transport`, while `registry` was already a public read-only property.
Verifying what a wrapper was actually built around — the pool limits, the TLS
context, the proxy — meant reading privates across two libraries
(`transport._transport._pool._max_connections`), so tests ended up asserting
constructor kwargs instead of the object that was built.

Both the synchronous and asynchronous transports now expose a read-only
`wrapped` property alongside `registry`, in `interlock.integrations.httpx` and
`interlock.integrations.httpx2`. The wrapped transport is fixed at
construction, so there is no setter.

`CircuitBreakerAdapter` (requests) inherits from `HTTPAdapter` and has no
equivalent inner object, and the aiohttp middleware wraps no transport, so the
change stays transport-specific — as scoped in the issue.

Additive only: a new property on existing classes, no behaviour change on any
request path (`griffe check` reports no API breakage).

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

Test plan: four unit tests (sync + async × httpx + httpx2) asserting the
property returns the exact transport passed in; written first, verified failing
with `AttributeError` before the property existed. Full suite: 771 passed,
2 skipped, coverage 100%. Docs examples were executed against both libraries.

## Related issues

Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Added

- Added read-only `wrapped` properties to synchronous and asynchronous `CircuitBreakerTransport` classes in the `httpx` and `httpx2` extras.
- Exposed the underlying transport through the public API alongside `registry`.

### Changed

- Updated integration and API documentation for `wrapped`.
- Added tests for synchronous and asynchronous `httpx` and `httpx2` transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->