### PR TITLE
feat: raise rejections inside each client library's exception hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **A rejected request now lands in its client library's own exception
+  hierarchy.** Every HTTP integration raised a bare `CircuitOpenError`, a type
+  no handler written against httpx, aiohttp or requests catches. Application
+  code degrades on the idiom its client teaches — `except httpx.TransportError`,
+  `except requests.exceptions.RequestException`, `except aiohttp.ClientError` —
+  so the day a breaker left `METRICS_ONLY` and started rejecting, the rejection
+  flew past every one of those handlers at once and turned a partial outage into
+  a full one. The rejection is now `CircuitOpenTransportError` (httpx, httpx2),
+  `CircuitOpenClientError` (aiohttp) or `CircuitOpenRequestError` (requests):
+  each is both a native error of the host library and still a
+  `CircuitOpenError`, carrying `breaker_name`, `retry_after` and `last_failure`
+  plus the library's own request context (`.request` on httpx and httpx2,
+  `.request` / `.response` on requests).
+
+  The host base is deliberately the broadest "the request never completed" type
+  — `httpx.TransportError`, `aiohttp.ClientConnectionError`,
+  `requests.exceptions.ConnectionError` — and never a leaf such as
+  `ConnectError`, `ReadTimeout` or `SSLError`. A leaf promises a physical cause
+  that never happened, and leaves are exactly what retry predicates key on:
+  inheriting from one would make every rejection retryable, and each retry would
+  hit the same open circuit and burn an attempt for nothing. One choice puts the
+  rejection inside every degradation handler and outside every typical retry
+  predicate.
+
+- **The httpx and httpx2 transports retype the other two interlock errors as
+  well.** `CallTimeoutTransportError` (an `httpx.TimeoutException`) and
+  `BulkheadFullTransportError` (an `httpx.PoolTimeout`) surface a pipeline
+  timeout or bulkhead rejection raised by a layer sitting inside the wrapped
+  transport. Both describe transient *local* conditions, so — unlike a circuit
+  rejection — they sit under httpx's timeout types on purpose, where retry
+  predicates do fire on them. An error raised by the wrapped transport itself is
+  never retyped, and neither is one that already carries a host hierarchy.
+
+### Changed
+
+- **`except httpx.TransportError` and its aiohttp / requests equivalents now
+  catch circuit rejections.** That is the point of the change, but it is a
+  behavioural difference for code that already catches those types: a rejection
+  reaches such a handler where it previously escaped to an outer `except
+  Exception`. Nothing that catches `CircuitOpenError` changes, and no typical
+  retry predicate starts firing — see the note on base types above.
+
 ## [2.6.1] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **`except httpx.TransportError` and its aiohttp / requests equivalents now
-  catch circuit rejections.** That is the point of the change, but it is a
+- **`except httpx.TransportError` — and `except httpx2.TransportError`,
+  `except aiohttp.ClientError`, `except requests.exceptions.RequestException` —
+  now catch circuit rejections.** That is the point of the change, but it is a
   behavioural difference for code that already catches those types: a rejection
   reaches such a handler where it previously escaped to an outer `except
   Exception`. Nothing that catches `CircuitOpenError` changes, and no typical

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -85,6 +85,13 @@ retry predicates key on — a retried rejection burns an attempt against a
 circuit that is still open. It also stays outside `ClientResponseError`, which
 would claim a response that never arrived.
 
+Only the rejection is retyped. The httpx transports also pair `CallTimeoutError`
+with `httpx.TimeoutException` and `BulkheadFullError` with `httpx.PoolTimeout`;
+aiohttp has no honest counterpart for "no local slot was free" — the nearest type
+is `aiohttp.ClientConnectionError`, which the rejection already uses, so the pairing would claim a
+distinction it cannot express. A `CallTimeoutError` raised by a pipeline of your
+own inside the guarded call therefore stays an interlock error on its way out.
+
 ## Custom breaker keys
 
 Pass `name_resolver` when host-based isolation does not match the logical

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -44,12 +44,46 @@ idempotent.
 
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
-request raises [`CircuitOpenError`](../reference.md) *before* a connection is
-made.
+request raises `CircuitOpenClientError` *before* a connection is made.
 
 The breaker observes the time to *response headers*; reading the body happens
 outside the guarded call — the same semantics as the
 [httpx2 transport](httpx2.md).
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenClientError`, which is
+both an `aiohttp.ClientConnectionError` and interlock's `CircuitOpenError`:
+
+```python
+import aiohttp
+
+from interlock.integrations.aiohttp import CircuitOpenClientError
+
+try:
+    response = await session.get('https://api.example.com/v1/users')
+except aiohttp.ClientError as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenClientError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in aiohttp's own idiom keep working the day a breaker leaves shadow
+mode. The rejection is still a `CircuitOpenError` too, so `except
+CircuitOpenError`, a `FallbackStrategy(on=(CircuitOpenError,))` or a framework
+exception handler registered for it catch exactly what they caught before. It
+carries `breaker_name`, `retry_after` and `last_failure`. aiohttp re-raises a
+`ClientError` from the middleware chain untouched, so it reaches the caller
+exactly as raised.
+
+The base type is deliberately the broad `ClientConnectionError` and never a
+leaf such as `ClientOSError` or `ServerDisconnectedError`: nothing was
+connected and no server dropped anything, and those leaves are exactly what
+retry predicates key on — a retried rejection burns an attempt against a
+circuit that is still open. It also stays outside `ClientResponseError`, which
+would claim a response that never arrived.
 
 ## Custom breaker keys
 

--- a/docs/integrations/httpx.md
+++ b/docs/integrations/httpx.md
@@ -86,9 +86,56 @@ transport configured for shadow mode would still create future hosts in
 
 Each host gets its own lazily created breaker. A failing
 `api.a.example.com` trips only that host; traffic to `api.b.example.com`
-continues normally. An open breaker raises `CircuitOpenError` before the
-wrapped transport performs I/O. A request URL without a host raises
+continues normally. An open breaker raises `CircuitOpenTransportError`
+before the wrapped transport performs I/O. A request URL without a host raises
 `ValueError` for the same reason: there is no dependency identity to key on.
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenTransportError`, which is
+both an `httpx.TransportError` and interlock's `CircuitOpenError`:
+
+```python
+import httpx
+
+from interlock.integrations.httpx import CircuitOpenTransportError
+
+try:
+    response = client.get('https://api.example.com/v1/users')
+except httpx.TransportError as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenTransportError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in httpx's own idiom keep working the day a breaker leaves shadow mode.
+The rejection is still a `CircuitOpenError` too, so `except CircuitOpenError`,
+a `FallbackStrategy(on=(CircuitOpenError,))` or a framework exception handler
+registered for it catch exactly what they caught before. It carries
+`breaker_name`, `retry_after` and `last_failure`, plus httpx's own `.request`.
+
+The base type is deliberately `TransportError` and never a leaf such as
+`ConnectError` or `TimeoutException`: nothing was connected and nothing timed
+out, and those leaves are exactly what retry predicates key on — a retried
+rejection burns an attempt against a circuit that is still open.
+
+Two further types cover the other interlock errors that can reach the caller
+through the transport, raised when a layer of your own inside the wrapped
+transport (a pipeline timeout, a bulkhead) fails the request:
+
+| interlock error | dialect type | httpx base |
+|---|---|---|
+| `CircuitOpenError` | `CircuitOpenTransportError` | `httpx.TransportError` |
+| `CallTimeoutError` | `CallTimeoutTransportError` | `httpx.TimeoutException` |
+| `BulkheadFullError` | `BulkheadFullTransportError` | `httpx.PoolTimeout` |
+
+Those two describe transient *local* conditions — a deadline, a busy slot pool
+— so unlike a rejection they sit under httpx's timeout types on purpose, where
+retry predicates do fire on them. An error raised by the wrapped transport
+itself is never retyped, and neither is one that already carries an httpx
+hierarchy.
 
 ## Custom breaker keys
 
