### PR TITLE
docs: improve README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   copying the shadow-mode snippet — the one the documentation recommends
   starting with — got a `NameError` before reaching the breaker. They now pass
   the built-in `LoggingEventListener()`, which needs no setup and can be
-  swapped for a metrics exporter.
+  swapped for a metrics exporter. The `aiohttp` and `requests` blocks also
+  never imported the middleware and the adapter they construct, unlike every
+  other block on those pages.
 
 ## [2.6.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   on the one page that is linked and ranked the most, leaving it without a
   single word describing what the project is.
 
+- **Every safe-rollout example now runs as written.** The README and the
+  `httpx`, `httpx2`, `aiohttp` and `requests` pages passed
+  `listener=metrics_listener`, a name defined nowhere on the page, so anyone
+  copying the shadow-mode snippet — the one the documentation recommends
+  starting with — got a `NameError` before reaching the breaker. They now pass
+  the built-in `LoggingEventListener()`, which needs no setup and can be
+  swapped for a metrics exporter.
+
 ## [2.6.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # interlock
 
 [![CI](https://github.com/bagowix/interlock/actions/workflows/ci.yml/badge.svg)](https://github.com/bagowix/interlock/actions/workflows/ci.yml)
@@ -82,18 +80,19 @@ per-host breaker can admit its first request:
 ```python
 import httpx2
 
-from interlock import Config, State
+from interlock import Config, LoggingEventListener, State
 from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
 
 transport = AsyncCircuitBreakerTransport(
     httpx2.AsyncHTTPTransport(),
     initial_state=State.METRICS_ONLY,
     config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
-    listener=None,  # or a custom EventListener instance
+    listener=LoggingEventListener(),
 )
 ```
 
-Use an `EventListener` for production metrics. For local diagnostics,
+`LoggingEventListener` writes every event through stdlib logging; swap it for
+an `EventListener` that exports to your metrics backend. For local diagnostics,
 `transport.registry.get_existing(host)` returns an already-created breaker
 without creating one, so its `state` and `snapshot()` can be inspected safely.
 Hosts are only known at runtime, so `transport.registry.items()` lists every

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # interlock
 
 [![CI](https://github.com/bagowix/interlock/actions/workflows/ci.yml/badge.svg)](https://github.com/bagowix/interlock/actions/workflows/ci.yml)
@@ -87,7 +89,7 @@ transport = AsyncCircuitBreakerTransport(
     httpx2.AsyncHTTPTransport(),
     initial_state=State.METRICS_ONLY,
     config=Config(failure_rate_threshold=0.25, minimum_number_of_calls=50),
-    listener=metrics_listener,
+    listener=None,  # or a custom EventListener instance
 )
 ```
 

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -116,6 +116,7 @@ its first request:
 
 ```python
 from interlock import LoggingEventListener, State
+from interlock.integrations.aiohttp import CircuitBreakerMiddleware
 
 middleware = CircuitBreakerMiddleware(
     initial_state=State.METRICS_ONLY,
@@ -126,9 +127,10 @@ middleware = CircuitBreakerMiddleware(
 The public `middleware.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
 the breakers created so far — point-in-time copies, without the ones created
-afterwards. Use an `EventListener` for
-production metrics, then deploy a new middleware with the default `CLOSED`
-state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
+afterwards. `LoggingEventListener` writes every event through stdlib logging;
+swap it for an `EventListener` that exports to your metrics backend, then
+deploy a new middleware with the default `CLOSED` state to begin enforcement.
+See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -115,11 +115,11 @@ rejecting requests. The state is applied to every lazily created host before
 its first request:
 
 ```python
-from interlock import State
+from interlock import LoggingEventListener, State
 
 middleware = CircuitBreakerMiddleware(
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -57,13 +57,13 @@ Start in shadow mode when introducing the integration to existing traffic:
 ```python
 import httpx
 
-from interlock import State
+from interlock import LoggingEventListener, State
 from interlock.integrations.httpx import AsyncCircuitBreakerTransport
 
 transport = AsyncCircuitBreakerTransport(
     httpx.AsyncHTTPTransport(),
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -68,8 +68,9 @@ transport = AsyncCircuitBreakerTransport(
 ```
 
 Every host created later starts in `METRICS_ONLY` before its first request: it
-records outcomes but never raises `CircuitOpenError`. Use the listener for
-production metrics. For local diagnosis,
+records outcomes but never raises `CircuitOpenError`. `LoggingEventListener`
+writes every event through stdlib logging; swap it for an `EventListener` that
+exports to your metrics backend. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -61,13 +61,13 @@ Start in shadow mode when introducing the integration to existing traffic:
 ```python
 import httpx2
 
-from interlock import State
+from interlock import LoggingEventListener, State
 from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
 
 transport = AsyncCircuitBreakerTransport(
     httpx2.AsyncHTTPTransport(),
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -72,8 +72,9 @@ transport = AsyncCircuitBreakerTransport(
 ```
 
 Every host created later starts in `METRICS_ONLY` before its first request: it
-records outcomes but never raises `CircuitOpenError`. Use the listener for
-production metrics. For local diagnosis,
+records outcomes but never raises `CircuitOpenError`. `LoggingEventListener`
+writes every event through stdlib logging; swap it for an `EventListener` that
+exports to your metrics backend. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -120,6 +120,7 @@ its first request:
 
 ```python
 from interlock import LoggingEventListener, State
+from interlock.integrations.requests import CircuitBreakerAdapter
 
 adapter = CircuitBreakerAdapter(
     initial_state=State.METRICS_ONLY,
@@ -130,9 +131,10 @@ adapter = CircuitBreakerAdapter(
 The public `adapter.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
 the breakers created so far — point-in-time copies, without the ones created
-afterwards. Use an `EventListener` for
-production metrics, then deploy a new adapter with the default `CLOSED` state
-to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
+afterwards. `LoggingEventListener` writes every event through stdlib logging;
+swap it for an `EventListener` that exports to your metrics backend, then
+deploy a new adapter with the default `CLOSED` state to begin enforcement.
+See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -119,11 +119,11 @@ rejecting requests. The state is applied to every lazily created host before
 its first request:
 
 ```python
-from interlock import State
+from interlock import LoggingEventListener, State
 
 adapter = CircuitBreakerAdapter(
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2869,8 +2869,9 @@ transport = AsyncCircuitBreakerTransport(
 ```
 
 Every host created later starts in `METRICS_ONLY` before its first request: it
-records outcomes but never raises `CircuitOpenError`. Use the listener for
-production metrics. For local diagnosis,
+records outcomes but never raises `CircuitOpenError`. `LoggingEventListener`
+writes every event through stdlib logging; swap it for an `EventListener` that
+exports to your metrics backend. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and
@@ -3116,8 +3117,9 @@ transport = AsyncCircuitBreakerTransport(
 ```
 
 Every host created later starts in `METRICS_ONLY` before its first request: it
-records outcomes but never raises `CircuitOpenError`. Use the listener for
-production metrics. For local diagnosis,
+records outcomes but never raises `CircuitOpenError`. `LoggingEventListener`
+writes every event through stdlib logging; swap it for an `EventListener` that
+exports to your metrics backend. For local diagnosis,
 `transport.registry.get_existing(host)` returns an existing breaker without
 creating one; inspect its `state` and `snapshot()`. Hosts are only known at
 runtime, so `transport.registry.items()` lists the breakers created so far and
@@ -3416,6 +3418,7 @@ its first request:
 
 ```python
 from interlock import LoggingEventListener, State
+from interlock.integrations.aiohttp import CircuitBreakerMiddleware
 
 middleware = CircuitBreakerMiddleware(
     initial_state=State.METRICS_ONLY,
@@ -3426,9 +3429,10 @@ middleware = CircuitBreakerMiddleware(
 The public `middleware.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
 the breakers created so far — point-in-time copies, without the ones created
-afterwards. Use an `EventListener` for
-production metrics, then deploy a new middleware with the default `CLOSED`
-state to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
+afterwards. `LoggingEventListener` writes every event through stdlib logging;
+swap it for an `EventListener` that exports to your metrics backend, then
+deploy a new middleware with the default `CLOSED` state to begin enforcement.
+See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 
@@ -3596,6 +3600,7 @@ its first request:
 
 ```python
 from interlock import LoggingEventListener, State
+from interlock.integrations.requests import CircuitBreakerAdapter
 
 adapter = CircuitBreakerAdapter(
     initial_state=State.METRICS_ONLY,
@@ -3606,9 +3611,10 @@ adapter = CircuitBreakerAdapter(
 The public `adapter.registry` supports local diagnosis with
 `get_existing(host)`, `state` and `snapshot()`, plus `names()` and `items()` for
 the breakers created so far — point-in-time copies, without the ones created
-afterwards. Use an `EventListener` for
-production metrics, then deploy a new adapter with the default `CLOSED` state
-to begin enforcement. See [Safe rollout](../guides/states.md#safe-rollout).
+afterwards. `LoggingEventListener` writes every event through stdlib logging;
+swap it for an `EventListener` that exports to your metrics backend, then
+deploy a new adapter with the default `CLOSED` state to begin enforcement.
+See [Safe rollout](../guides/states.md#safe-rollout).
 
 ## Failure policy
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2858,13 +2858,13 @@ Start in shadow mode when introducing the integration to existing traffic:
 ```python
 import httpx2
 
-from interlock import State
+from interlock import LoggingEventListener, State
 from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport
 
 transport = AsyncCircuitBreakerTransport(
     httpx2.AsyncHTTPTransport(),
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 
@@ -3105,13 +3105,13 @@ Start in shadow mode when introducing the integration to existing traffic:
 ```python
 import httpx
 
-from interlock import State
+from interlock import LoggingEventListener, State
 from interlock.integrations.httpx import AsyncCircuitBreakerTransport
 
 transport = AsyncCircuitBreakerTransport(
     httpx.AsyncHTTPTransport(),
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 
@@ -3415,11 +3415,11 @@ rejecting requests. The state is applied to every lazily created host before
 its first request:
 
 ```python
-from interlock import State
+from interlock import LoggingEventListener, State
 
 middleware = CircuitBreakerMiddleware(
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 
@@ -3595,11 +3595,11 @@ rejecting requests. The state is applied to every lazily created host before
 its first request:
 
 ```python
-from interlock import State
+from interlock import LoggingEventListener, State
 
 adapter = CircuitBreakerAdapter(
     initial_state=State.METRICS_ONLY,
-    listener=metrics_listener,
+    listener=LoggingEventListener(),
 )
 ```
 


### PR DESCRIPTION
Makes one small, focused improvement to the existing README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Fixed
- Replaced the undefined `metrics_listener` with the public `LoggingEventListener()` from the core package in safe-rollout examples.
- Added missing imports for the aiohttp middleware and requests adapter examples.
- Prevented `NameError` failures when users copy the examples.

### Changed
- Updated the README and httpx, httpx2, aiohttp, and requests integration pages.
- Documented standard-library logging and replacement with a metrics-exporting `EventListener`.
- Regenerated `docs/llms-full.txt`.
- Added an `[Unreleased]` changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->