### PR TITLE
chore: prepare the 2.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-09-01
+
+### Added
+
+- **The open wait can now grow while probe rounds keep failing.**
+  `wait_duration_in_open` was a constant, so a breaker that could not recover
+  retried at full rate indefinitely, each round hammering a dependency already
+  in trouble. `Config.wait_duration_backoff_multiplier` lengthens the wait
+  after each consecutive failed round and `Config.wait_duration_in_open_max`
+  caps it; a passing round resets both. The default multiplier of `1.0` keeps
+  the historical constant wait, so nothing changes until it is raised. The
+  growing interval doubles as a signal: a breaker that is merely waiting out a
+  blip looks nothing like one that has failed ten rounds in a row.
+
+- **A Dependabot pull request no longer fails CI on the Codecov upload.** A run
+  triggered by Dependabot resolves `secrets.*` against the separate Dependabot
+  secret store, so `CODECOV_TOKEN` has to be maintained in two places — and a
+  drift between them is invisible until the upload is rejected and the required
+  `Coverage` check turns red on every open bump PR at once, with nothing wrong
+  in any of the diffs. The coverage gate is `fail_under = 100`, which `pytest`
+  enforces in that same job before the upload runs, so the upload is now
+  non-fatal on bot pull requests only; human pull requests and pushes to `main`
+  still fail hard when Codecov rejects a report.
+
 ### Fixed
 
 - **A backoff the coordinated lane cannot honour is now refused instead of
@@ -33,28 +57,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   through `unreachable_exceptions` on `CircuitBreaker`, `Registry` and
   `Engine`. `CLOSED` is deliberately untouched — an exhausted pool is a real
   signal there, and shedding load is the point.
-
-### Added
-
-- **The open wait can now grow while probe rounds keep failing.**
-  `wait_duration_in_open` was a constant, so a breaker that could not recover
-  retried at full rate indefinitely, each round hammering a dependency already
-  in trouble. `Config.wait_duration_backoff_multiplier` lengthens the wait
-  after each consecutive failed round and `Config.wait_duration_in_open_max`
-  caps it; a passing round resets both. The default multiplier of `1.0` keeps
-  the historical constant wait, so nothing changes until it is raised. The
-  growing interval doubles as a signal: a breaker that is merely waiting out a
-  blip looks nothing like one that has failed ten rounds in a row.
-
-- **A Dependabot pull request no longer fails CI on the Codecov upload.** A run
-  triggered by Dependabot resolves `secrets.*` against the separate Dependabot
-  secret store, so `CODECOV_TOKEN` has to be maintained in two places — and a
-  drift between them is invisible until the upload is rejected and the required
-  `Coverage` check turns red on every open bump PR at once, with nothing wrong
-  in any of the diffs. The coverage gate is `fail_under = 100`, which `pytest`
-  enforces in that same job before the upload runs, so the upload is now
-  non-fatal on bot pull requests only; human pull requests and pushes to `main`
-  still fail hard when Codecov rejects a report.
 
 ## [2.7.0] - 2026-08-18
 
@@ -968,7 +970,8 @@ The major version marks the scope of what is added, not a migration burden.
 - `InterlockDeprecationWarning` (subclasses `UserWarning`, visible by default).
 - `py.typed`; strict mypy and pyright; 100% test coverage.
 
-[Unreleased]: https://github.com/bagowix/interlock/compare/v2.7.0...HEAD
+[Unreleased]: https://github.com/bagowix/interlock/compare/v2.8.0...HEAD
+[2.8.0]: https://github.com/bagowix/interlock/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/bagowix/interlock/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/bagowix/interlock/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/bagowix/interlock/compare/v2.5.0...v2.6.0

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,7 +35,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.7.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of September 2026) | 2.8.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -770,7 +770,7 @@ choice.
 | OpenTelemetry metrics | ✅ | — | — | — | — |
 | Operator overrides (force-open / disable / shadow mode) | ✅ | — | — | — | — |
 | Years of production use | new | ✅ | ✅ | ✅ | ✅ |
-| Latest release (as of August 2026) | 2.7.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
+| Latest release (as of September 2026) | 2.8.0 · 2026 | 1.4.1 · 2025 | 2.1.3 | 1.2.0 · 2021 | 3.0.1 · 2024 |
 | Python | ≥ 3.11 | ≥ 3.9 | ≥ 3.8 | ≥ 3.6 | ≥ 3.9 |
 
 <sub>Compared against pybreaker 1.4.1, circuitbreaker 2.1.3, aiobreaker 1.2.0

--- a/interlock/version.py
+++ b/interlock/version.py
@@ -7,7 +7,7 @@ and read at build time by hatchling (see ``[tool.hatch.version]`` in
 
 __all__ = ('VERSION',)
 
-VERSION = '2.7.0'
+VERSION = '2.8.0'
 """The installed version of interlock.
 
 Guaranteed to comply with PEP 440 version specifiers.


### PR DESCRIPTION
## Summary

Prepare the `2.8.0` minor release.

* Bump the package version from `2.7.0` to `2.8.0`.
* Move the current `[Unreleased]` changelog entries into `[2.8.0] - 2026-09-01`, in the Added-before-Fixed order every other section uses.
* Update the changelog comparison links, and the release version and month on the comparison page.
* Regenerate `docs/llms-full.txt`.

Minor, not patch: the release adds public API. #194 gives `Config` an open wait that can grow — `wait_duration_backoff_multiplier` and `wait_duration_in_open_max` — and gives `CircuitBreaker`, `Registry` and `Engine` an `unreachable_exceptions` set, so a `HALF_OPEN` probe that never reached the dependency hands its slot back instead of deciding the round against it. #195 refuses, at construction, a backoff asked for alongside a shared `Storage`, which the coordinated lane has no way to honour.

Nothing an existing caller does stops working. The defaults keep the historical behaviour: `wait_duration_backoff_multiplier` is `1.0`, so the wait stays constant until it is raised, and only the two httpx transports pass a non-empty `unreachable_exceptions` out of the box (`PoolTimeout`). The new `ValueError` cannot reach a caller who upgrades either — the multiplier it guards ships in this same release, so no configuration written against `2.7.0` can trip it.

The two changes are released together on purpose. Shipping the backoff without the guard would leave an option that reads as enabled and does nothing under a shared `Storage`, and adding the guard afterwards would then be the breaking change.

## Checklist

* [x] Tests added or updated (suite stays at 100% coverage)
* [x] `uv run ruff format --check` and `uv run ruff check` pass
* [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
* [x] Docs updated (`docs/`) for user-facing changes
* [x] `CHANGELOG.md` `[Unreleased]` updated
* [x] Commits follow Conventional Commits

Additional release checks: the package build passes (`interlock_cb-2.8.0`), `twine check` PASSED on both artefacts, and griffe reports the `VERSION` attribute (`2.7.0` → `2.8.0`) as the only public difference — the backoff fields and `unreachable_exceptions` are additions, so nothing is flagged as a breakage.

## Related issues

#194, #195