@@ -245,4 +292,6 @@ transport = CircuitBreakerTransport(
 ```
 
 The transport never retries. If another layer owns retries, keep them bounded
-and stop retrying when the breaker raises `CircuitOpenError`.
+and stop retrying when the breaker rejects: `CircuitOpenTransportError` sits
+outside the httpx leaf types retry predicates key on, so a predicate written
+against `ConnectError` or `TimeoutException` already leaves it alone.

--- a/docs/integrations/httpx2.md
+++ b/docs/integrations/httpx2.md
@@ -93,8 +93,55 @@ Each host gets its own breaker, created lazily and cached. A failing
 `api.b.example.com` are unaffected. Per-instance, per-host state is usually more
 correct than global state — each host's health is observed independently.
 
-When a host's breaker is open, its requests raise `CircuitOpenError` before
-reaching the network.
+When a host's breaker is open, its requests raise `CircuitOpenTransportError`
+before reaching the network.
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenTransportError`, which is
+both an `httpx2.TransportError` and interlock's `CircuitOpenError`:
+
+```python
+import httpx2
+
+from interlock.integrations.httpx2 import CircuitOpenTransportError
+
+try:
+    response = client.get('https://api.example.com/v1/users')
+except httpx2.TransportError as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenTransportError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in httpx2's own idiom keep working the day a breaker leaves shadow mode.
+The rejection is still a `CircuitOpenError` too, so `except CircuitOpenError`,
+a `FallbackStrategy(on=(CircuitOpenError,))` or a framework exception handler
+registered for it catch exactly what they caught before. It carries
+`breaker_name`, `retry_after` and `last_failure`, plus httpx2's own `.request`.
+
+The base type is deliberately `TransportError` and never a leaf such as
+`ConnectError` or `TimeoutException`: nothing was connected and nothing timed
+out, and those leaves are exactly what retry predicates key on — a retried
+rejection burns an attempt against a circuit that is still open.
+
+Two further types cover the other interlock errors that can reach the caller
+through the transport, raised when a layer of your own inside the wrapped
+transport (a pipeline timeout, a bulkhead) fails the request:
+
+| interlock error | dialect type | httpx2 base |
+|---|---|---|
+| `CircuitOpenError` | `CircuitOpenTransportError` | `httpx2.TransportError` |
+| `CallTimeoutError` | `CallTimeoutTransportError` | `httpx2.TimeoutException` |
+| `BulkheadFullError` | `BulkheadFullTransportError` | `httpx2.PoolTimeout` |
+
+Those two describe transient *local* conditions — a deadline, a busy slot pool
+— so unlike a rejection they sit under httpx2's timeout types on purpose, where
+retry predicates do fire on them. An error raised by the wrapped transport
+itself is never retyped, and neither is one that already carries an httpx2
+hierarchy.
 
 ## Custom breaker keys
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -50,8 +50,9 @@ Every integration follows the same rules, so learning one means knowing all:
   `retry_after` estimate and the last recorded failure — *before* a
   connection is attempted. Each HTTP client integration raises a subclass that
   is *also* a native error of that library, so an application's existing
-  degradation path catches it: `CircuitOpenTransportError`
-  (an `httpx.TransportError`), `CircuitOpenClientError`
+  degradation path catches it: `CircuitOpenTransportError` (an
+  `httpx.TransportError` for the httpx integration, an `httpx2.TransportError`
+  for the httpx2 one), `CircuitOpenClientError`
   (an `aiohttp.ClientConnectionError`), `CircuitOpenRequestError`
   (a `requests.exceptions.ConnectionError`). The host base is always the
   broadest "the request never completed" type, never a leaf such as

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -45,10 +45,18 @@ Every integration follows the same rules, so learning one means knowing all:
   before the middleware chain runs). Pass
   `HttpStatusClassifier(failure_statuses={...}, excluded_exceptions=(...))` or
   your own `FailureClassifier` to change the policy.
-- **One rejection signal.** An open circuit always raises
+- **One rejection signal, in two dialects.** An open circuit always raises
   [`CircuitOpenError`](../reference.md) — carrying the breaker name, a
   `retry_after` estimate and the last recorded failure — *before* a
-  connection is attempted.
+  connection is attempted. Each HTTP client integration raises a subclass that
+  is *also* a native error of that library, so an application's existing
+  degradation path catches it: `CircuitOpenTransportError`
+  (an `httpx.TransportError`), `CircuitOpenClientError`
+  (an `aiohttp.ClientConnectionError`), `CircuitOpenRequestError`
+  (a `requests.exceptions.ConnectionError`). The host base is always the
+  broadest "the request never completed" type, never a leaf such as
+  `ConnectError` — leaves are what retry predicates key on, and retrying a
+  rejection only burns an attempt against a circuit that is still open.
 - **Zero-dependency core.** Integrations live in `interlock.integrations.*`
   as optional extras; `import interlock` itself never pulls anything beyond
   the standard library.

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -82,6 +82,13 @@ rejection burns an attempt against a circuit that is still open. urllib3's own
 `Retry` never sees it either: that runs inside `HTTPAdapter.send`, which the
 rejection replaces rather than enters.
 
+Only the rejection is retyped. The httpx transports also pair `CallTimeoutError`
+with `httpx.TimeoutException` and `BulkheadFullError` with `httpx.PoolTimeout`;
+requests has no honest counterpart for "no local slot was free" — the nearest type
+is `requests.exceptions.ConnectionError`, which the rejection already uses, so the pairing would claim a
+distinction it cannot express. A `CallTimeoutError` raised by a pipeline of your
+own inside the guarded call therefore stays an interlock error on its way out.
+
 ## Custom breaker keys
 
 Pass `name_resolver` when the request host is not the logical dependency

--- a/docs/integrations/requests.md
+++ b/docs/integrations/requests.md
@@ -45,8 +45,42 @@ created.
 
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
-request raises [`CircuitOpenError`](../reference.md) *before* a connection is
-made.
+request raises `CircuitOpenRequestError` *before* a connection is made.
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenRequestError`, which is
+both a `requests.exceptions.ConnectionError` and interlock's
+`CircuitOpenError`:
+
+```python
+import requests
+
+from interlock.integrations.requests import CircuitOpenRequestError
+
+try:
+    response = session.get('https://api.example.com/v1/users')
+except requests.exceptions.RequestException as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenRequestError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in requests' own idiom keep working the day a breaker leaves shadow
+mode. The rejection is still a `CircuitOpenError` too, so `except
+CircuitOpenError`, a `FallbackStrategy(on=(CircuitOpenError,))` or a framework
+exception handler registered for it catch exactly what they caught before. It
+carries `breaker_name`, `retry_after` and `last_failure`, plus requests' own
+`.request` and `.response`.
+
+The base type is deliberately `ConnectionError` and never a leaf such as
+`SSLError` or `ConnectTimeout`: no connection was attempted and nothing timed
+out, and those leaves are exactly what retry predicates key on — a retried
+rejection burns an attempt against a circuit that is still open. urllib3's own
+`Retry` never sees it either: that runs inside `HTTPAdapter.send`, which the
+rejection replaces rather than enters.
 
 ## Custom breaker keys
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4642,10 +4642,11 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
 - **`InterlockDeprecationWarning`** — subclasses `UserWarning`, visible by
   default.
 
-Every HTTP client integration raises a subclass of these that is *also* a
-native error of the host library, so the idiom that library teaches and
-`except CircuitOpenError` catch the same rejection. The native base differs per
-integration — one `except` clause covers one client, not all four:
+Every HTTP client integration retypes the **rejection** — and only the
+rejection — as a subclass that is *also* a native error of the host library, so
+the idiom that library teaches and `except CircuitOpenError` catch the same
+error. The native base differs per integration; one `except` clause covers one
+client, not all four:
 
 | Integration | Rejection type | Native base |
 |---|---|---|
@@ -4654,7 +4655,13 @@ integration — one `except` clause covers one client, not all four:
 | aiohttp | `CircuitOpenClientError` | `aiohttp.ClientConnectionError` |
 | requests | `CircuitOpenRequestError` | `requests.exceptions.ConnectionError` |
 
-See the integration sections below.
+`CallTimeoutError` and `BulkheadFullError` are paired only by the httpx and
+httpx2 transports, as `CallTimeoutTransportError` (a `TimeoutException`) and
+`BulkheadFullTransportError` (a `PoolTimeout`); they surface a timeout or
+bulkhead raised by a layer inside the wrapped transport. The aiohttp middleware
+and the requests adapter leave both untouched — neither hierarchy has an honest
+type for "no local slot was free" — so they reach the caller as plain interlock
+errors. See the integration sections below.
 
 ## `timeout` / `sync_timeout`
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2544,8 +2544,9 @@ Every integration follows the same rules, so learning one means knowing all:
   `retry_after` estimate and the last recorded failure — *before* a
   connection is attempted. Each HTTP client integration raises a subclass that
   is *also* a native error of that library, so an application's existing
-  degradation path catches it: `CircuitOpenTransportError`
-  (an `httpx.TransportError`), `CircuitOpenClientError`
+  degradation path catches it: `CircuitOpenTransportError` (an
+  `httpx.TransportError` for the httpx integration, an `httpx2.TransportError`
+  for the httpx2 one), `CircuitOpenClientError`
   (an `aiohttp.ClientConnectionError`), `CircuitOpenRequestError`
   (a `requests.exceptions.ConnectionError`). The host base is always the
   broadest "the request never completed" type, never a leaf such as
@@ -3491,6 +3492,13 @@ retry predicates key on — a retried rejection burns an attempt against a
 circuit that is still open. It also stays outside `ClientResponseError`, which
 would claim a response that never arrived.
 
+Only the rejection is retyped. The httpx transports also pair `CallTimeoutError`
+with `httpx.TimeoutException` and `BulkheadFullError` with `httpx.PoolTimeout`;
+aiohttp has no honest counterpart for "no local slot was free" — the nearest type
+is `aiohttp.ClientConnectionError`, which the rejection already uses, so the pairing would claim a
+distinction it cannot express. A `CallTimeoutError` raised by a pipeline of your
+own inside the guarded call therefore stays an interlock error on its way out.
+
 ## Custom breaker keys
 
 Pass `name_resolver` when host-based isolation does not match the logical
@@ -3699,6 +3707,13 @@ out, and those leaves are exactly what retry predicates key on — a retried
 rejection burns an attempt against a circuit that is still open. urllib3's own
 `Retry` never sees it either: that runs inside `HTTPAdapter.send`, which the
 rejection replaces rather than enters.
+
+Only the rejection is retyped. The httpx transports also pair `CallTimeoutError`
+with `httpx.TimeoutException` and `BulkheadFullError` with `httpx.PoolTimeout`;
+requests has no honest counterpart for "no local slot was free" — the nearest type
+is `requests.exceptions.ConnectionError`, which the rejection already uses, so the pairing would claim a
+distinction it cannot express. A `CallTimeoutError` raised by a pipeline of your
+own inside the guarded call therefore stays an interlock error on its way out.
 
 ## Custom breaker keys
 
@@ -4628,11 +4643,18 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
   default.
 
 Every HTTP client integration raises a subclass of these that is *also* a
-native error of the host library, so `except httpx.TransportError` and
-`except CircuitOpenError` both catch the same rejection:
-`CircuitOpenTransportError` (httpx, httpx2), `CircuitOpenClientError`
-(aiohttp), `CircuitOpenRequestError` (requests). See the integration sections
-below.
+native error of the host library, so the idiom that library teaches and
+`except CircuitOpenError` catch the same rejection. The native base differs per
+integration — one `except` clause covers one client, not all four:
+
+| Integration | Rejection type | Native base |
+|---|---|---|
+| httpx | `CircuitOpenTransportError` | `httpx.TransportError` |
+| httpx2 | `CircuitOpenTransportError` | `httpx2.TransportError` |
+| aiohttp | `CircuitOpenClientError` | `aiohttp.ClientConnectionError` |
+| requests | `CircuitOpenRequestError` | `requests.exceptions.ConnectionError` |
+
+See the integration sections below.
 
 ## `timeout` / `sync_timeout`
 
@@ -4719,7 +4741,8 @@ Implement any of these to swap a core behaviour:
 Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None)`**
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   fails on transport exceptions and statuses `429, 500, 502, 503, 504`
@@ -4737,7 +4760,12 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 Both transports expose their per-host `registry` and the guarded transport as a
 read-only `wrapped`. `close()` / `aclose()` release the wrapped transport and,
 when the transport owns the registry, every breaker in it; a caller-owned
-registry stays open and is closed by its owner. See the
+registry stays open and is closed by its owner. Every adapter below takes the
+same `registry` option — a caller-owned `Registry` shared between clients — and
+combining it with any breaker-construction option (`config`, `clock`,
+`initial_state`, `classifier`, `listener`) raises `ValueError`, since the
+registry already owns them. `name_resolver` maps each request to its breaker
+name and defaults to the request host. See the
 [httpx2 integration](integrations/httpx2.md).
 
 ## httpx adapters
@@ -4746,7 +4774,8 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 `interlock.integrations.httpx`:
 
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None)`**
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, including the caller-side `UnsupportedProtocol` /
@@ -4767,7 +4796,8 @@ See the [httpx integration](integrations/httpx.md).
 Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations.aiohttp`:
 
 - **`CircuitBreakerMiddleware(*, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None)`** —
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
@@ -4785,7 +4815,8 @@ shutdown. See the [aiohttp integration](integrations/aiohttp.md).
 Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
 
 - **`CircuitBreakerAdapter(*, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2539,10 +2539,18 @@ Every integration follows the same rules, so learning one means knowing all:
   before the middleware chain runs). Pass
   `HttpStatusClassifier(failure_statuses={...}, excluded_exceptions=(...))` or
   your own `FailureClassifier` to change the policy.
-- **One rejection signal.** An open circuit always raises
+- **One rejection signal, in two dialects.** An open circuit always raises
   [`CircuitOpenError`](../reference.md) — carrying the breaker name, a
   `retry_after` estimate and the last recorded failure — *before* a
-  connection is attempted.
+  connection is attempted. Each HTTP client integration raises a subclass that
+  is *also* a native error of that library, so an application's existing
+  degradation path catches it: `CircuitOpenTransportError`
+  (an `httpx.TransportError`), `CircuitOpenClientError`
+  (an `aiohttp.ClientConnectionError`), `CircuitOpenRequestError`
+  (a `requests.exceptions.ConnectionError`). The host base is always the
+  broadest "the request never completed" type, never a leaf such as
+  `ConnectError` — leaves are what retry predicates key on, and retrying a
+  rejection only burns an attempt against a circuit that is still open.
 - **Zero-dependency core.** Integrations live in `interlock.integrations.*`
   as optional extras; `import interlock` itself never pulls anything beyond
   the standard library.
@@ -2890,8 +2898,55 @@ Each host gets its own breaker, created lazily and cached. A failing
 `api.b.example.com` are unaffected. Per-instance, per-host state is usually more
 correct than global state — each host's health is observed independently.
 
-When a host's breaker is open, its requests raise `CircuitOpenError` before
-reaching the network.
+When a host's breaker is open, its requests raise `CircuitOpenTransportError`
+before reaching the network.
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenTransportError`, which is
+both an `httpx2.TransportError` and interlock's `CircuitOpenError`:
+
+```python
+import httpx2
+
+from interlock.integrations.httpx2 import CircuitOpenTransportError
+
+try:
+    response = client.get('https://api.example.com/v1/users')
+except httpx2.TransportError as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenTransportError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in httpx2's own idiom keep working the day a breaker leaves shadow mode.
+The rejection is still a `CircuitOpenError` too, so `except CircuitOpenError`,
+a `FallbackStrategy(on=(CircuitOpenError,))` or a framework exception handler
+registered for it catch exactly what they caught before. It carries
+`breaker_name`, `retry_after` and `last_failure`, plus httpx2's own `.request`.
+
+The base type is deliberately `TransportError` and never a leaf such as
+`ConnectError` or `TimeoutException`: nothing was connected and nothing timed
+out, and those leaves are exactly what retry predicates key on — a retried
+rejection burns an attempt against a circuit that is still open.
+
+Two further types cover the other interlock errors that can reach the caller
+through the transport, raised when a layer of your own inside the wrapped
+transport (a pipeline timeout, a bulkhead) fails the request:
+
+| interlock error | dialect type | httpx2 base |
+|---|---|---|
+| `CircuitOpenError` | `CircuitOpenTransportError` | `httpx2.TransportError` |
+| `CallTimeoutError` | `CallTimeoutTransportError` | `httpx2.TimeoutException` |
+| `BulkheadFullError` | `BulkheadFullTransportError` | `httpx2.PoolTimeout` |
+
+Those two describe transient *local* conditions — a deadline, a busy slot pool
+— so unlike a rejection they sit under httpx2's timeout types on purpose, where
+retry predicates do fire on them. An error raised by the wrapped transport
+itself is never retyped, and neither is one that already carries an httpx2
+hierarchy.
 
 ## Custom breaker keys
 
@@ -3135,9 +3190,56 @@ transport configured for shadow mode would still create future hosts in
 
 Each host gets its own lazily created breaker. A failing
 `api.a.example.com` trips only that host; traffic to `api.b.example.com`
-continues normally. An open breaker raises `CircuitOpenError` before the
-wrapped transport performs I/O. A request URL without a host raises
+continues normally. An open breaker raises `CircuitOpenTransportError`
+before the wrapped transport performs I/O. A request URL without a host raises
 `ValueError` for the same reason: there is no dependency identity to key on.
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenTransportError`, which is
+both an `httpx.TransportError` and interlock's `CircuitOpenError`:
+
+```python
+import httpx
+
+from interlock.integrations.httpx import CircuitOpenTransportError
+
+try:
+    response = client.get('https://api.example.com/v1/users')
+except httpx.TransportError as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenTransportError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in httpx's own idiom keep working the day a breaker leaves shadow mode.
+The rejection is still a `CircuitOpenError` too, so `except CircuitOpenError`,
+a `FallbackStrategy(on=(CircuitOpenError,))` or a framework exception handler
+registered for it catch exactly what they caught before. It carries
+`breaker_name`, `retry_after` and `last_failure`, plus httpx's own `.request`.
+
+The base type is deliberately `TransportError` and never a leaf such as
+`ConnectError` or `TimeoutException`: nothing was connected and nothing timed
+out, and those leaves are exactly what retry predicates key on — a retried
+rejection burns an attempt against a circuit that is still open.
+
+Two further types cover the other interlock errors that can reach the caller
+through the transport, raised when a layer of your own inside the wrapped
+transport (a pipeline timeout, a bulkhead) fails the request:
+
+| interlock error | dialect type | httpx base |
+|---|---|---|
+| `CircuitOpenError` | `CircuitOpenTransportError` | `httpx.TransportError` |
+| `CallTimeoutError` | `CallTimeoutTransportError` | `httpx.TimeoutException` |
+| `BulkheadFullError` | `BulkheadFullTransportError` | `httpx.PoolTimeout` |
+
+Those two describe transient *local* conditions — a deadline, a busy slot pool
+— so unlike a rejection they sit under httpx's timeout types on purpose, where
+retry predicates do fire on them. An error raised by the wrapped transport
+itself is never retyped, and neither is one that already carries an httpx
+hierarchy.
 
 ## Custom breaker keys
 
@@ -3294,7 +3396,9 @@ transport = CircuitBreakerTransport(
 ```
 
 The transport never retries. If another layer owns retries, keep them bounded
