### PR TITLE
docs: describe the project on the pages that represent it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Documentation pages now carry Open Graph and Twitter card tags.** A link to
+  any page pasted into Slack, Reddit or a chat rendered as a bare url, because
+  the theme emits no such tags and nothing supplied them. Each page now declares
+  its title, description and canonical url. The card is the text-only `summary`
+  kind: Zensical ships no social-card generation and the documentation carries
+  no image asset.
+
 ### Changed
 
 - **The PyPI sidebar no longer links to the same page twice.** `Homepage` and
@@ -14,14 +23,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the documentation. `Homepage` now points at the documentation site; the
   repository stays reachable through `Repository`.
 
+- **Page titles now describe the page to someone who has not arrived yet.**
+  Titles were written for a reader already inside the site — `Comparison`,
+  `httpx`, `Timeout` — which tells someone meeting the project in a search
+  result or a pasted link nothing about what they are looking at. A
+  `seo_titles` map in `zensical.toml` gives each page a self-describing title;
+  a page left out of the map keeps the theme default.
+
 ### Fixed
 
 - **The documentation landing page was titled `interlock - interlock`.**
   Zensical does not populate `page.is_homepage`, so the theme fell through to
   the generic "page title - site name" branch and duplicated the project name
   on the one page that is linked and ranked the most, leaving it without a
-  single word describing what the project is. The landing page now carries a
-  descriptive title; every other page is unchanged.
+  single word describing what the project is.
 
 ## [2.6.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   kind: Zensical ships no social-card generation and the documentation carries
   no image asset.
 
