### PR TITLE
ci: keep a Dependabot bump PR from failing on the Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,12 +297,19 @@ jobs:
           uv run pytest --cov --cov-report=xml
           --junitxml=junit.xml -o junit_family=legacy
 
+      # `fail_ci_if_error` is not a flat `true`: a Dependabot run resolves
+      # `secrets.*` against a separate secret store, so a `CODECOV_TOKEN` drift
+      # there turns the required check red on every bump PR at once. The gate is
+      # `fail_under = 100`, which the step above already enforced — Codecov only
+      # mirrors it — so a rejected upload on a bot PR is a reporting outage;
+      # human PRs and pushes to main still fail hard on one. `github.actor`
+      # survives a manual re-run, `github.triggering_actor` does not.
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -310,4 +317,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A Dependabot pull request no longer fails CI on the Codecov upload.** A run
+  triggered by Dependabot resolves `secrets.*` against the separate Dependabot
+  secret store, so `CODECOV_TOKEN` has to be maintained in two places — and a
+  drift between them is invisible until the upload is rejected and the required
+  `Coverage` check turns red on every open bump PR at once, with nothing wrong
+  in any of the diffs. The coverage gate is `fail_under = 100`, which `pytest`
+  enforces in that same job before the upload runs, so the upload is now
+  non-fatal on bot pull requests only; human pull requests and pushes to `main`
+  still fail hard when Codecov rejects a report.
+
 ## [2.7.0] - 2026-08-18
 
 ### Added


### PR DESCRIPTION
## Summary

Every open Dependabot bump PR (#179–#185) is red on the required `Coverage`
check, and nothing is wrong in any of the diffs — all other checks pass, and the
`pytest --cov` step inside that very job passes at 100%. Only the Codecov upload
fails.

The cause is that a workflow run triggered by Dependabot resolves `secrets.*`
against the **Dependabot** secret store (Settings → Secrets → Dependabot), never
against Actions secrets. `CODECOV_TOKEN` therefore has to be maintained in two
places, and a drift between them is invisible until Codecov rejects the upload —
at which point every open bump PR turns red at once. Two failure modes seen back
to back on the same run:

| Attempt | Token | Codecov |
|---|---|---|
| 2026-08-21 | absent (`INPUT_TOKEN:` empty) | `{"message":"Token required because branch is protected"}` |
| 2026-08-23 | present (`Token length: 36`) | `{"message":"Repository not found"}` |

The first row also rules out the obvious alternative: dropping the token and
relying on a tokenless upload does not work while `main` is protected.

The coverage gate is `fail_under = 100` in `pyproject.toml`, which `pytest`
enforces in that same job before the upload runs — and in all five `quality`
matrix jobs besides. Codecov only mirrors it (`.github/codecov.yml`). So a
rejected upload on a bot PR is a reporting outage, not a coverage regression,
and it must not hold up a routine bump. `fail_ci_if_error` becomes
`${{ github.actor != 'dependabot[bot]' }}` on both upload steps; human PRs and
pushes to `main` still fail hard when Codecov rejects a report.

`github.actor` and not `github.triggering_actor`: the former stays
`dependabot[bot]` when a maintainer re-runs the job by hand, the latter becomes
the maintainer.

This is the safety net, not the fix — the Dependabot-store `CODECOV_TOKEN` still
has to be set to the repository upload token from
`app.codecov.io/gh/bagowix/interlock/config/general` for bump PRs to report
coverage at all. What changes here is that the next drift costs a missing report
instead of a blocked merge queue.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage) — CI-only change, no
      production code touched; the suite still passes at 100%
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes — none needed, nothing in
      the published surface changes
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Commits follow Conventional Commits
- [x] `uv run zizmor .github/workflows/` passes

## Related issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Fixed
- Dependabot pull requests no longer fail CI when Codecov rejects coverage or test-results uploads.

### Changed
- Codecov upload failures remain fatal for human pull requests and pushes to `main`.
- The existing 100% coverage gate remains enforced by `pytest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->