-and stop retrying when the breaker raises `CircuitOpenError`.
+and stop retrying when the breaker rejects: `CircuitOpenTransportError` sits
+outside the httpx leaf types retry predicates key on, so a predicate written
+against `ConnectError` or `TimeoutException` already leaves it alone.
 
 ---
 
@@ -3346,12 +3450,46 @@ idempotent.
 
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
-request raises [`CircuitOpenError`](../reference.md) *before* a connection is
-made.
+request raises `CircuitOpenClientError` *before* a connection is made.
 
 The breaker observes the time to *response headers*; reading the body happens
 outside the guarded call — the same semantics as the
 [httpx2 transport](httpx2.md).
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenClientError`, which is
+both an `aiohttp.ClientConnectionError` and interlock's `CircuitOpenError`:
+
+```python
+import aiohttp
+
+from interlock.integrations.aiohttp import CircuitOpenClientError
+
+try:
+    response = await session.get('https://api.example.com/v1/users')
+except aiohttp.ClientError as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenClientError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in aiohttp's own idiom keep working the day a breaker leaves shadow
+mode. The rejection is still a `CircuitOpenError` too, so `except
+CircuitOpenError`, a `FallbackStrategy(on=(CircuitOpenError,))` or a framework
+exception handler registered for it catch exactly what they caught before. It
+carries `breaker_name`, `retry_after` and `last_failure`. aiohttp re-raises a
+`ClientError` from the middleware chain untouched, so it reaches the caller
+exactly as raised.
+
+The base type is deliberately the broad `ClientConnectionError` and never a
+leaf such as `ClientOSError` or `ServerDisconnectedError`: nothing was
+connected and no server dropped anything, and those leaves are exactly what
+retry predicates key on — a retried rejection burns an attempt against a
+circuit that is still open. It also stays outside `ClientResponseError`, which
+would claim a response that never arrived.
 
 ## Custom breaker keys
 
@@ -3525,8 +3663,42 @@ created.
 
 Each host gets its own breaker (a failing `api.a` never trips `api.b`),
 created lazily and shared across requests. When a host's circuit is open the
-request raises [`CircuitOpenError`](../reference.md) *before* a connection is
-made.
+request raises `CircuitOpenRequestError` *before* a connection is made.
+
+## What a rejection looks like
+
+An open circuit rejects the request with `CircuitOpenRequestError`, which is
+both a `requests.exceptions.ConnectionError` and interlock's
+`CircuitOpenError`:
+
+```python
+import requests
+
+from interlock.integrations.requests import CircuitOpenRequestError
+
+try:
+    response = session.get('https://api.example.com/v1/users')
+except requests.exceptions.RequestException as exc:
+    # The dependency being unreachable and the breaker rejecting both land here.
+    if isinstance(exc, CircuitOpenRequestError):
+        ...  # rejected before any I/O; the next probe is exc.retry_after away
+    raise
+```
+
+That is the point of the type: the degradation paths an application already
+writes in requests' own idiom keep working the day a breaker leaves shadow
+mode. The rejection is still a `CircuitOpenError` too, so `except
+CircuitOpenError`, a `FallbackStrategy(on=(CircuitOpenError,))` or a framework
+exception handler registered for it catch exactly what they caught before. It
+carries `breaker_name`, `retry_after` and `last_failure`, plus requests' own
+`.request` and `.response`.
+
+The base type is deliberately `ConnectionError` and never a leaf such as
+`SSLError` or `ConnectTimeout`: no connection was attempted and nothing timed
+out, and those leaves are exactly what retry predicates key on — a retried
+rejection burns an attempt against a circuit that is still open. urllib3's own
+`Retry` never sees it either: that runs inside `HTTPAdapter.send`, which the
+rejection replaces rather than enters.
 
 ## Custom breaker keys
 
@@ -4455,6 +4627,13 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
 - **`InterlockDeprecationWarning`** — subclasses `UserWarning`, visible by
   default.
 
+Every HTTP client integration raises a subclass of these that is *also* a
+native error of the host library, so `except httpx.TransportError` and
+`except CircuitOpenError` both catch the same rejection:
+`CircuitOpenTransportError` (httpx, httpx2), `CircuitOpenClientError`
+(aiohttp), `CircuitOpenRequestError` (requests). See the integration sections
+below.
+
 ## `timeout` / `sync_timeout`
 
 ```python
@@ -4547,6 +4726,13 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
   (override the set via `failure_statuses`). `UnsupportedProtocol` and
   `LocalProtocolError` are caller-side and count as successes; replace that set
   via `excluded_exceptions`.
+- **`CircuitOpenTransportError(breaker_name, *, retry_after=None,
+  last_failure=None, request=None)`** — the rejection: an
+  `httpx2.TransportError` *and* a `CircuitOpenError`.
+- **`CallTimeoutTransportError(timeout, *, request=None)`** — an
+  `httpx2.TimeoutException` *and* a `CallTimeoutError`.
+- **`BulkheadFullTransportError(max_concurrent, *, max_wait=0.0,
+  request=None)`** — an `httpx2.PoolTimeout` *and* a `BulkheadFullError`.
 
 Both transports expose their per-host `registry` and the guarded transport as a
 read-only `wrapped`. `close()` / `aclose()` release the wrapped transport and,
@@ -4565,6 +4751,10 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, including the caller-side `UnsupportedProtocol` /
   `LocalProtocolError` exclusions.
+- **`CircuitOpenTransportError`**, **`CallTimeoutTransportError`**,
+  **`BulkheadFullTransportError`** — the same three dialect errors as the
+  httpx2 adapters, built on `httpx.TransportError`, `httpx.TimeoutException`
+  and `httpx.PoolTimeout`.
 
 Both transports expose their per-host `registry` and the guarded transport as a
 read-only `wrapped`, and preserve streaming responses. `close()` / `aclose()`
@@ -4583,6 +4773,9 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same canonical HTTP policy, reading `ClientResponse.status`; nothing is
   excluded by default (aiohttp rejects bad URLs before the middleware runs).
+- **`CircuitOpenClientError(breaker_name, *, retry_after=None,
+  last_failure=None)`** — the rejection: an `aiohttp.ClientConnectionError`
+  *and* a `CircuitOpenError`.
 
 It exposes its `registry`; call `await middleware.aclose()` during application
 shutdown. See the [aiohttp integration](integrations/aiohttp.md).
@@ -4598,6 +4791,10 @@ Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, reading `Response.status_code`; the caller-side `InvalidURL`
   counts as a success.
+- **`CircuitOpenRequestError(breaker_name, *, retry_after=None,
+  last_failure=None, request=None)`** — the rejection: a
+  `requests.exceptions.ConnectionError` *and* a `CircuitOpenError`; carries
+  requests' own `.request` and `.response`.
 
 It exposes its `registry`; closing the adapter or owning session releases both
 the connection pools and breaker resources. See the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -103,10 +103,11 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
 - **`InterlockDeprecationWarning`** — subclasses `UserWarning`, visible by
   default.
 
-Every HTTP client integration raises a subclass of these that is *also* a
-native error of the host library, so the idiom that library teaches and
-`except CircuitOpenError` catch the same rejection. The native base differs per
-integration — one `except` clause covers one client, not all four:
+Every HTTP client integration retypes the **rejection** — and only the
+rejection — as a subclass that is *also* a native error of the host library, so
+the idiom that library teaches and `except CircuitOpenError` catch the same
+error. The native base differs per integration; one `except` clause covers one
+client, not all four:
 
 | Integration | Rejection type | Native base |
 |---|---|---|
@@ -115,7 +116,13 @@ integration — one `except` clause covers one client, not all four:
 | aiohttp | `CircuitOpenClientError` | `aiohttp.ClientConnectionError` |
 | requests | `CircuitOpenRequestError` | `requests.exceptions.ConnectionError` |
 
-See the integration sections below.
+`CallTimeoutError` and `BulkheadFullError` are paired only by the httpx and
+httpx2 transports, as `CallTimeoutTransportError` (a `TimeoutException`) and
+`BulkheadFullTransportError` (a `PoolTimeout`); they surface a timeout or
+bulkhead raised by a layer inside the wrapped transport. The aiohttp middleware
+and the requests adapter leave both untouched — neither hierarchy has an honest
+type for "no local slot was free" — so they reach the caller as plain interlock
+errors. See the integration sections below.
 
 ## `timeout` / `sync_timeout`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -103,6 +103,13 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
 - **`InterlockDeprecationWarning`** — subclasses `UserWarning`, visible by
   default.
 
+Every HTTP client integration raises a subclass of these that is *also* a
+native error of the host library, so `except httpx.TransportError` and
+`except CircuitOpenError` both catch the same rejection:
+`CircuitOpenTransportError` (httpx, httpx2), `CircuitOpenClientError`
+(aiohttp), `CircuitOpenRequestError` (requests). See the integration sections
+below.
+
 ## `timeout` / `sync_timeout`
 
 ```python
@@ -195,6 +202,13 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
   (override the set via `failure_statuses`). `UnsupportedProtocol` and
   `LocalProtocolError` are caller-side and count as successes; replace that set
   via `excluded_exceptions`.
+- **`CircuitOpenTransportError(breaker_name, *, retry_after=None,
+  last_failure=None, request=None)`** — the rejection: an
+  `httpx2.TransportError` *and* a `CircuitOpenError`.
+- **`CallTimeoutTransportError(timeout, *, request=None)`** — an
+  `httpx2.TimeoutException` *and* a `CallTimeoutError`.
+- **`BulkheadFullTransportError(max_concurrent, *, max_wait=0.0,
+  request=None)`** — an `httpx2.PoolTimeout` *and* a `BulkheadFullError`.
 
 Both transports expose their per-host `registry` and the guarded transport as a
 read-only `wrapped`. `close()` / `aclose()` release the wrapped transport and,
@@ -213,6 +227,10 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, including the caller-side `UnsupportedProtocol` /
   `LocalProtocolError` exclusions.
+- **`CircuitOpenTransportError`**, **`CallTimeoutTransportError`**,
+  **`BulkheadFullTransportError`** — the same three dialect errors as the
+  httpx2 adapters, built on `httpx.TransportError`, `httpx.TimeoutException`
+  and `httpx.PoolTimeout`.
 
 Both transports expose their per-host `registry` and the guarded transport as a
 read-only `wrapped`, and preserve streaming responses. `close()` / `aclose()`
@@ -231,6 +249,9 @@ Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same canonical HTTP policy, reading `ClientResponse.status`; nothing is
   excluded by default (aiohttp rejects bad URLs before the middleware runs).
+- **`CircuitOpenClientError(breaker_name, *, retry_after=None,
+  last_failure=None)`** — the rejection: an `aiohttp.ClientConnectionError`
+  *and* a `CircuitOpenError`.
 
 It exposes its `registry`; call `await middleware.aclose()` during application
 shutdown. See the [aiohttp integration](integrations/aiohttp.md).
@@ -246,6 +267,10 @@ Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, reading `Response.status_code`; the caller-side `InvalidURL`
   counts as a success.
+- **`CircuitOpenRequestError(breaker_name, *, retry_after=None,
+  last_failure=None, request=None)`** — the rejection: a
+  `requests.exceptions.ConnectionError` *and* a `CircuitOpenError`; carries
+  requests' own `.request` and `.response`.
 
 It exposes its `registry`; closing the adapter or owning session releases both
 the connection pools and breaker resources. See the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -104,11 +104,18 @@ Frozen dataclass: `total_calls`, `failed_calls`, `slow_calls`, plus
   default.
 
 Every HTTP client integration raises a subclass of these that is *also* a
-native error of the host library, so `except httpx.TransportError` and
-`except CircuitOpenError` both catch the same rejection:
-`CircuitOpenTransportError` (httpx, httpx2), `CircuitOpenClientError`
-(aiohttp), `CircuitOpenRequestError` (requests). See the integration sections
-below.
+native error of the host library, so the idiom that library teaches and
+`except CircuitOpenError` catch the same rejection. The native base differs per
+integration — one `except` clause covers one client, not all four:
+
+| Integration | Rejection type | Native base |
+|---|---|---|
+| httpx | `CircuitOpenTransportError` | `httpx.TransportError` |
+| httpx2 | `CircuitOpenTransportError` | `httpx2.TransportError` |
+| aiohttp | `CircuitOpenClientError` | `aiohttp.ClientConnectionError` |
+| requests | `CircuitOpenRequestError` | `requests.exceptions.ConnectionError` |
+
+See the integration sections below.
 
 ## `timeout` / `sync_timeout`
 
