### PR TITLE
chore: prepare the 2.6.1 releas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-08-17
+
 ### Added
 
 - **Documentation pages now carry Open Graph and Twitter card tags.** A link to
@@ -869,7 +871,8 @@ The major version marks the scope of what is added, not a migration burden.
 - `InterlockDeprecationWarning` (subclasses `UserWarning`, visible by default).
 - `py.typed`; strict mypy and pyright; 100% test coverage.
 
-[Unreleased]: https://github.com/bagowix/interlock/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/bagowix/interlock/compare/v2.6.1...HEAD
+[2.6.1]: https://github.com/bagowix/interlock/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/bagowix/interlock/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/bagowix/interlock/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/bagowix/interlock/compare/v2.3.0...v2.4.0

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,7 +35,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.6.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of August 2026) | 2.6.1 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -770,7 +770,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.6.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of August 2026) | 2.6.1 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/interlock/version.py
+++ b/interlock/version.py
@@ -7,7 +7,7 @@ and read at build time by hatchling (see ``[tool.hatch.version]`` in
 
 __all__ = ('VERSION',)
 
-VERSION = '2.6.0'
+VERSION = '2.6.1'
 """The installed version of interlock.
 
 Guaranteed to comply with PEP 440 version specifiers.


### PR DESCRIPTION
## Summary

Prepare the `2.6.1` patch release.

* Bump the package version from `2.6.0` to `2.6.1`.
* Move the current `[Unreleased]` changelog entries into `[2.6.1] - 2026-08-17`.
* Update changelog comparison links and the comparison-page release version.
* Regenerate `docs/llms-full.txt`.

Patch, not minor: nothing under `interlock/` changed since v2.6.0 — the release carries documentation and packaging metadata only (#166, #173, #174), and griffe reports the `VERSION` attribute as the sole public difference.

It exists because a package page keeps the description and the project urls of the version that was uploaded, so none of that work is visible where it was aimed. pypi.org currently serves the README whose 31 relative links answer 404 there, and a `Homepage` pointing at the repository rather than at the documentation. Checked on the built wheel: `Homepage` → the documentation site, 0 relative links in the long description, state-machine diagram embedded.

## Checklist

* [x] Tests added or updated (suite stays at 100% coverage)
* [x] `uv run ruff format --check` and `uv run ruff check` pass
* [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
* [x] Docs updated (`docs/`) for user-facing changes
* [x] `CHANGELOG.md` `[Unreleased]` updated
* [x] Commits follow Conventional Commits

Additional release checks: the package build passes (`interlock_cb-2.6.1`), `twine check` PASSED on both artefacts, and griffe reports only the expected public `VERSION` change (`2.6.0` → `2.6.1`).

One timing note for tagging: GitHub is currently returning `No server is currently available to service your request` on parts of its API — CodeQL and Scorecard failed that way on #174 and on `main`, at the Initialize step rather than in analysis. Worth having those green before pushing the tag, so the publish job does not meet the same outage.

## Related issues

#166 
#173 
#174 