+- **The documentation site is verified with Google Search Console.** Every
+  generated page carries the ownership tag for the property, so the maintainers
+  can finally see which pages are indexed and which searches reach them —
+  previously a blind spot. Nothing about the library itself changes. Removing
+  the tag silently un-verifies the property.
+
 ### Changed
 
 - **Every link in the PyPI sidebar now goes somewhere different.** `Homepage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The PyPI sidebar no longer links to the same page twice.** `Homepage` and
+  `Repository` both pointed at the GitHub repository, so a reader arriving on
+  the package page got two identically-targeted links and no obvious route to
+  the documentation. `Homepage` now points at the documentation site; the
+  repository stays reachable through `Repository`.
+
+### Fixed
+
+- **The documentation landing page was titled `interlock - interlock`.**
+  Zensical does not populate `page.is_homepage`, so the theme fell through to
+  the generic "page title - site name" branch and duplicated the project name
+  on the one page that is linked and ranked the most, leaving it without a
+  single word describing what the project is. The landing page now carries a
+  descriptive title; every other page is unchanged.
+
 ## [2.6.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **The PyPI sidebar no longer links to the same page twice.** `Homepage` and
-  `Repository` both pointed at the GitHub repository, so a reader arriving on
-  the package page got two identically-targeted links and no obvious route to
-  the documentation. `Homepage` now points at the documentation site; the
-  repository stays reachable through `Repository`.
+- **Every link in the PyPI sidebar now goes somewhere different.** `Homepage`
+  and `Repository` both pointed at the GitHub repository, so a reader arriving
+  on the package page got two identically-targeted links and no obvious route
+  to the documentation. `Homepage` now points at the documentation site and the
+  redundant `Documentation` entry is gone; the repository stays reachable
+  through `Repository`.
 
 - **Page titles now describe the page to someone who has not arrived yet.**
   Titles were written for a reader already inside the site — `Comparison`,

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,17 @@
 {% extends "base.html" %}
 
+{# Zensical does not populate page.is_homepage, so the theme falls through to
+   "{{ page.title }} - {{ site_name }}" and the landing page ends up titled
+   "interlock - interlock" — a duplicated brand and no keyword for the one page
+   search engines rank first. The homepage is identified by its empty url. #}
+{% block htmltitle %}
+  {% if not page.url %}
+    <title>interlock — a modern circuit breaker for Python</title>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block scripts %}
   {{ super() }}
   <script src="https://context7.com/widget.js" data-library="/bagowix/interlock"></script>

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -21,6 +21,12 @@
    as a bare url. Zensical ships no social-card generation and the docs carry no
    image asset, so this is the text-only `summary` card, not a large one. #}
 {% block extrahead %}
+  {# Proves ownership of https://bagowix.github.io/interlock/ to Google Search
+     Console. Public by design, not a secret. Google only reads it from the
+     property root, but emitting it everywhere costs nothing and does not depend
+     on detecting the landing page — the very thing Zensical gets wrong above.
+     Removing this tag silently un-verifies the property. #}
+  <meta name="google-site-verification" content="0pvG2U_OKhCqv-fBlzprkqkYKRno4kI_bE3XpmO1JLw">
   {% set og_title = seo_titles[page.url] if page.url in seo_titles else (page.title | striptags) %}
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ config.site_name }}">

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,15 +1,35 @@
 {% extends "base.html" %}
 
-{# Zensical does not populate page.is_homepage, so the theme falls through to
-   "{{ page.title }} - {{ site_name }}" and the landing page ends up titled
-   "interlock - interlock" — a duplicated brand and no keyword for the one page
-   search engines rank first. The homepage is identified by its empty url. #}
+{# Page titles are written for someone already inside the site — "Comparison",
+   "httpx", "Timeout" — which says nothing to someone meeting the project in a
+   search result or a pasted link. `seo_titles` in zensical.toml maps a page url
+   to the title that page should carry outside the site. It also covers the
+   landing page: Zensical never populates `page.is_homepage`, so the theme falls
+   through to "{{ page.title }} - {{ site_name }}" and titles it
+   "interlock - interlock". A page absent from the map keeps the theme default. #}
+{% set seo_titles = config.extra.seo_titles | d({}) %}
+
 {% block htmltitle %}
-  {% if not page.url %}
-    <title>interlock — a modern circuit breaker for Python</title>
+  {% if page.url in seo_titles %}
+    <title>{{ seo_titles[page.url] }} · {{ config.site_name }}</title>
   {% else %}
     {{ super() }}
   {% endif %}
+{% endblock %}
+
+{# Without these a link to the docs pasted into Slack, Reddit or a chat renders
+   as a bare url. Zensical ships no social-card generation and the docs carry no
+   image asset, so this is the text-only `summary` card, not a large one. #}
+{% block extrahead %}
+  {% set og_title = seo_titles[page.url] if page.url in seo_titles else (page.title | striptags) %}
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ og_title }}">
+  <meta property="og:description" content="{{ config.site_description }}">
+  <meta property="og:url" content="{{ page.canonical_url }}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ og_title }}">
+  <meta name="twitter:description" content="{{ config.site_description }}">
 {% endblock %}
 
 {% block scripts %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ aiohttp = ["aiohttp>=3.12.0"]
 
 [project.urls]
 Homepage = "https://bagowix.github.io/interlock/"
-Documentation = "https://bagowix.github.io/interlock/"
 Repository = "https://github.com/bagowix/interlock"
 Changelog = "https://github.com/bagowix/interlock/blob/main/CHANGELOG.md"
 Issues = "https://github.com/bagowix/interlock/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requests = ["requests>=2.31.0"]
 aiohttp = ["aiohttp>=3.12.0"]
 
 [project.urls]
-Homepage = "https://github.com/bagowix/interlock"
+Homepage = "https://bagowix.github.io/interlock/"
 Documentation = "https://bagowix.github.io/interlock/"
 Repository = "https://github.com/bagowix/interlock"
 Changelog = "https://github.com/bagowix/interlock/blob/main/CHANGELOG.md"

--- a/zensical.toml
+++ b/zensical.toml
@@ -67,3 +67,35 @@ custom_fences = [
 alternate_style = true
 [project.markdown_extensions.pymdownx.tasklist]
 custom_checkbox = true
+
+# Titles for readers who have not arrived yet: search results, pasted links,
+# social cards. Keyed by page url ("" is the landing page), consumed by the
+# htmltitle and extrahead blocks in overrides/main.html, which append the site
+# name. Keep each under ~60 characters or search engines truncate it. A page
+# left out of this map keeps the theme's "<page title> - interlock".
+[project.extra.seo_titles]
+"" = "A modern circuit breaker for Python"
+"getting-started/" = "Getting started with a Python circuit breaker"
+"comparison/" = "Python circuit breaker libraries compared"
+"migration/" = "Migrating from pybreaker or circuitbreaker"
+"demo/" = "A runnable Python circuit breaker demo"
+"correctness/" = "How the circuit breaker is tested for correctness"
+"reference/" = "Python circuit breaker API reference"
+"guides/configuration/" = "Configuring a Python circuit breaker"
+"guides/states/" = "Circuit breaker states and manual control"
+"guides/failure-classification/" = "Which failures should trip a circuit breaker"
+"guides/observability/" = "Circuit breaker metrics and OpenTelemetry"
+"guides/timeout/" = "Timeouts with a Python circuit breaker"
+"guides/retries/" = "Retries and circuit breakers in Python"
+"guides/pipeline/" = "Resilience pipeline: timeout, retry, bulkhead"
+"integrations/" = "Circuit breaker integrations for Python clients"
+"integrations/fastapi/" = "FastAPI circuit breaker with 503 and Retry-After"
+"integrations/litestar/" = "Litestar circuit breaker with 503 and Retry-After"
+"integrations/httpx/" = "httpx circuit breaker transport"
+"integrations/httpx2/" = "httpx2 circuit breaker transport"
+"integrations/aiohttp/" = "aiohttp circuit breaker middleware"
+"integrations/requests/" = "requests circuit breaker adapter"
+"integrations/redis/" = "Distributed circuit breaker state in Redis"
+"integrations/tenacity/" = "tenacity retries with a circuit breaker"
+"integrations/llm/" = "Circuit breaker for OpenAI and Anthropic calls"
+"integrations/frameworks/" = "Circuit breaker for Flask and Django"


### PR DESCRIPTION
## Summary

Nothing about the package's public surface changes. Three defects on the pages
that represent the project to people who have not adopted it yet.

**Two entries in `[project.urls]` pointed at the same page.** `Homepage` and
`Repository` both named the GitHub repository, so the PyPI sidebar rendered two
identically-targeted links and offered a reader no route to the documentation.
`Homepage` now points at the documentation site, which makes the separate
`Documentation` entry redundant, so it is gone. Four links, four destinations.

**The documentation landing page was titled `interlock - interlock`.** Zensical
never populates `page.is_homepage`, so the theme falls through to its
`<page title> - <site name>` branch and duplicates the project name on the one
page that is linked and ranked the most, without a single word saying what the
project is. The rest of the titles had the matching problem in a milder form:
`Comparison`, `httpx`, `Timeout` are written for a reader already inside the
site and tell someone meeting the project in a search result nothing.

A `seo_titles` map in `zensical.toml`, keyed by page url and consumed by the
`htmltitle` block, now covers all 25 published pages; the block appends the site
name. Titles are data in the config rather than branches in the template, so
adding a page is a one-line change, and a page left out of the map keeps the
theme default rather than breaking. Every title stays under the length at which
search results truncate.

**No Open Graph or Twitter card tags anywhere.** The theme emits none and
nothing supplied them, so a link to the docs pasted into Slack, Reddit or a
chat rendered as a bare url. Each page now declares its title, description and
canonical url. The card is the text-only `summary` kind — Zensical ships no
social-card generation and the documentation carries no image asset to point
`og:image` at.

Also adds the Google Search Console ownership tag for the URL-prefix property
`https://bagowix.github.io/interlock/`. The token is public by design, ships in
the HTML of every page, and proves ownership only — it grants no access. Why it
is emitted on every page rather than the landing page alone is explained where
it matters, next to the tag in `overrides/main.html`.