@@ -195,7 +202,8 @@ Implement any of these to swap a core behaviour:
 Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None)`**
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   fails on transport exceptions and statuses `429, 500, 502, 503, 504`
@@ -213,7 +221,12 @@ Extra `interlock-cb[httpx2]`, module `interlock.integrations.httpx2`:
 Both transports expose their per-host `registry` and the guarded transport as a
 read-only `wrapped`. `close()` / `aclose()` release the wrapped transport and,
 when the transport owns the registry, every breaker in it; a caller-owned
-registry stays open and is closed by its owner. See the
+registry stays open and is closed by its owner. Every adapter below takes the
+same `registry` option — a caller-owned `Registry` shared between clients — and
+combining it with any breaker-construction option (`config`, `clock`,
+`initial_state`, `classifier`, `listener`) raises `ValueError`, since the
+registry already owns them. `name_resolver` maps each request to its breaker
+name and defaults to the request host. See the
 [httpx2 integration](integrations/httpx2.md).
 
 ## httpx adapters
@@ -222,7 +235,8 @@ Extra `interlock-cb[httpx]` (httpx ≥ 0.27.0), module
 `interlock.integrations.httpx`:
 
 - **`CircuitBreakerTransport(transport, *, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None)`**
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>)`**
 - **`AsyncCircuitBreakerTransport(transport, *, ...)`**
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
   same policy, including the caller-side `UnsupportedProtocol` /
@@ -243,7 +257,8 @@ See the [httpx integration](integrations/httpx.md).
 Extra `interlock-cb[aiohttp]` (aiohttp ≥ 3.12), module `interlock.integrations.aiohttp`:
 
 - **`CircuitBreakerMiddleware(*, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None)`** —
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>)`** —
   client middleware for `ClientSession(middlewares=(...,))`; one breaker per
   request host.
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —
@@ -261,7 +276,8 @@ shutdown. See the [aiohttp integration](integrations/aiohttp.md).
 Extra `interlock-cb[requests]`, module `interlock.integrations.requests`:
 
 - **`CircuitBreakerAdapter(*, config=None, clock=None,
-  initial_state=State.CLOSED, classifier=None, listener=None, **adapter_kwargs)`** —
+  initial_state=State.CLOSED, classifier=None, listener=None, registry=None,
+  name_resolver=<request host>, **adapter_kwargs)`** —
   `HTTPAdapter` subclass for `session.mount(...)`; one breaker per request
   host. Extra kwargs go to `HTTPAdapter`.
 - **`HttpStatusClassifier(*, failure_statuses=None, excluded_exceptions=None)`** —

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -145,6 +145,14 @@ class HttpStatusClassifier:
 # retry predicates key on — a retried rejection burns an attempt against a
 # circuit that is still open. It also keeps the rejection outside
 # ``ClientResponseError``, which would claim a response that never arrived.
+#
+# Only the rejection is retyped here, unlike the httpx transports, which also
+# pair ``CallTimeoutError`` with ``TimeoutException`` and ``BulkheadFullError``
+# with ``PoolTimeout``. aiohttp has no honest counterpart for "no local slot was
+# free": the nearest type is ``ClientConnectionError``, which this rejection
+# already uses, so the pairing would claim a distinction it cannot express.
+# A ``CallTimeoutError`` from an inner layer therefore stays an interlock error
+# on the way out — deliberately, not by omission.
 class CircuitOpenClientError(ClientConnectionError, CircuitOpenError):
     """A request rejected by an open circuit, raised in aiohttp's hierarchy.
 

--- a/interlock/integrations/aiohttp.py
+++ b/interlock/integrations/aiohttp.py
@@ -14,8 +14,12 @@ sites::
 
 Client middlewares require aiohttp >= 3.12. Each host gets its own breaker
 (a failing ``api.a`` must not trip ``api.b``), created lazily and shared
-across requests. When a host's circuit is open the request is rejected with
-``CircuitOpenError`` before a connection is made.
+across requests. When a host's circuit is open the request is rejected before a
+connection is made, with ``CircuitOpenClientError``: an
+``aiohttp.ClientConnectionError`` *and* a ``CircuitOpenError``, so the aiohttp
+idiom (``except aiohttp.ClientError``) degrades on it exactly as it degrades on
+the dependency being unreachable, and existing ``except CircuitOpenError``
+handlers keep working.
 
 By default a response counts as a failure when its status is in the canonical
 retryable set (``429, 500, 502, 503, 504``) and any exception raised by the
@@ -28,17 +32,18 @@ outside the guarded call — the same semantics as the httpx2 transport.
 
 import http
 from collections.abc import Callable, Iterable
-from typing import cast
+from typing import NoReturn, cast
 
-from aiohttp import ClientHandlerType, ClientRequest, ClientResponse
+from aiohttp import ClientConnectionError, ClientHandlerType, ClientRequest, ClientResponse
 
 from interlock.config import Config
+from interlock.errors import CircuitOpenError
 from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
 from interlock.state import State
 
-__all__ = ('CircuitBreakerMiddleware', 'HttpStatusClassifier')
+__all__ = ('CircuitBreakerMiddleware', 'CircuitOpenClientError', 'HttpStatusClassifier')
 
 # Mirrors urllib3's recommended ``status_forcelist`` (also used by AWS/Google):
 # transient server-side conditions where the dependency is unhealthy or
@@ -126,6 +131,51 @@ class HttpStatusClassifier:
             return not isinstance(exception, self._excluded_exceptions)
 
         return cast('ClientResponse', result).status in self._failure_statuses
+
+
+# Application code degrades on the idiom its http client teaches — for aiohttp
+# that is ``except aiohttp.ClientError``. An error raised from outside that
+# hierarchy sails past every such handler, so the day a breaker leaves shadow
+# mode every degradation path stops working at once. The rejection is therefore
+# both an aiohttp error and a ``CircuitOpenError``.
+#
+# The aiohttp base is the broadest "the connection never happened" type and
+# never a leaf like ``ClientOSError`` or ``ServerDisconnectedError``: a leaf
+# promises a physical cause that never happened, and leaves are exactly what
+# retry predicates key on — a retried rejection burns an attempt against a
+# circuit that is still open. It also keeps the rejection outside
+# ``ClientResponseError``, which would claim a response that never arrived.
+class CircuitOpenClientError(ClientConnectionError, CircuitOpenError):
+    """A request rejected by an open circuit, raised in aiohttp's hierarchy.
+
+    Caught by ``except aiohttp.ClientConnectionError`` (and by ``except
+    aiohttp.ClientError``) and by ``except CircuitOpenError`` alike. aiohttp
+    itself re-raises a ``ClientError`` from the middleware chain untouched, so
+    the rejection reaches the caller exactly as raised.
+
+    Args:
+        breaker_name: Name of the breaker that rejected the request.
+        retry_after: Seconds until the next probe is allowed, or ``None`` when
+            the breaker cannot estimate it.
+        last_failure: The most recent recorded failure, if any.
+    """
+
+
+def _raise_in_dialect(error: CircuitOpenError) -> NoReturn:
+    """Re-raise ``error`` as its aiohttp twin, or unchanged when it has none.
+
+    Only the exact core type is retyped. A subclass — including this dialect
+    type, raised by an interlock layer further in — already carries a host
+    hierarchy of its own and must not be wrapped a second time.
+    """
+    if type(error) is CircuitOpenError:
+        raise CircuitOpenClientError(
+            error.breaker_name,
+            retry_after=error.retry_after,
+            last_failure=error.last_failure,
+        ) from error
+
+    raise error
 
 
 def _host(request: ClientRequest) -> str:
@@ -216,7 +266,9 @@ class CircuitBreakerMiddleware:
         """Run the request under its resolved dependency's breaker.
 
         Raises:
-            CircuitOpenError: If the resolved dependency's breaker is open.
+            CircuitOpenClientError: If the resolved dependency's breaker is open
+                — an ``aiohttp.ClientConnectionError`` and a
+                ``CircuitOpenError``.
             ValueError: If the request URL has no host under the default
                 resolver, or the configured resolver returns a non-string or
                 empty name.
@@ -227,4 +279,7 @@ class CircuitBreakerMiddleware:
         # (middleware chains may hand over plain callables returning
         # awaitables), so the breaker's sync/async detection must not decide
         # here: call_async awaits whatever the handler returns.
-        return await breaker.call_async(handler, request)
+        try:
+            return await breaker.call_async(handler, request)
+        except CircuitOpenError as error:
+            _raise_in_dialect(error)

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -20,24 +20,34 @@ By default a response counts as a failure when its status is one of
 504`` — and a transport exception (connect/read errors) is a failure unless it
 is caller-side (a malformed URL, a local protocol violation). Supply a custom
 ``classifier`` to change that policy.
+
+A rejected request is raised as ``CircuitOpenTransportError``: an
+``httpx.TransportError`` *and* a ``CircuitOpenError``, so the httpx idiom
+(``except httpx.TransportError``) degrades on it exactly as it degrades on the
+dependency being unreachable, and existing ``except CircuitOpenError`` handlers
+keep working.
 """
 
 import http
 from collections.abc import Callable, Iterable
 from contextlib import AsyncExitStack, ExitStack
 from types import TracebackType
-from typing import Self, cast
+from typing import NoReturn, Self, cast
 
 from httpx import (
     AsyncBaseTransport,
     BaseTransport,
     LocalProtocolError,
+    PoolTimeout,
     Request,
     Response,
+    TimeoutException,
+    TransportError,
     UnsupportedProtocol,
 )
 
 from interlock.config import Config
+from interlock.errors import BulkheadFullError, CallTimeoutError, CircuitOpenError, InterlockError
 from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
@@ -45,7 +55,10 @@ from interlock.state import State
 
 __all__ = (
     'AsyncCircuitBreakerTransport',
+    'BulkheadFullTransportError',
+    'CallTimeoutTransportError',
     'CircuitBreakerTransport',
+    'CircuitOpenTransportError',
     'HttpStatusClassifier',
 )
 
@@ -143,6 +156,126 @@ class HttpStatusClassifier:
         return cast('Response', result).status_code in self._failure_statuses
 
 
+# Application code degrades on the idiom its http client teaches — for httpx
+# that is ``except httpx.TransportError``. An error raised from outside that
+# hierarchy sails past every such handler, so the day a breaker leaves shadow
+# mode every degradation path stops working at once. Each type below is
+# therefore both an httpx error and the interlock error it retypes.
+#
+# The httpx base is always the broadest "the request never completed" type and
+# never a leaf like ``ConnectError`` or ``ReadTimeout``: a leaf promises a
+# physical cause that never happened, and leaves are exactly what retry
+# predicates key on — a retried rejection burns an attempt against a circuit
+# that is still open.
+class CircuitOpenTransportError(TransportError, CircuitOpenError):
+    """A request rejected by an open circuit, raised in httpx's hierarchy.
+
+    Caught by ``except httpx.TransportError`` and by ``except CircuitOpenError``
+    alike; not by ``except httpx.ConnectError`` or ``except
+    httpx.TimeoutException``, so a retry predicate keyed on those does not fire
+    on a rejection no retry can satisfy.
+
+    Args:
+        breaker_name: Name of the breaker that rejected the request.
+        retry_after: Seconds until the next probe is allowed, or ``None`` when
+            the breaker cannot estimate it.
+        last_failure: The most recent recorded failure, if any.
+        request: The rejected request, published as httpx's ``.request``.
+    """
+
+    # ``HTTPError.__init__`` is unreachable from here: its ``super()`` call
+    # follows *this* class's MRO into ``CircuitOpenError.__init__``, which would
+    # read the message as a breaker name. Declaring the attribute it would have
+    # set keeps ``.request`` failing the way httpx documents it instead of with
+    # an ``AttributeError``.
+    _request: Request | None = None
+
+    def __init__(
+        self,
+        breaker_name: str,
+        *,
+        retry_after: float | None = None,
+        last_failure: BaseException | None = None,
+        request: Request | None = None,
+    ) -> None:
+        CircuitOpenError.__init__(
+            self, breaker_name, retry_after=retry_after, last_failure=last_failure
+        )
+        if request is not None:
+            self.request = request
+
+
+class CallTimeoutTransportError(TimeoutException, CallTimeoutError):
+    """A guarded call that ran past its deadline, raised in httpx's hierarchy.
+
+    ``httpx.TimeoutException`` is the exact counterpart — a deadline expired
+    with no response — so unlike a rejection this one *is* meant to be caught
+    by timeout-shaped retry predicates.
+
+    Args:
+        timeout: The deadline, in seconds, that was exceeded.
+        request: The request that ran out of time, published as ``.request``.
+    """
+
+    _request: Request | None = None  # see CircuitOpenTransportError
+
+    def __init__(self, timeout: float, *, request: Request | None = None) -> None:
+        CallTimeoutError.__init__(self, timeout)
+        if request is not None:
+            self.request = request
+
+
+class BulkheadFullTransportError(PoolTimeout, BulkheadFullError):
+    """A request refused for want of a concurrency slot, in httpx's hierarchy.
+
+    ``httpx.PoolTimeout`` says the same thing about httpx's own connection
+    pool: no local slot was free in time. The condition is local and transient,
+    so — again unlike a rejection — a retry can genuinely succeed.
+
+    Args:
+        max_concurrent: The bulkhead's concurrency limit.
+        max_wait: Seconds the call was willing to wait for a slot.
+        request: The refused request, published as httpx's ``.request``.
+    """
+
+    _request: Request | None = None  # see CircuitOpenTransportError
+
+    def __init__(
+        self,
+        max_concurrent: int,
+        *,
+        max_wait: float = 0.0,
+        request: Request | None = None,
+    ) -> None:
+        BulkheadFullError.__init__(self, max_concurrent, max_wait=max_wait)
+        if request is not None:
+            self.request = request
+
+
+def _raise_in_dialect(error: InterlockError, request: Request) -> NoReturn:
+    """Re-raise ``error`` as its httpx twin, or unchanged when it has none.
+
+    Only the exact core types are retyped. A subclass — including these dialect
+    types, raised by an interlock layer further in — already carries a host
+    hierarchy of its own and must not be wrapped a second time.
+    """
+    if type(error) is CircuitOpenError:
+        raise CircuitOpenTransportError(
+            error.breaker_name,
+            retry_after=error.retry_after,
+            last_failure=error.last_failure,
+            request=request,
+        ) from error
+    if type(error) is CallTimeoutError:
+        raise CallTimeoutTransportError(error.timeout, request=request) from error
+    if type(error) is BulkheadFullError:
+        raise BulkheadFullTransportError(
+            error.max_concurrent, max_wait=error.max_wait, request=request
+        ) from error
+
+    raise error
+
+
 def _host(request: Request) -> str:
     """Return the host key, rejecting URLs that cannot identify a dependency."""
     host = request.url.host
@@ -230,13 +363,19 @@ class CircuitBreakerTransport(BaseTransport):
         """Run a request under the breaker for its resolved dependency.
 
         Raises:
