### PR TITLE
chore: prepare the 2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-08-12
+
 ### Added
 
 - **`CircuitBreaker.call_sync()` and `call_async()` protect a call without
@@ -787,7 +789,8 @@ The major version marks the scope of what is added, not a migration burden.
 - `InterlockDeprecationWarning` (subclasses `UserWarning`, visible by default).
 - `py.typed`; strict mypy and pyright; 100% test coverage.
 
-[Unreleased]: https://github.com/bagowix/interlock/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/bagowix/interlock/compare/v2.6.0...HEAD
+[2.6.0]: https://github.com/bagowix/interlock/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/bagowix/interlock/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/bagowix/interlock/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/bagowix/interlock/compare/v2.2.0...v2.3.0

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,7 +35,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.5.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of August 2026) | 2.6.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -770,7 +770,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.5.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of August 2026) | 2.6.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/interlock/version.py
+++ b/interlock/version.py
@@ -7,7 +7,7 @@ and read at build time by hatchling (see ``[tool.hatch.version]`` in
 
 __all__ = ('VERSION',)
 
-VERSION = '2.5.0'
+VERSION = '2.6.0'
 """The installed version of interlock.
 
 Guaranteed to comply with PEP 440 version specifiers.


### PR DESCRIPTION
## Summary

Prepare the `2.6.0` minor release.

- Bump the package version from `2.5.0` to `2.6.0`.
- Move the current `[Unreleased]` changelog entries into `[2.6.0] - 2026-08-12`.
- Update changelog comparison links and the comparison-page release version.
- Regenerate `docs/llms-full.txt`.

Minor, not patch: the release includes backward-compatible public additions —
`CircuitBreaker.call_sync()` / `call_async()`, `Registry.names()` / `items()`
and the read-only `wrapped` property on the httpx2/httpx transports.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

Additional release checks: the package build passes (`interlock_cb-2.6.0`).
Griffe reports only the expected public `VERSION` change (`2.5.0` → `2.6.0`).

## Related issues

Closes #155
Closes #156
Closes #157
Closes #158
Closes #159