### After merging

`docs.yml` deploys on push to `main` only, so the verification tag reaches the
live site only once this lands. Confirm with

```
curl -s https://bagowix.github.io/interlock/ | grep google-site-verification
```

and only then press **Verify** in Search Console, followed by submitting
`sitemap.xml` under **Sitemaps**.

## Checklist

- [ ] Tests added or updated (suite stays at 100% coverage) — no Python changed,
      so nothing was added to test; the suite passes unchanged (772 passed,
      2 skipped) and coverage is untouched.
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes — this PR is the docs
      change. No content page was edited, so `docs/llms-full.txt` needs no
      regeneration and `docs/llms.txt` gains no entry.
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

Verified by building the site and asserting across every generated page that the
mapped title rendered, that each stayed under the truncation length, and that
the Open Graph, Twitter and verification tags were present; and by building the
wheel and asserting that no two `Project-URL` entries share a target.

## Related issues

None — not tracked by an issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Added
- Added SEO titles for all 25 published documentation pages.
- Added page descriptions, canonical URLs, Open Graph metadata, Twitter summary-card metadata, and Google Search Console verification metadata.

### Fixed
- Fixed the duplicated documentation landing-page title.
- Fixed duplicate PyPI documentation links.

### Changed
- Changed the PyPI `Homepage` URL to `https://bagowix.github.io/interlock/`.
- Retained the GitHub repository URL under `Repository`.
- Updated `CHANGELOG.md`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->