### PR TITLE
docs: add the skills.sh install badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-2f6f55.svg)](https://bagowix.github.io/interlock/)
 [![llms.txt](https://img.shields.io/badge/-llms.txt-brightgreen)](https://bagowix.github.io/interlock/llms.txt)
 [![Context7](https://img.shields.io/badge/docs-Context7-1f6feb.svg)](https://context7.com/bagowix/interlock)
+[![skills.sh](https://skills.sh/b/bagowix/interlock)](https://skills.sh/bagowix/interlock)
 
 A modern circuit breaker for Python — sync and async in a single class,
 sliding-window rate and slow-call detection, a type-safe API, and transparent


### PR DESCRIPTION
## Summary

Adds the official skills.sh badge to the README badge row, next to the llms.txt and Context7 badges, the other two entry points for agents. It renders the install count skills.sh aggregates from the skills CLI for the Agent Skill shipped in #205, and links to the repository's page on skills.sh, which carries the `npx skills add bagowix/interlock` command. The badge endpoint started returning data today after the first install; before that it rendered "resource not found", which is why this waited for the merge of #205.

No changelog entry, following #75, which added the documentation and Context7 badges the same way.

## Checklist

- [x] Tests added or updated (suite stays at 100% coverage): no code changes; the suite is untouched
- [x] `uv run ruff format --check` and `uv run ruff check` pass
- [x] `uv run mypy`, `uv run pyright` and `uv run pyrefly check` pass
- [x] Docs updated (`docs/`) for user-facing changes: README only, the docs landing page carries no badge row
- [x] `CHANGELOG.md` `[Unreleased]` updated: deliberately not, see above
- [x] Commits follow Conventional Commits

## Related issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Added
- Add the official skills.sh install badge to the README badge row.
- Link the badge to the `bagowix/interlock` skills.sh page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->