-            CircuitOpenError: If the resolved dependency's breaker is open.
+            CircuitOpenTransportError: If the resolved dependency's breaker is
+                open — an ``httpx.TransportError`` and a ``CircuitOpenError``.
+                A ``CallTimeoutError`` or ``BulkheadFullError`` coming out of
+                the wrapped transport is retyped the same way.
             ValueError: If the request URL has no host under the default
                 resolver, or the configured resolver returns a non-string or
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        return breaker.call_sync(self._transport.handle_request, request)
+        try:
+            return breaker.call_sync(self._transport.handle_request, request)
+        except InterlockError as error:
+            _raise_in_dialect(error, request)
 
     def __enter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""
@@ -328,13 +467,19 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         """Run a request under the breaker for its resolved dependency.
 
         Raises:
-            CircuitOpenError: If the resolved dependency's breaker is open.
+            CircuitOpenTransportError: If the resolved dependency's breaker is
+                open — an ``httpx.TransportError`` and a ``CircuitOpenError``.
+                A ``CallTimeoutError`` or ``BulkheadFullError`` coming out of
+                the wrapped transport is retyped the same way.
             ValueError: If the request URL has no host under the default
                 resolver, or the configured resolver returns a non-string or
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        return await breaker.call_async(self._transport.handle_async_request, request)
+        try:
+            return await breaker.call_async(self._transport.handle_async_request, request)
+        except InterlockError as error:
+            _raise_in_dialect(error, request)
 
     async def __aenter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""

--- a/interlock/integrations/httpx.py
+++ b/interlock/integrations/httpx.py
@@ -230,7 +230,10 @@ class BulkheadFullTransportError(PoolTimeout, BulkheadFullError):
 
     ``httpx.PoolTimeout`` says the same thing about httpx's own connection
     pool: no local slot was free in time. The condition is local and transient,
-    so — again unlike a rejection — a retry can genuinely succeed.
+    so — again unlike a rejection — a retry can genuinely succeed. Note the
+    consequence: ``PoolTimeout`` *is* a ``httpx.TimeoutException``, so a
+    predicate keyed on that type retries a bulkhead rejection. Only
+    ``CircuitOpenTransportError`` is deliberately kept out of its reach.
 
     Args:
         max_concurrent: The bulkhead's concurrency limit.

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -19,24 +19,34 @@ By default a response counts as a failure when its status is one of
 504`` — and a transport exception (connect/read errors) is a failure unless it
 is caller-side (a malformed URL, a local protocol violation). Supply a custom
 ``classifier`` to change that policy.
+
+A rejected request is raised as ``CircuitOpenTransportError``: an
+``httpx2.TransportError`` *and* a ``CircuitOpenError``, so the httpx2 idiom
+(``except httpx2.TransportError``) degrades on it exactly as it degrades on the
+dependency being unreachable, and existing ``except CircuitOpenError`` handlers
+keep working.
 """
 
 import http
 from collections.abc import Callable, Iterable
 from contextlib import AsyncExitStack, ExitStack
 from types import TracebackType
-from typing import Self, cast
+from typing import NoReturn, Self, cast
 
 from httpx2 import (
     AsyncBaseTransport,
     BaseTransport,
     LocalProtocolError,
+    PoolTimeout,
     Request,
     Response,
+    TimeoutException,
+    TransportError,
     UnsupportedProtocol,
 )
 
 from interlock.config import Config
+from interlock.errors import BulkheadFullError, CallTimeoutError, CircuitOpenError, InterlockError
 from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
@@ -44,7 +54,10 @@ from interlock.state import State
 
 __all__ = (
     'AsyncCircuitBreakerTransport',
+    'BulkheadFullTransportError',
+    'CallTimeoutTransportError',
     'CircuitBreakerTransport',
+    'CircuitOpenTransportError',
     'HttpStatusClassifier',
 )
 
@@ -142,6 +155,126 @@ class HttpStatusClassifier:
         return cast('Response', result).status_code in self._failure_statuses
 
 
+# Application code degrades on the idiom its http client teaches — for httpx2
+# that is ``except httpx2.TransportError``. An error raised from outside that
+# hierarchy sails past every such handler, so the day a breaker leaves shadow
+# mode every degradation path stops working at once. Each type below is
+# therefore both an httpx2 error and the interlock error it retypes.
+#
+# The httpx2 base is always the broadest "the request never completed" type and
+# never a leaf like ``ConnectError`` or ``ReadTimeout``: a leaf promises a
+# physical cause that never happened, and leaves are exactly what retry
+# predicates key on — a retried rejection burns an attempt against a circuit
+# that is still open.
+class CircuitOpenTransportError(TransportError, CircuitOpenError):
+    """A request rejected by an open circuit, raised in httpx2's hierarchy.
+
+    Caught by ``except httpx2.TransportError`` and by ``except
+    CircuitOpenError`` alike; not by ``except httpx2.ConnectError`` or ``except
+    httpx2.TimeoutException``, so a retry predicate keyed on those does not fire
+    on a rejection no retry can satisfy.
+
+    Args:
+        breaker_name: Name of the breaker that rejected the request.
+        retry_after: Seconds until the next probe is allowed, or ``None`` when
+            the breaker cannot estimate it.
+        last_failure: The most recent recorded failure, if any.
+        request: The rejected request, published as httpx2's ``.request``.
+    """
+
+    # ``HTTPError.__init__`` is unreachable from here: its ``super()`` call
+    # follows *this* class's MRO into ``CircuitOpenError.__init__``, which would
+    # read the message as a breaker name. Declaring the attribute it would have
+    # set keeps ``.request`` failing the way httpx2 documents it instead of with
+    # an ``AttributeError``.
+    _request: Request | None = None
+
+    def __init__(
+        self,
+        breaker_name: str,
+        *,
+        retry_after: float | None = None,
+        last_failure: BaseException | None = None,
+        request: Request | None = None,
+    ) -> None:
+        CircuitOpenError.__init__(
+            self, breaker_name, retry_after=retry_after, last_failure=last_failure
+        )
+        if request is not None:
+            self.request = request
+
+
+class CallTimeoutTransportError(TimeoutException, CallTimeoutError):
+    """A guarded call that ran past its deadline, raised in httpx2's hierarchy.
+
+    ``httpx2.TimeoutException`` is the exact counterpart — a deadline expired
+    with no response — so unlike a rejection this one *is* meant to be caught
+    by timeout-shaped retry predicates.
+
+    Args:
+        timeout: The deadline, in seconds, that was exceeded.
+        request: The request that ran out of time, published as ``.request``.
+    """
+
+    _request: Request | None = None  # see CircuitOpenTransportError
+
+    def __init__(self, timeout: float, *, request: Request | None = None) -> None:
+        CallTimeoutError.__init__(self, timeout)
+        if request is not None:
+            self.request = request
+
+
+class BulkheadFullTransportError(PoolTimeout, BulkheadFullError):
+    """A request refused for want of a concurrency slot, in httpx2's hierarchy.
+
+    ``httpx2.PoolTimeout`` says the same thing about httpx2's own connection
+    pool: no local slot was free in time. The condition is local and transient,
+    so — again unlike a rejection — a retry can genuinely succeed.
+
+    Args:
+        max_concurrent: The bulkhead's concurrency limit.
+        max_wait: Seconds the call was willing to wait for a slot.
+        request: The refused request, published as httpx2's ``.request``.
+    """
+
+    _request: Request | None = None  # see CircuitOpenTransportError
+
+    def __init__(
+        self,
+        max_concurrent: int,
+        *,
+        max_wait: float = 0.0,
+        request: Request | None = None,
+    ) -> None:
+        BulkheadFullError.__init__(self, max_concurrent, max_wait=max_wait)
+        if request is not None:
+            self.request = request
+
+
+def _raise_in_dialect(error: InterlockError, request: Request) -> NoReturn:
+    """Re-raise ``error`` as its httpx2 twin, or unchanged when it has none.
+
+    Only the exact core types are retyped. A subclass — including these dialect
+    types, raised by an interlock layer further in — already carries a host
+    hierarchy of its own and must not be wrapped a second time.
+    """
+    if type(error) is CircuitOpenError:
+        raise CircuitOpenTransportError(
+            error.breaker_name,
+            retry_after=error.retry_after,
+            last_failure=error.last_failure,
+            request=request,
+        ) from error
+    if type(error) is CallTimeoutError:
+        raise CallTimeoutTransportError(error.timeout, request=request) from error
+    if type(error) is BulkheadFullError:
+        raise BulkheadFullTransportError(
+            error.max_concurrent, max_wait=error.max_wait, request=request
+        ) from error
+
+    raise error
+
+
 def _host(request: Request) -> str:
     """The host keying the request's breaker; empty hosts are rejected eagerly."""
     host = request.url.host
@@ -230,13 +363,19 @@ class CircuitBreakerTransport(BaseTransport):
         """Run the request under its resolved dependency's breaker.
 
         Raises:
-            CircuitOpenError: If the resolved dependency's breaker is open.
+            CircuitOpenTransportError: If the resolved dependency's breaker is
+                open — an ``httpx2.TransportError`` and a ``CircuitOpenError``.
+                A ``CallTimeoutError`` or ``BulkheadFullError`` coming out of
+                the wrapped transport is retyped the same way.
             ValueError: If the request URL has no host under the default
                 resolver, or the configured resolver returns a non-string or
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        return breaker.call_sync(self._transport.handle_request, request)
+        try:
+            return breaker.call_sync(self._transport.handle_request, request)
+        except InterlockError as error:
+            _raise_in_dialect(error, request)
 
     def __enter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""
@@ -329,13 +468,19 @@ class AsyncCircuitBreakerTransport(AsyncBaseTransport):
         """Run the request under its resolved dependency's breaker.
 
         Raises:
-            CircuitOpenError: If the resolved dependency's breaker is open.
+            CircuitOpenTransportError: If the resolved dependency's breaker is
+                open — an ``httpx2.TransportError`` and a ``CircuitOpenError``.
+                A ``CallTimeoutError`` or ``BulkheadFullError`` coming out of
+                the wrapped transport is retyped the same way.
             ValueError: If the request URL has no host under the default
                 resolver, or the configured resolver returns a non-string or
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        return await breaker.call_async(self._transport.handle_async_request, request)
+        try:
+            return await breaker.call_async(self._transport.handle_async_request, request)
+        except InterlockError as error:
+            _raise_in_dialect(error, request)
 
     async def __aenter__(self) -> Self:
         """Enter the wrapped transport's context and return this wrapper."""

--- a/interlock/integrations/httpx2.py
+++ b/interlock/integrations/httpx2.py
@@ -229,7 +229,10 @@ class BulkheadFullTransportError(PoolTimeout, BulkheadFullError):
 
     ``httpx2.PoolTimeout`` says the same thing about httpx2's own connection
     pool: no local slot was free in time. The condition is local and transient,
-    so — again unlike a rejection — a retry can genuinely succeed.
+    so — again unlike a rejection — a retry can genuinely succeed. Note the
+    consequence: ``PoolTimeout`` *is* a ``httpx2.TimeoutException``, so a
+    predicate keyed on that type retries a bulkhead rejection. Only
+    ``CircuitOpenTransportError`` is deliberately kept out of its reach.
 
     Args:
         max_concurrent: The bulkhead's concurrency limit.

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -14,7 +14,12 @@ sites::
 
 Each host gets its own breaker (a failing ``api.a`` must not trip ``api.b``),
 created lazily and shared across requests. When a host's circuit is open the
-request is rejected with ``CircuitOpenError`` before a connection is made.
+request is rejected before a connection is made, with
+``CircuitOpenRequestError``: a ``requests.exceptions.ConnectionError`` *and* a
+``CircuitOpenError``, so the requests idiom (``except
+requests.exceptions.RequestException``) degrades on it exactly as it degrades on
+the dependency being unreachable, and existing ``except CircuitOpenError``
+handlers keep working.
 
 By default a response counts as a failure when its status is in the canonical
 retryable set (``429, 500, 502, 503, 504``) and a transport exception
@@ -26,20 +31,22 @@ host); ``4xx`` client mistakes like ``404`` are successes. Supply a custom
 import http
 from collections.abc import Callable, Iterable, Mapping
 from contextlib import ExitStack
-from typing import cast
+from typing import NoReturn, cast
 from urllib.parse import urlsplit
 
 from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import InvalidURL
 
 from interlock.config import Config
+from interlock.errors import CircuitOpenError
 from interlock.integrations._registry import reject_registry_options, resolve_registry
 from interlock.protocols import Clock, CoreEventListener, FailureClassifier, StorageEventListener
 from interlock.registry import Registry
 from interlock.state import State
 
