### PR TITLE
chore: prepare the 2.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-08-18
+
 ### Added
 
 - **A rejected request now lands in its client library's own exception
@@ -916,7 +918,8 @@ The major version marks the scope of what is added, not a migration burden.
 - `InterlockDeprecationWarning` (subclasses `UserWarning`, visible by default).
 - `py.typed`; strict mypy and pyright; 100% test coverage.
 
-[Unreleased]: https://github.com/bagowix/interlock/compare/v2.6.1...HEAD
+[Unreleased]: https://github.com/bagowix/interlock/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/bagowix/interlock/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/bagowix/interlock/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/bagowix/interlock/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/bagowix/interlock/compare/v2.4.0...v2.5.0

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,7 +35,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.6.1 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of August 2026) | 2.7.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -770,7 +770,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.6.1 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of August 2026) | 2.7.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/interlock/version.py
+++ b/interlock/version.py
@@ -7,7 +7,7 @@ and read at build time by hatchling (see ``[tool.hatch.version]`` in
 
 __all__ = ('VERSION',)
 
-VERSION = '2.6.1'
+VERSION = '2.7.0'
 """The installed version of interlock.
 
 Guaranteed to comply with PEP 440 version specifiers.


### PR DESCRIPTION
## Summary

Prepare the `2.7.0` minor release.

* Bump the package version from `2.6.1` to `2.7.0`.
* Move the current `[Unreleased]` changelog entries into `[2.7.0] - 2026-08-18`.
* Update changelog comparison links and the comparison-page release version.
* Regenerate `docs/llms-full.txt`.

Minor, not patch: the release adds public API. #177 gives every HTTP client integration a rejection type that lives in the host library's own hierarchy — `CircuitOpenTransportError` (httpx, httpx2), `CircuitOpenClientError` (aiohttp), `CircuitOpenRequestError` (requests), plus `CallTimeoutTransportError` and `BulkheadFullTransportError` on the two httpx transports.

Nothing an existing caller does stops working: a rejection is still a `CircuitOpenError` carrying `breaker_name`, `retry_after` and `last_failure`; it now also carries the host base type. The one behavioural difference is the point of the change — `except httpx.TransportError`, `except aiohttp.ClientError` and `except requests.exceptions.RequestException` now catch a rejection where it previously escaped to an outer `except Exception`. The bases are the broadest "the request never completed" types, never a leaf, so no typical retry predicate starts firing on a rejection; the changelog entry records that choice.

## Checklist

* [x] Tests added or updated (suite stays at 100% coverage)
* [x] `uv run ruff format --check` and `uv run ruff check` pass
* [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
* [x] Docs updated (`docs/`) for user-facing changes
* [x] `CHANGELOG.md` `[Unreleased]` updated
* [x] Commits follow Conventional Commits

Additional release checks: the package build passes (`interlock_cb-2.7.0`), `twine check` PASSED on both artefacts, and griffe reports the `VERSION` attribute (`2.6.1` → `2.7.0`) as the only public difference — the new exception types are additions, so nothing is flagged as a breakage.

## Related issues

#177