-__all__ = ('CircuitBreakerAdapter', 'HttpStatusClassifier')
+__all__ = ('CircuitBreakerAdapter', 'CircuitOpenRequestError', 'HttpStatusClassifier')
 
 # Mirrors urllib3's recommended ``status_forcelist`` (also used by AWS/Google):
 # transient server-side conditions where the dependency is unhealthy or
@@ -131,6 +138,72 @@ class HttpStatusClassifier:
             return not isinstance(exception, self._excluded_exceptions)
 
         return cast('Response', result).status_code in self._failure_statuses
+
+
+# Application code degrades on the idiom its http client teaches — for requests
+# that is ``except requests.exceptions.RequestException`` (or its
+# ``ConnectionError`` branch). An error raised from outside that hierarchy sails
+# past every such handler, so the day a breaker leaves shadow mode every
+# degradation path stops working at once. The rejection is therefore both a
+# requests error and a ``CircuitOpenError``.
+#
+# The requests base is the broadest "the request never reached the dependency"
+# type and never a leaf like ``SSLError`` or ``ConnectTimeout``: a leaf promises
+# a physical cause that never happened, and leaves are exactly what retry
+# predicates key on — a retried rejection burns an attempt against a circuit
+# that is still open. urllib3's own ``Retry`` never sees it either: it runs
+# inside ``HTTPAdapter.send``, which this rejection replaces rather than enters.
+class CircuitOpenRequestError(RequestsConnectionError, CircuitOpenError):
+    """A request rejected by an open circuit, raised in requests' hierarchy.
+
+    Caught by ``except requests.exceptions.ConnectionError`` (and by ``except
+    requests.exceptions.RequestException``) and by ``except CircuitOpenError``
+    alike.
+
+    Args:
+        breaker_name: Name of the breaker that rejected the request.
+        retry_after: Seconds until the next probe is allowed, or ``None`` when
+            the breaker cannot estimate it.
+        last_failure: The most recent recorded failure, if any.
+        request: The rejected request, published as requests' ``.request``.
+    """
+
+    def __init__(
+        self,
+        breaker_name: str,
+        *,
+        retry_after: float | None = None,
+        last_failure: BaseException | None = None,
+        request: PreparedRequest | None = None,
+    ) -> None:
+        CircuitOpenError.__init__(
+            self, breaker_name, retry_after=retry_after, last_failure=last_failure
+        )
+        # ``RequestException.__init__`` is unreachable from here: its
+        # ``super()`` call follows *this* class's MRO into
+        # ``CircuitOpenError.__init__``, which would read the message as a
+        # breaker name. The two attributes it publishes are set directly, so a
+        # handler reading ``.request`` or ``.response`` finds what it expects.
+        self.request = request
+        self.response = None
+
+
+def _raise_in_dialect(error: CircuitOpenError, request: PreparedRequest) -> NoReturn:
+    """Re-raise ``error`` as its requests twin, or unchanged when it has none.
+
+    Only the exact core type is retyped. A subclass — including this dialect
+    type, raised by an interlock layer further in — already carries a host
+    hierarchy of its own and must not be wrapped a second time.
+    """
+    if type(error) is CircuitOpenError:
+        raise CircuitOpenRequestError(
+            error.breaker_name,
+            retry_after=error.retry_after,
+            last_failure=error.last_failure,
+            request=request,
+        ) from error
+
+    raise error
 
 
 def _host(request: PreparedRequest) -> str:
@@ -242,18 +315,23 @@ class CircuitBreakerAdapter(HTTPAdapter):
         """Run the request under its resolved dependency's breaker.
 
         Raises:
-            CircuitOpenError: If the resolved dependency's breaker is open.
+            CircuitOpenRequestError: If the resolved dependency's breaker is
+                open — a ``requests.exceptions.ConnectionError`` and a
+                ``CircuitOpenError``.
             ValueError: If the request URL has no host under the default
                 resolver, or the configured resolver returns a non-string or
                 empty name.
         """
         breaker = self._registry.get(_breaker_name(request, self._name_resolver))
-        return breaker.call_sync(
-            super().send,
-            request,
-            stream=stream,
-            timeout=timeout,
-            verify=verify,
-            cert=cert,
-            proxies=proxies,
-        )
+        try:
+            return breaker.call_sync(
+                super().send,
+                request,
+                stream=stream,
+                timeout=timeout,
+                verify=verify,
+                cert=cert,
+                proxies=proxies,
+            )
+        except CircuitOpenError as error:
+            _raise_in_dialect(error, request)

--- a/interlock/integrations/requests.py
+++ b/interlock/integrations/requests.py
@@ -153,6 +153,14 @@ class HttpStatusClassifier:
 # predicates key on — a retried rejection burns an attempt against a circuit
 # that is still open. urllib3's own ``Retry`` never sees it either: it runs
 # inside ``HTTPAdapter.send``, which this rejection replaces rather than enters.
+#
+# Only the rejection is retyped here, unlike the httpx transports, which also
+# pair ``CallTimeoutError`` with ``TimeoutException`` and ``BulkheadFullError``
+# with ``PoolTimeout``. requests has no honest counterpart for "no local slot
+# was free": the nearest type is ``ConnectionError``, which this rejection
+# already uses, so the pairing would claim a distinction it cannot express.
+# A ``CallTimeoutError`` from an inner layer therefore stays an interlock error
+# on the way out — deliberately, not by omission.
 class CircuitOpenRequestError(RequestsConnectionError, CircuitOpenError):
     """A request rejected by an open circuit, raised in requests' hierarchy.
 

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -4,14 +4,29 @@ from collections.abc import Awaitable
 from typing import cast
 
 import pytest
-from aiohttp import ClientHandlerType, ClientRequest, ClientResponse, ClientSession, web
+from aiohttp import (
+    ClientConnectionError,
+    ClientError,
+    ClientHandlerType,
+    ClientOSError,
+    ClientRequest,
+    ClientResponse,
+    ClientResponseError,
+    ClientSession,
+    ServerTimeoutError,
+    web,
+)
 from aiohttp.test_utils import TestServer
 from pytest_mock import MockerFixture
 from tests.conftest import FakeClock
 from yarl import URL
 
 from interlock import CircuitBreaker, CircuitOpenError, Config, Registry, State
-from interlock.integrations.aiohttp import CircuitBreakerMiddleware, HttpStatusClassifier
+from interlock.integrations.aiohttp import (
+    CircuitBreakerMiddleware,
+    CircuitOpenClientError,
+    HttpStatusClassifier,
+)
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
 
@@ -365,3 +380,109 @@ def test__http_status_classifier__custom_statuses__override_default_set() -> Non
     assert classifier.is_failure(result=_StubResponse(404), exception=None) is True
     assert classifier.is_failure(result=_StubResponse(408), exception=None) is True
     assert classifier.is_failure(result=_StubResponse(500), exception=None) is False
+
+
+# --- dialect errors -----------------------------------------------------------
+
+
+async def _tripped_middleware(fake_clock: FakeClock) -> CircuitBreakerMiddleware:
+    """A middleware whose ``api.a`` breaker has just been tripped open."""
+    middleware = CircuitBreakerMiddleware(config=_TRIP_FAST, clock=fake_clock)
+    handler = _handler([ClientConnectionError('down'), ClientConnectionError('down')])
+    for _ in range(2):
+        with pytest.raises(ClientConnectionError):
+            await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+    return middleware
+
+
+@pytest.mark.asyncio
+async def test__middleware__open_circuit__rejects_inside_aiohttp_hierarchy(
+    fake_clock: FakeClock,
+) -> None:
+    middleware = await _tripped_middleware(fake_clock)
+    handler = _handler([])
+
+    with pytest.raises(CircuitOpenClientError) as excinfo:
+        await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+    assert isinstance(excinfo.value, ClientConnectionError)
+    assert isinstance(excinfo.value, ClientError)
+    assert isinstance(excinfo.value, CircuitOpenError)
+
+
+@pytest.mark.asyncio
+async def test__middleware__open_circuit__stays_outside_retryable_leaf_types(
+    fake_clock: FakeClock,
+) -> None:
+    middleware = await _tripped_middleware(fake_clock)
+    handler = _handler([])
+
+    with pytest.raises(CircuitOpenClientError) as excinfo:
+        await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+    assert not isinstance(excinfo.value, ClientResponseError)
+    assert not isinstance(excinfo.value, ClientOSError)
+    assert not isinstance(excinfo.value, ServerTimeoutError)
+
+
+@pytest.mark.asyncio
+async def test__middleware__open_circuit__carries_breaker_context(
+    fake_clock: FakeClock,
+) -> None:
+    middleware = await _tripped_middleware(fake_clock)
+    handler = _handler([])
+
+    with pytest.raises(CircuitOpenClientError) as excinfo:
+        await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+    error = excinfo.value
+    assert error.breaker_name == 'api.a'
+    assert error.retry_after == _TRIP_FAST.wait_duration_in_open
+    assert isinstance(error.last_failure, ClientConnectionError)
+    assert str(error) == f"Circuit 'api.a' is open; retry in ~{error.retry_after:.3f}s"
+    assert type(error.__cause__) is CircuitOpenError
+
+
+@pytest.mark.asyncio
+async def test__middleware__inner_dialect_error__propagates_unchanged(
+    fake_clock: FakeClock,
+) -> None:
+    rejection = CircuitOpenClientError('inner', retry_after=1.0)
+    middleware = CircuitBreakerMiddleware(config=_TRIP_FAST, clock=fake_clock)
+    handler = _handler([rejection])
+
+    with pytest.raises(CircuitOpenClientError) as excinfo:
+        await middleware(_request('https://api.a/x'), cast('ClientHandlerType', handler))
+
+    assert excinfo.value is rejection
+    assert excinfo.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test__middleware__e2e_real_session__rejection_is_caught_as_client_error(
+    fake_clock: FakeClock,
+) -> None:
+    """A real session must not mangle the rejection on its way out of the chain."""
+
+    async def unhealthy(_request: web.Request) -> web.Response:
+        return web.Response(status=503)
+
+    app = web.Application()
+    app.router.add_get('/', unhealthy)
+    server = TestServer(app)
+    await server.start_server()
+
+    middleware = CircuitBreakerMiddleware(config=_TRIP_FAST, clock=fake_clock)
+    try:
+        async with ClientSession(middlewares=(middleware,)) as session:
+            for _ in range(2):
+                async with session.get(server.make_url('/')) as response:
+                    assert response.status == 503
+
+            with pytest.raises(ClientConnectionError) as excinfo:
+                await session.get(server.make_url('/'))
+    finally:
+        await server.close()
+
+    assert isinstance(excinfo.value, CircuitOpenClientError)

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -66,6 +66,7 @@ async def test__installed_handler__dialect_rejection__returns_503_with_retry_aft
 
     assert response.status_code == 503
     assert response.headers['retry-after'] == '3'  # ceil(2.2)
+    assert response.json()['detail'] == "Circuit 'payments' is open"
 
 
 def _build_app() -> FastAPI:

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -13,6 +13,7 @@ from interlock.integrations.fastapi import (
     circuit_open_handler,
     install_exception_handler,
 )
+from interlock.integrations.httpx2 import CircuitOpenTransportError
 
 
 def _request() -> Request:
@@ -47,6 +48,24 @@ def test__breaker_dependency__returns_shared_breaker_from_registry() -> None:
 
     assert isinstance(first, CircuitBreaker)
     assert first is second  # the registry caches one breaker per name
+
+
+@pytest.mark.asyncio
+async def test__installed_handler__dialect_rejection__returns_503_with_retry_after() -> None:
+    """Starlette resolves a handler by walking the MRO; the httpx2 bases come first."""
+    app = FastAPI()
+    install_exception_handler(app)
+
+    @app.get('/down')
+    async def down() -> dict[str, str]:
+        raise CircuitOpenTransportError('payments', retry_after=2.2)
+
+    transport = httpx2.ASGITransport(app=app)
+    async with httpx2.AsyncClient(transport=transport, base_url='http://test') as client:
+        response = await client.get('/down')
+
+    assert response.status_code == 503
+    assert response.headers['retry-after'] == '3'  # ceil(2.2)
 
 
 def _build_app() -> FastAPI:

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -7,10 +7,22 @@ import pytest
 from pytest_mock import MockerFixture
 from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, Registry, State
+from interlock import (
+    BulkheadFullError,
+    CallTimeoutError,
+    CircuitBreaker,
+    CircuitOpenError,
+    Config,
+    Outcome,
+    Registry,
+    State,
+)
 from interlock.integrations.httpx import (
     AsyncCircuitBreakerTransport,
+    BulkheadFullTransportError,
+    CallTimeoutTransportError,
     CircuitBreakerTransport,
+    CircuitOpenTransportError,
     HttpStatusClassifier,
 )
 
@@ -809,3 +821,178 @@ async def test__async_transport__metrics_only_new_hosts__all_start_in_shadow_mod
         breaker = transport.registry.get_existing(host)
         assert breaker is not None
         assert breaker.state is State.METRICS_ONLY
+
+
+# --- dialect errors -----------------------------------------------------------
+
+
+def _tripped_sync_transport(fake_clock: FakeClock) -> CircuitBreakerTransport:
+    """A transport whose ``api.example.com`` breaker has just been tripped open."""
+
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError('down', request=request)
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+    for _ in range(2):
+        with pytest.raises(httpx.ReadError):
+            transport.handle_request(_request())
+
+    return transport
+
+
+def _failing_async_transport(fake_clock: FakeClock) -> AsyncCircuitBreakerTransport:
+    """An async transport whose inner stub fails every request; the caller trips it."""
+
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError('down', request=request)
+
+    return AsyncCircuitBreakerTransport(_AsyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+
+
+def test__sync_transport__open_circuit__rejects_inside_httpx_hierarchy(
+    fake_clock: FakeClock,
+) -> None:
+    transport = _tripped_sync_transport(fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(_request())
+
+    assert isinstance(excinfo.value, httpx.TransportError)
+    assert isinstance(excinfo.value, CircuitOpenError)
+
+
+def test__sync_transport__open_circuit__stays_outside_retryable_leaf_types(
+    fake_clock: FakeClock,
+) -> None:
+    transport = _tripped_sync_transport(fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(_request())
+
+    assert not isinstance(excinfo.value, httpx.ConnectError)
+    assert not isinstance(excinfo.value, httpx.TimeoutException)
+
+
+def test__sync_transport__open_circuit__carries_breaker_and_request_context(
+    fake_clock: FakeClock,
+) -> None:
+    transport = _tripped_sync_transport(fake_clock)
+    request = _request()
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(request)
+
+    error = excinfo.value
+    assert error.breaker_name == 'api.example.com'
+    assert error.retry_after == _TRIP_FAST.wait_duration_in_open
+    assert isinstance(error.last_failure, httpx.ReadError)
+    assert error.request is request
+    assert str(error) == f"Circuit 'api.example.com' is open; retry in ~{error.retry_after:.3f}s"
+    assert type(error.__cause__) is CircuitOpenError
+
+
+@pytest.mark.asyncio
+async def test__async_transport__open_circuit__rejects_inside_httpx_hierarchy(
+    fake_clock: FakeClock,
+) -> None:
+    transport = _failing_async_transport(fake_clock)
+    for _ in range(2):
+        with pytest.raises(httpx.ReadError):
+            await transport.handle_async_request(_request())
+
+    request = _request()
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        await transport.handle_async_request(request)
+
+    error = excinfo.value
+    assert isinstance(error, httpx.TransportError)
+    assert isinstance(error, CircuitOpenError)
+    assert error.breaker_name == 'api.example.com'
+    assert error.request is request
+
+
+def test__sync_transport__inner_call_timeout__retyped_as_httpx_timeout(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise CallTimeoutError(1.5)
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+    request = _request()
+
+    with pytest.raises(CallTimeoutTransportError) as excinfo:
+        transport.handle_request(request)
+
+    error = excinfo.value
+    assert isinstance(error, httpx.TimeoutException)
+    assert isinstance(error, CallTimeoutError)
+    assert error.timeout == 1.5
+    assert error.request is request
+    assert str(error) == 'Operation exceeded its 1.500s timeout'
+
+
+def test__sync_transport__inner_bulkhead_rejection__retyped_as_httpx_pool_timeout(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise BulkheadFullError(4, max_wait=0.25)
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+    request = _request()
+
+    with pytest.raises(BulkheadFullTransportError) as excinfo:
+        transport.handle_request(request)
+
+    error = excinfo.value
+    assert isinstance(error, httpx.PoolTimeout)
+    assert isinstance(error, BulkheadFullError)
+    assert error.max_concurrent == 4
+    assert error.max_wait == 0.25
+    assert error.request is request
+
+
+def test__sync_transport__inner_dialect_error__propagates_unchanged(
+    fake_clock: FakeClock,
+) -> None:
+    rejection = CircuitOpenTransportError('inner', retry_after=1.0)
+
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise rejection
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(_request())
+
+    assert excinfo.value is rejection
+    assert excinfo.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test__async_transport__inner_dialect_error__propagates_unchanged(
+    fake_clock: FakeClock,
+) -> None:
+    rejection = CircuitOpenTransportError('inner', retry_after=1.0)
+
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise rejection
+
+    transport = AsyncCircuitBreakerTransport(_AsyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        await transport.handle_async_request(_request())
+
+    assert excinfo.value is rejection
+
+
+@pytest.mark.parametrize(
+    'error',
+    [
+        CircuitOpenTransportError('api'),
+        CallTimeoutTransportError(1.0),
+        BulkheadFullTransportError(2),
+    ],
+)
+def test__dialect_errors__request_not_set__keep_httpx_contract(error: httpx.HTTPError) -> None:
+    with pytest.raises(RuntimeError, match='has not been set'):
+        _ = error.request

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -8,10 +8,22 @@ from httpx2 import AsyncBaseTransport, BaseTransport, Request, Response
 from pytest_mock import MockerFixture
 from tests.conftest import FakeClock, RecordingListener
 
-from interlock import CircuitBreaker, CircuitOpenError, Config, Outcome, Registry, State
+from interlock import (
+    BulkheadFullError,
+    CallTimeoutError,
+    CircuitBreaker,
+    CircuitOpenError,
+    Config,
+    Outcome,
+    Registry,
+    State,
+)
 from interlock.integrations.httpx2 import (
     AsyncCircuitBreakerTransport,
+    BulkheadFullTransportError,
+    CallTimeoutTransportError,
     CircuitBreakerTransport,
+    CircuitOpenTransportError,
     HttpStatusClassifier,
 )
 
@@ -576,3 +588,172 @@ async def test__async_transport__url_without_host__raises_value_error(
         await transport.handle_async_request(_request('/relative/path'))
 
     assert stub.calls == 0
+
+
+# --- dialect errors -----------------------------------------------------------
+
+
+def _tripped_sync_transport(fake_clock: FakeClock) -> CircuitBreakerTransport:
+    """A transport whose ``api.example.com`` breaker has just been tripped open."""
+
+    def boom(request: Request) -> Response:
+        raise httpx2.ReadError('down', request=request)
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+    for _ in range(2):
+        with pytest.raises(httpx2.ReadError):
+            transport.handle_request(_request())
+
+    return transport
+
+
+def test__sync_transport__open_circuit__rejects_inside_httpx2_hierarchy(
+    fake_clock: FakeClock,
+) -> None:
+    transport = _tripped_sync_transport(fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(_request())
+
+    assert isinstance(excinfo.value, httpx2.TransportError)
+    assert isinstance(excinfo.value, CircuitOpenError)
+
+
+def test__sync_transport__open_circuit__stays_outside_retryable_leaf_types(
+    fake_clock: FakeClock,
+) -> None:
+    transport = _tripped_sync_transport(fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(_request())
+
+    assert not isinstance(excinfo.value, httpx2.ConnectError)
+    assert not isinstance(excinfo.value, httpx2.TimeoutException)
+
+
+def test__sync_transport__open_circuit__carries_breaker_and_request_context(
+    fake_clock: FakeClock,
+) -> None:
+    transport = _tripped_sync_transport(fake_clock)
+    request = _request()
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(request)
+
+    error = excinfo.value
+    assert error.breaker_name == 'api.example.com'
+    assert error.retry_after == _TRIP_FAST.wait_duration_in_open
+    assert isinstance(error.last_failure, httpx2.ReadError)
+    assert error.request is request
+    assert str(error) == f"Circuit 'api.example.com' is open; retry in ~{error.retry_after:.3f}s"
+    assert type(error.__cause__) is CircuitOpenError
+
+
+@pytest.mark.asyncio
+async def test__async_transport__open_circuit__rejects_inside_httpx2_hierarchy(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(request: Request) -> Response:
+        raise httpx2.ReadError('down', request=request)
+
+    transport = AsyncCircuitBreakerTransport(_AsyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+    for _ in range(2):
+        with pytest.raises(httpx2.ReadError):
+            await transport.handle_async_request(_request())
+
+    request = _request()
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        await transport.handle_async_request(request)
+
+    error = excinfo.value
+    assert isinstance(error, httpx2.TransportError)
+    assert isinstance(error, CircuitOpenError)
+    assert error.breaker_name == 'api.example.com'
+    assert error.request is request
+
+
+def test__sync_transport__inner_call_timeout__retyped_as_httpx2_timeout(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(_request: Request) -> Response:
+        raise CallTimeoutError(1.5)
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+    request = _request()
+
+    with pytest.raises(CallTimeoutTransportError) as excinfo:
+        transport.handle_request(request)
+
+    error = excinfo.value
+    assert isinstance(error, httpx2.TimeoutException)
+    assert isinstance(error, CallTimeoutError)
+    assert error.timeout == 1.5
+    assert error.request is request
+    assert str(error) == 'Operation exceeded its 1.500s timeout'
+
+
+def test__sync_transport__inner_bulkhead_rejection__retyped_as_httpx2_pool_timeout(
+    fake_clock: FakeClock,
+) -> None:
+    def boom(_request: Request) -> Response:
+        raise BulkheadFullError(4, max_wait=0.25)
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+    request = _request()
+
+    with pytest.raises(BulkheadFullTransportError) as excinfo:
+        transport.handle_request(request)
+
+    error = excinfo.value
+    assert isinstance(error, httpx2.PoolTimeout)
+    assert isinstance(error, BulkheadFullError)
+    assert error.max_concurrent == 4
+    assert error.max_wait == 0.25
+    assert error.request is request
+
+
+def test__sync_transport__inner_dialect_error__propagates_unchanged(
+    fake_clock: FakeClock,
+) -> None:
+    rejection = CircuitOpenTransportError('inner', retry_after=1.0)
+
+    def boom(_request: Request) -> Response:
+        raise rejection
+
+    transport = CircuitBreakerTransport(_SyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        transport.handle_request(_request())
+
+    assert excinfo.value is rejection
+    assert excinfo.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test__async_transport__inner_dialect_error__propagates_unchanged(
+    fake_clock: FakeClock,
+) -> None:
+    rejection = CircuitOpenTransportError('inner', retry_after=1.0)
+
+    def boom(_request: Request) -> Response:
+        raise rejection
+
+    transport = AsyncCircuitBreakerTransport(_AsyncStub(boom), config=_TRIP_FAST, clock=fake_clock)
+
+    with pytest.raises(CircuitOpenTransportError) as excinfo:
+        await transport.handle_async_request(_request())
+
+    assert excinfo.value is rejection
+
+
+@pytest.mark.parametrize(
+    'error',
+    [
+        CircuitOpenTransportError('api'),
+        CallTimeoutTransportError(1.0),
+        BulkheadFullTransportError(2),
+    ],
+)
+def test__dialect_errors__request_not_set__keep_httpx2_contract(error: httpx2.HTTPError) -> None:
+    with pytest.raises(RuntimeError, match='has not been set'):
+        _ = error.request

--- a/tests/test_httpx2_e2e.py
+++ b/tests/test_httpx2_e2e.py
@@ -19,7 +19,11 @@ import pytest
 from tests.conftest import FakeClock, Upstream, closed_port
 
 from interlock import CircuitOpenError, Config
-from interlock.integrations.httpx2 import AsyncCircuitBreakerTransport, CircuitBreakerTransport
+from interlock.integrations.httpx2 import (
+    AsyncCircuitBreakerTransport,
+    CircuitBreakerTransport,
+    CircuitOpenTransportError,
+)
 
 # Trip after two failures so scenarios stay short; the default 10-call minimum
 # would only add noise to an end-to-end flow test. One half-open probe decides
@@ -202,3 +206,22 @@ async def test__e2e_async__connection_refused__opens_breaker(fake_clock: FakeClo
 
         with pytest.raises(CircuitOpenError):
             await client.get(url)
+
+
+def test__httpx2_e2e_sync__open_circuit__rejects_as_transport_error(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    """A real client must deliver the rejection through httpx2's own hierarchy."""
+    backend = Upstream(status=503)
+    url = serve(backend)
+
+    with _sync_client(fake_clock) as client:
+        assert client.get(url).status_code == 503
+        assert client.get(url).status_code == 503
+
+        with pytest.raises(httpx2.TransportError) as rejected:
+            client.get(url)
+
+    assert isinstance(rejected.value, CircuitOpenTransportError)
+    assert rejected.value.request.url == httpx2.URL(url)
+    assert not isinstance(rejected.value, httpx2.ConnectError)

--- a/tests/test_httpx_e2e.py
+++ b/tests/test_httpx_e2e.py
@@ -7,7 +7,11 @@ import pytest
 from tests.conftest import FakeClock, Upstream, closed_port
 
 from interlock import CircuitOpenError, Config
-from interlock.integrations.httpx import AsyncCircuitBreakerTransport, CircuitBreakerTransport
+from interlock.integrations.httpx import (
+    AsyncCircuitBreakerTransport,
+    CircuitBreakerTransport,
+    CircuitOpenTransportError,
+)
 
 _TRIP_FAST = Config(
     minimum_number_of_calls=2,
@@ -161,3 +165,22 @@ async def test__httpx_e2e_async__connection_refused__opens_breaker(fake_clock: F
 
         with pytest.raises(CircuitOpenError):
             await client.get(url)
+
+
+def test__httpx_e2e_sync__open_circuit__rejects_as_transport_error(
+    serve: Callable[..., str], fake_clock: FakeClock
+) -> None:
+    """A real client must deliver the rejection through httpx's own hierarchy."""
+    backend = Upstream(status=503)
+    url = serve(backend)
+
+    with _sync_client(fake_clock) as client:
+        assert client.get(url).status_code == 503
+        assert client.get(url).status_code == 503
+
+        with pytest.raises(httpx.TransportError) as rejected:
+            client.get(url)
+
+    assert isinstance(rejected.value, CircuitOpenTransportError)
+    assert rejected.value.request.url == httpx.URL(url)
+    assert not isinstance(rejected.value, httpx.ConnectError)

--- a/tests/test_litestar.py
+++ b/tests/test_litestar.py
@@ -5,6 +5,7 @@ from litestar.di import NamedDependency, Provide
 from litestar.testing import RequestFactory, TestClient, create_test_client
 
 from interlock import CircuitBreaker, CircuitOpenError, Config, Registry
+from interlock.integrations.aiohttp import CircuitOpenClientError
 from interlock.integrations.litestar import breaker_dependency, circuit_open_handler
 
 
@@ -36,6 +37,23 @@ def test__breaker_dependency__returns_a_provide_with_the_shared_breaker() -> Non
     second = provided.dependency()
     assert isinstance(first, CircuitBreaker)
     assert first is second  # the registry caches one breaker per name
+
+
+def test__exception_handlers__dialect_rejection__returns_503_with_retry_after() -> None:
+    """Litestar resolves a handler by class hierarchy; an aiohttp base must not hide it."""
+
+    @get('/down', sync_to_thread=False)
+    def down() -> None:
+        raise CircuitOpenClientError('payments', retry_after=2.2)
+
+    with create_test_client(
+        route_handlers=[down],
+        exception_handlers={CircuitOpenError: circuit_open_handler},
+    ) as client:
+        response = client.get('/down')
+
+    assert response.status_code == 503
+    assert response.headers['Retry-After'] == '3'  # ceil(2.2)
 
 
 def _client() -> TestClient:

--- a/tests/test_litestar.py
+++ b/tests/test_litestar.py
@@ -54,6 +54,7 @@ def test__exception_handlers__dialect_rejection__returns_503_with_retry_after() 
 
     assert response.status_code == 503
     assert response.headers['Retry-After'] == '3'  # ceil(2.2)
+    assert response.json() == {'detail': "Circuit 'payments' is open"}
 
 
 def _client() -> TestClient:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -11,7 +11,11 @@ from requests.adapters import HTTPAdapter
 from tests.conftest import FakeClock
 
 from interlock import CircuitBreaker, CircuitOpenError, Config, Registry, State
-from interlock.integrations.requests import CircuitBreakerAdapter, HttpStatusClassifier
+from interlock.integrations.requests import (
+    CircuitBreakerAdapter,
+    CircuitOpenRequestError,
+    HttpStatusClassifier,
+)
 
 _TRIP_FAST = Config(minimum_number_of_calls=2, failure_rate_threshold=0.5)
 
@@ -365,3 +369,97 @@ def test__http_status_classifier__custom_statuses__override_default_set() -> Non
     assert classifier.is_failure(result=_response(404), exception=None) is True
     assert classifier.is_failure(result=_response(408), exception=None) is True
     assert classifier.is_failure(result=_response(500), exception=None) is False
+
+
+# --- dialect errors -----------------------------------------------------------
+
+
+def _tripped_adapter(mocker: MockerFixture, fake_clock: FakeClock) -> CircuitBreakerAdapter:
+    """An adapter whose ``api.a`` breaker has just been tripped open."""
+    _patch_transport(mocker, [_response(503), _response(503)])
+    adapter = CircuitBreakerAdapter(config=_TRIP_FAST, clock=fake_clock)
+    for _ in range(2):
+        adapter.send(_prepared('https://api.a/x'))
+
+    return adapter
+
+
+def test__adapter__open_circuit__rejects_inside_requests_hierarchy(
+    mocker: MockerFixture, fake_clock: FakeClock
+) -> None:
+    adapter = _tripped_adapter(mocker, fake_clock)
+
+    with pytest.raises(CircuitOpenRequestError) as excinfo:
+        adapter.send(_prepared('https://api.a/x'))
+
+    assert isinstance(excinfo.value, requests.exceptions.ConnectionError)
+    assert isinstance(excinfo.value, requests.exceptions.RequestException)
+    assert isinstance(excinfo.value, CircuitOpenError)
+
+
+def test__adapter__open_circuit__stays_outside_retryable_leaf_types(
+    mocker: MockerFixture, fake_clock: FakeClock
+) -> None:
+    adapter = _tripped_adapter(mocker, fake_clock)
+
+    with pytest.raises(CircuitOpenRequestError) as excinfo:
+        adapter.send(_prepared('https://api.a/x'))
+
+    assert not isinstance(excinfo.value, requests.exceptions.Timeout)
+    assert not isinstance(excinfo.value, requests.exceptions.SSLError)
+
+
+def test__adapter__open_circuit__carries_breaker_and_request_context(
+    mocker: MockerFixture, fake_clock: FakeClock
+) -> None:
+    adapter = _tripped_adapter(mocker, fake_clock)
+    request = _prepared('https://api.a/x')
+
+    with pytest.raises(CircuitOpenRequestError) as excinfo:
+        adapter.send(request)
+
+    error = excinfo.value
+    assert error.breaker_name == 'api.a'
+    assert error.retry_after == _TRIP_FAST.wait_duration_in_open
+    assert error.last_failure is None
+    assert error.request is request
+    assert error.response is None
+    assert str(error) == f"Circuit 'api.a' is open; retry in ~{error.retry_after:.3f}s"
+    assert type(error.__cause__) is CircuitOpenError
+
+
+def test__adapter__open_circuit__records_the_last_failure(
+    mocker: MockerFixture, fake_clock: FakeClock
+) -> None:
+    failure = requests.exceptions.ReadTimeout('slow')
+    _patch_transport(mocker, [failure, failure])
+    adapter = CircuitBreakerAdapter(config=_TRIP_FAST, clock=fake_clock)
+    for _ in range(2):
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            adapter.send(_prepared('https://api.a/x'))
+
+    with pytest.raises(CircuitOpenRequestError) as excinfo:
+        adapter.send(_prepared('https://api.a/x'))
+
+    assert excinfo.value.last_failure is failure
+
+
+def test__adapter__inner_dialect_error__propagates_unchanged(
+    mocker: MockerFixture, fake_clock: FakeClock
+) -> None:
+    rejection = CircuitOpenRequestError('inner', retry_after=1.0)
+    _patch_transport(mocker, [rejection])
+    adapter = CircuitBreakerAdapter(config=_TRIP_FAST, clock=fake_clock)
+
+    with pytest.raises(CircuitOpenRequestError) as excinfo:
+        adapter.send(_prepared('https://api.a/x'))
+
+    assert excinfo.value is rejection
+    assert excinfo.value.__cause__ is None
+
+
+def test__circuit_open_request_error__constructed_bare__keeps_requests_attributes() -> None:
+    error = CircuitOpenRequestError('api')
+
+    assert error.request is None
+    assert error.response is None

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -3,6 +3,7 @@
 import importlib
 import sys
 
+import httpx
 import pytest
 from tenacity import (
     RetryError,
@@ -15,6 +16,7 @@ from tenacity import (
 from tests.conftest import ExplodingListener, FakeClock
 
 from interlock import CircuitBreaker, CircuitOpenError, Config, State
+from interlock.integrations.httpx import CircuitOpenTransportError
 from interlock.integrations.tenacity import RetryStrategy, retry_unless_open, wait_probe
 from interlock.pipeline import CircuitBreakerStrategy, Pipeline, Strategy
 
@@ -71,6 +73,30 @@ def test__retry_unless_open__circuit_open_error__stops_immediately() -> None:
     )
 
     with pytest.raises(CircuitOpenError):
+        retrying(rejected)
+    assert attempts == 1
+
+
+def test__retry_unless_open__dialect_rejection__stops_immediately() -> None:
+    """An integration's rejection is a host-library error too, and still not retried."""
+    attempts = 0
+
+    def rejected() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise CircuitOpenTransportError('payments', retry_after=1.0)
+
+    # The retryable type deliberately covers the rejection's own httpx base: the
+    # predicate must still refuse it, or every rejection would burn an attempt
+    # against a circuit that is open anyway.
+    retrying = Retrying(
+        retry=retry_unless_open(httpx.TransportError),
+        stop=stop_after_attempt(5),
+        sleep=_noop_sleep,
+        reraise=True,
+    )
+
+    with pytest.raises(CircuitOpenTransportError):
         retrying(rejected)
     assert attempts == 1
 


### PR DESCRIPTION
## Summary

Every HTTP integration rejected a request with a bare `CircuitOpenError` — a type that stands outside the exception hierarchy of the library it is raised into. Application code degrades on the idiom its client teaches (`except httpx.TransportError`, `except requests.exceptions.RequestException`, `except aiohttp.ClientError`), so a rejection flew straight past every one of those handlers. Nothing shows while a breaker sits in `METRICS_ONLY`; the moment it starts rejecting, *all* of an application's degradation paths stop working at once and a partial outage becomes a full one — the library meant to soften an outage widens it instead. Counted on one real service: 28 call sites of the shape `except (..., HTTPStatusError, TransportError)` would have stopped degrading together.

The rejection now lands inside the host library's hierarchy while staying an interlock error:

| Integration | Rejection type | Host base |
|---|---|---|
| httpx, httpx2 | `CircuitOpenTransportError` | `httpx.TransportError` |
| aiohttp | `CircuitOpenClientError` | `aiohttp.ClientConnectionError` |
| requests | `CircuitOpenRequestError` | `requests.exceptions.ConnectionError` |

Each is still a `CircuitOpenError` carrying `breaker_name`, `retry_after` and `last_failure`, and each fills in the host's native request context (`.request` on httpx and httpx2, `.request` / `.response` on requests).

### Why that base and never a leaf

The host base is always the broadest "the request never completed" type — never `ConnectError`, `ReadTimeout` or `SSLError`. Two independent reasons:

1. a leaf promises a physical cause that never happened: nothing was connected, nothing was read;
2. leaves are exactly what retry predicates key on. Inheriting from one would make every rejection retryable, and each retry would hit the same open circuit and burn an attempt for nothing.

One choice puts the rejection inside every degradation handler and outside every typical retry predicate. urllib3's `Retry` never sees it either: that runs inside `HTTPAdapter.send`, which the rejection replaces rather than enters.

### Also covered

The httpx and httpx2 transports retype the other two interlock errors on the same path: `CallTimeoutTransportError` (an `httpx.TimeoutException`) and `BulkheadFullTransportError` (an `httpx.PoolTimeout`), for a pipeline timeout or bulkhead raised by a layer sitting inside the wrapped transport. Both describe transient *local* conditions, so — unlike a rejection — they sit under httpx's timeout types deliberately, where retry predicates do fire on them.

Only the *exact* core types are retyped, so an error that already carries a host hierarchy is never wrapped twice, and an error raised by the wrapped transport itself passes through untouched.

`requests` and `aiohttp` retype the rejection only: neither hierarchy has an honest type for "no local slot was free", and mapping a bulkhead rejection onto `ConnectionError` would say exactly what a circuit rejection already says. Easy to extend later if the symmetry is worth more than the precision.

### Implementation note

The host `__init__` is unreachable from a dual-inherited error: its `super()` call follows the subclass MRO into `CircuitOpenError.__init__` and would read the message as a breaker name. Each type therefore calls `CircuitOpenError.__init__` explicitly and publishes the native context through the host's *public* attributes — httpx's `request` property setter, requests' plain `.request` / `.response` — so no private attribute of a host library is touched. httpx's `_request` default is declared on the class so `.request` keeps failing the way httpx documents it rather than with an `AttributeError`.

### Compatibility

Additive for everything keyed on `CircuitOpenError`: `install_exception_handler`, Litestar `exception_handlers`, `retry_unless_open`, `wait_probe` and any `FallbackStrategy(on=(CircuitOpenError,))` behave exactly as before. Behaviour *does* change for code catching `httpx.TransportError` and its aiohttp / requests equivalents — rejections now reach those handlers instead of escaping to an outer `except Exception`. That is the point of the change; it has its own `Changed` entry in the changelog, with the note that the base was chosen so a rejection stays out of typical retry predicates. Minor bump; `griffe check` reports no breakage.

### Testing notes

Each integration owns the same four checks: host hierarchy, *not* a retry-leaf type, breaker context (plus native request context), and no double wrapping. Three consumer-side regression tests guard the one invariant that does not rest on `isinstance` — Starlette and Litestar resolve a handler by walking the MRO, where the host bases now come *before* `CircuitOpenError`: `test_fastapi.py` and `test_litestar.py` prove the `503` + `Retry-After` mapping still fires, and `test_tenacity.py` proves a predicate keyed on `httpx.TransportError` itself still refuses to retry a rejection. E2E coverage goes through a real `httpx.Client` (httpx fills in `.request` on the way out) and a real `aiohttp.ClientSession` (which re-raises a `ClientError` from the middleware chain untouched). The `extras-min` floors were checked directly: `httpx==0.27.0` and `httpx2==2.4.0` expose the same public `request` property this relies on.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage)
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits

## Related issues

None — found while integrating the httpx transport into a live service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Added

- **httpx/httpx2 extras:** Add `CircuitOpenTransportError`, `CallTimeoutTransportError`, and `BulkheadFullTransportError`.
- **aiohttp extra:** Add `CircuitOpenClientError`.
- **requests extra:** Add `CircuitOpenRequestError`.
- Preserve `CircuitOpenError` metadata and native request context in integration-specific errors.

### Fixed

- Allow host-library exception handlers to catch circuit rejections.
- Prevent standard retry predicates from retrying open-circuit requests.
- Preserve existing dialect-specific errors without double wrapping.

### Changed

- **httpx/httpx2 extras:** Map call timeouts to `TimeoutException` and bulkhead rejections to `PoolTimeout`.
- **aiohttp and requests extras:** Retype only circuit rejections to their broad native connection-error types.
- Keep circuit rejections compatible with existing `CircuitOpenError` handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->